### PR TITLE
Port trick-taking and round/game scoring to TS

### DIFF
--- a/web/src/engine/game.test.ts
+++ b/web/src/engine/game.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { checkGameOutcome } from './game'
+
+describe('checkGameOutcome', () => {
+  it('returns null when neither team has crossed a threshold', () => {
+    expect(checkGameOutcome({ 0: 400, 1: -200 }, 0)).toBeNull()
+  })
+
+  it('a team at or below -1000 loses immediately; the other team wins regardless of their own score', () => {
+    expect(checkGameOutcome({ 0: -1000, 1: 50 }, 1)).toBe(1)
+    expect(checkGameOutcome({ 0: -1200, 1: -900 }, 0)).toBe(1)
+  })
+
+  it('a single team crossing +1000 wins, even if they are not the bidding team', () => {
+    expect(checkGameOutcome({ 0: 1050, 1: 600 }, 1)).toBe(0)
+  })
+
+  it('the bidding team wins the tie-break if both teams cross +1000 in the same round', () => {
+    expect(checkGameOutcome({ 0: 1010, 1: 1200 }, 1)).toBe(1)
+    expect(checkGameOutcome({ 0: 1010, 1: 1200 }, 0)).toBe(0)
+  })
+
+  it('the -1000 bust check takes priority over the +1000 win check', () => {
+    // Contrived, but confirms bust is evaluated first per the Python reference.
+    expect(checkGameOutcome({ 0: -1000, 1: 1200 }, 0)).toBe(1)
+  })
+})

--- a/web/src/engine/game.ts
+++ b/web/src/engine/game.ts
@@ -1,0 +1,41 @@
+// Game — cumulative team scores and the +-1000 win/loss thresholds.
+// Ported from pinochle_engine.py's Game class (frozen Python reference).
+//
+// Deliberately scoped to just the threshold check, not a full game loop:
+// running an actual multi-round game needs Round's bidding/pass phases
+// (#17) to exist first. A future Game orchestrator adds each round's
+// scoreRound() result (round.ts) onto each team's running total, then
+// calls checkGameOutcome() to see whether the game just ended.
+
+import { GAME_LOSE_SCORE, GAME_WIN_SCORE } from './card'
+import type { TeamId } from './round'
+
+const TEAM_IDS: readonly TeamId[] = [0, 1]
+
+/**
+ * Checks the win/loss thresholds after a round's scores have already
+ * been added to each team's cumulative total. Returns the winning team,
+ * or null if the game continues. Per pinochle_rules.md "Game Win / Loss":
+ *
+ *   - A team's cumulative score at or below -1000 ends the game
+ *     immediately; the OTHER team wins, regardless of that team's score.
+ *   - Otherwise, if either team has reached +1000, the bidding team wins
+ *     the tie if both crossed it in the same round; else whichever team
+ *     crossed it wins.
+ */
+export function checkGameOutcome(
+  cumulativeScores: Record<TeamId, number>,
+  bidWinnerTeam: TeamId,
+): TeamId | null {
+  const busted = TEAM_IDS.filter((t) => cumulativeScores[t] <= GAME_LOSE_SCORE)
+  if (busted.length > 0) {
+    return TEAM_IDS.find((t) => !busted.includes(t)) ?? null
+  }
+
+  const over = TEAM_IDS.filter((t) => cumulativeScores[t] >= GAME_WIN_SCORE)
+  if (over.length > 0) {
+    return over.includes(bidWinnerTeam) ? bidWinnerTeam : over[0]
+  }
+
+  return null
+}

--- a/web/src/engine/round.test.ts
+++ b/web/src/engine/round.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { Deck, Suit } from './card'
+import {
+  type ChooseCardFn,
+  type Hands,
+  playTrickTakingPhase,
+  scoreRound,
+  teamOf,
+} from './round'
+
+describe('teamOf', () => {
+  it('pairs player 0 & 2 as team A (0), player 1 & 3 as team B (1)', () => {
+    expect(teamOf(0)).toBe(0)
+    expect(teamOf(2)).toBe(0)
+    expect(teamOf(1)).toBe(1)
+    expect(teamOf(3)).toBe(1)
+  })
+})
+
+// Always plays the first legal card — mirrors the Python engine's
+// placeholder `choose_card` fallback (legal_moves[0]), enough to drive a
+// full round through without needing real trick-play strategy (out of
+// scope for this port).
+const chooseFirstLegal: ChooseCardFn = (_player, _hand, legalMoves) => legalMoves[0]
+
+describe('playTrickTakingPhase', () => {
+  it('plays all 12 tricks and distributes exactly 250 trick points total (incl. last-trick bonus)', () => {
+    const deck = new Deck()
+    deck.shuffle()
+    const hands = deck.deal() as Hands
+
+    const result = playTrickTakingPhase(hands, Suit.Spades, 0, chooseFirstLegal)
+
+    expect(result.trickWinners).toHaveLength(12)
+    const total = result.trickPointsByTeam[0] + result.trickPointsByTeam[1]
+    expect(total).toBe(250)
+  })
+
+  it('does not mutate the hands passed in', () => {
+    const deck = new Deck()
+    deck.shuffle()
+    const hands = deck.deal() as Hands
+    const originalCounts = hands.map((h) => h.length)
+
+    playTrickTakingPhase(hands, Suit.Spades, 0, chooseFirstLegal)
+
+    expect(hands.map((h) => h.length)).toEqual(originalCounts)
+  })
+
+  it('the contract winner leads the first trick', () => {
+    const deck = new Deck()
+    deck.shuffle()
+    const hands = deck.deal() as Hands
+
+    let firstTrickLeader: number | undefined
+    const recordingChoose: ChooseCardFn = (player, _hand, legalMoves, trick) => {
+      if (trick.plays.length === 0 && firstTrickLeader === undefined) {
+        firstTrickLeader = player
+      }
+      return legalMoves[0]
+    }
+
+    playTrickTakingPhase(hands, Suit.Diamonds, 2, recordingChoose)
+    expect(firstTrickLeader).toBe(2)
+  })
+
+  it('the winner of each trick leads the next', () => {
+    const deck = new Deck()
+    deck.shuffle()
+    const hands = deck.deal() as Hands
+
+    const leaders: number[] = []
+    const recordingChoose: ChooseCardFn = (player, _hand, legalMoves, trick) => {
+      if (trick.plays.length === 0) leaders.push(player)
+      return legalMoves[0]
+    }
+
+    const result = playTrickTakingPhase(hands, Suit.Clubs, 1, recordingChoose)
+    // Every leader after the first should be the previous trick's winner.
+    for (let i = 1; i < 12; i++) {
+      expect(leaders[i]).toBe(result.trickWinners[i - 1])
+    }
+  })
+})
+
+describe('scoreRound', () => {
+  it("scores the bidding team -bid when their total falls short (going set)", () => {
+    const scores = scoreRound({
+      meldPointsByTeam: { 0: 20, 1: 40 },
+      trickPointsByTeam: { 0: 100, 1: 150 },
+      bidWinnerTeam: 0,
+      bid: 300,
+    })
+    // Team 0 (bidding): 20 + 100 = 120 < 300 -> goes set, scores -300.
+    expect(scores[0]).toBe(-300)
+    // Team 1 (defending) always keeps its own meld + trick points.
+    expect(scores[1]).toBe(190)
+  })
+
+  it('scores the bidding team their actual total when they make the contract', () => {
+    const scores = scoreRound({
+      meldPointsByTeam: { 0: 150, 1: 10 },
+      trickPointsByTeam: { 0: 160, 1: 90 },
+      bidWinnerTeam: 0,
+      bid: 300,
+    })
+    // Team 0: 150 + 160 = 310 >= 300 -> makes it, scores the real total.
+    expect(scores[0]).toBe(310)
+    expect(scores[1]).toBe(100)
+  })
+
+  it('the defending team scores their own total even if the bidder goes set', () => {
+    const scores = scoreRound({
+      meldPointsByTeam: { 0: 0, 1: 60 },
+      trickPointsByTeam: { 0: 90, 1: 100 },
+      bidWinnerTeam: 1,
+      bid: 400,
+    })
+    // Team 1 (bidding): 60 + 100 = 160 < 400 -> goes set, scores -400.
+    expect(scores[1]).toBe(-400)
+    expect(scores[0]).toBe(90)
+  })
+})

--- a/web/src/engine/round.ts
+++ b/web/src/engine/round.ts
@@ -1,0 +1,118 @@
+// Round — trick-taking phase and round-level (contract) scoring. Ported
+// from pinochle_engine.py's Round._trick_taking_loop / Round._score_round
+// (frozen Python reference).
+//
+// Bidding and the 3-card pass (#17) aren't reimplemented here — this
+// module picks up *after* trump is set and hands are finalized (post
+// pass), taking the bid winner and the agreed contract as given inputs.
+// A future Round orchestrator (once #17 lands) is expected to run, in
+// order: deal -> bidding (#17) -> passing (#17) -> scoreMelds (melds.ts,
+// per player) -> playTrickTakingPhase -> scoreRound -> feed the result
+// into game.ts's checkGameOutcome. Using PlayerIndex/TeamId from this
+// module and trick.ts keeps that future glue code consistent with
+// however bidding/passing chooses to represent players/hands.
+
+import type { Card, Suit } from './card'
+import { type PlayerIndex, Trick } from './trick'
+
+export type TeamId = 0 | 1
+
+/** Fixed seating per pinochle_rules.md: Player 0 & 2 = Team A (0), Player 1 & 3 = Team B (1). */
+export function teamOf(player: PlayerIndex): TeamId {
+  return (player % 2) as TeamId
+}
+
+export type Hands = [Card[], Card[], Card[], Card[]]
+
+/**
+ * Picks which legal card `player` plays. `trick` gives access to
+ * `trumpSuit`, `leadSuit`, and the plays made so far this trick.
+ * Left fully generic on purpose — real strategy (Proficient-tier AI,
+ * or human input) is out of scope for this port; this only enforces
+ * legality and resolves the outcome.
+ */
+export type ChooseCardFn = (
+  player: PlayerIndex,
+  hand: readonly Card[],
+  legalMoves: readonly Card[],
+  trick: Trick,
+) => Card
+
+export interface TrickTakingResult {
+  trickPointsByTeam: Record<TeamId, number>
+  /** Winning player of each of the 12 tricks, in order (for UI/debugging/replay). */
+  trickWinners: PlayerIndex[]
+}
+
+const TRICK_COUNT = 12
+const LAST_TRICK_BONUS = 10 // team that wins the 12th trick gets +10
+
+/**
+ * Plays all 12 tricks of a round. `hands` are cloned internally (not
+ * mutated in place), so the caller's arrays are safe to reuse/inspect
+ * afterward. The contract winner (`bidWinner`) leads the first trick;
+ * each subsequent trick is led by the previous trick's winner, per
+ * pinochle_rules.md Phase 4.
+ */
+export function playTrickTakingPhase(
+  hands: Readonly<Hands>,
+  trumpSuit: Suit,
+  bidWinner: PlayerIndex,
+  chooseCard: ChooseCardFn,
+): TrickTakingResult {
+  const workingHands = hands.map((h) => [...h]) as Hands
+  const trickPointsByTeam: Record<TeamId, number> = { 0: 0, 1: 0 }
+  const trickWinners: PlayerIndex[] = []
+
+  let leader = bidWinner
+  for (let trickNum = 0; trickNum < TRICK_COUNT; trickNum++) {
+    const trick = new Trick(trumpSuit)
+    let player = leader
+    for (let seat = 0; seat < 4; seat++) {
+      const hand = workingHands[player]
+      const legal = trick.legalMoves(hand)
+      const card = chooseCard(player, hand, legal, trick)
+      const idx = hand.findIndex((c) => c.equals(card))
+      if (idx === -1) {
+        throw new Error(
+          `chooseCard returned a card not in player ${player}'s hand: ${card.toString()}`,
+        )
+      }
+      hand.splice(idx, 1)
+      trick.play(player, card)
+      player = ((player + 1) % 4) as PlayerIndex
+    }
+
+    const winner = trick.winner()
+    let points = trick.points()
+    if (trickNum === TRICK_COUNT - 1) points += LAST_TRICK_BONUS
+    trickPointsByTeam[teamOf(winner)] += points
+    trickWinners.push(winner)
+    leader = winner
+  }
+
+  return { trickPointsByTeam, trickWinners }
+}
+
+export interface RoundScoreInput {
+  meldPointsByTeam: Record<TeamId, number>
+  trickPointsByTeam: Record<TeamId, number>
+  bidWinnerTeam: TeamId
+  bid: number
+}
+
+/**
+ * Contract check, per pinochle_rules.md Phase 5: if the bidding team's
+ * meld + trick total is less than their bid, they score -bid for the
+ * round ("going set"). The defending team always scores their own
+ * meld + trick points, regardless of what happens to the bidding team.
+ */
+export function scoreRound(input: RoundScoreInput): Record<TeamId, number> {
+  const { meldPointsByTeam, trickPointsByTeam, bidWinnerTeam, bid } = input
+  const scores: Record<TeamId, number> = { 0: 0, 1: 0 }
+  for (const team of [0, 1] as const) {
+    const total = meldPointsByTeam[team] + trickPointsByTeam[team]
+    scores[team] = team === bidWinnerTeam && total < bid ? -bid : total
+  }
+  return scores
+}

--- a/web/src/engine/trick.test.ts
+++ b/web/src/engine/trick.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { Card, Suit } from './card'
+import { Trick } from './trick'
+
+describe('Trick.legalMoves', () => {
+  it('leading: any card in hand is legal', () => {
+    const trick = new Trick(Suit.Hearts)
+    const hand = [
+      new Card(Suit.Spades, 'A', 1),
+      new Card(Suit.Clubs, '9', 1),
+    ]
+    expect(trick.legalMoves(hand)).toEqual(hand)
+  })
+
+  it('must follow lead suit and beat the best one on the table if able', () => {
+    const trick = new Trick(Suit.Hearts) // trump irrelevant here
+    trick.play(0, new Card(Suit.Spades, 'K', 1))
+
+    const hand = [
+      new Card(Suit.Spades, '10', 1), // beats King
+      new Card(Suit.Spades, 'J', 1), // does not beat King
+      new Card(Suit.Clubs, 'A', 1),
+    ]
+    const legal = trick.legalMoves(hand)
+    expect(legal).toEqual([hand[0]])
+  })
+
+  it('must follow lead suit even without a beater, if no beater exists', () => {
+    const trick = new Trick(Suit.Hearts)
+    trick.play(0, new Card(Suit.Spades, 'A', 1)) // unbeatable in-suit
+
+    const hand = [
+      new Card(Suit.Spades, 'J', 1),
+      new Card(Suit.Spades, '9', 1),
+      new Card(Suit.Clubs, 'A', 1),
+    ]
+    const legal = trick.legalMoves(hand)
+    expect(legal).toEqual([hand[0], hand[1]])
+  })
+
+  it('must play trump if void in lead suit and holding trump', () => {
+    const trick = new Trick(Suit.Hearts)
+    trick.play(0, new Card(Suit.Spades, 'A', 1))
+
+    const hand = [
+      new Card(Suit.Hearts, '9', 1),
+      new Card(Suit.Clubs, 'A', 1),
+    ]
+    const legal = trick.legalMoves(hand)
+    expect(legal).toEqual([hand[0]])
+  })
+
+  it('must beat the best trump on the table if able, when trumping in', () => {
+    const trick = new Trick(Suit.Hearts)
+    trick.play(0, new Card(Suit.Spades, 'A', 1))
+    trick.play(1, new Card(Suit.Hearts, 'Q', 1))
+
+    const hand = [
+      new Card(Suit.Hearts, 'K', 1), // beats Queen
+      new Card(Suit.Hearts, '9', 1), // does not beat Queen
+    ]
+    const legal = trick.legalMoves(hand)
+    expect(legal).toEqual([hand[0]])
+  })
+
+  it('may sluff anything when void in both lead suit and trump', () => {
+    const trick = new Trick(Suit.Hearts)
+    trick.play(0, new Card(Suit.Spades, 'A', 1))
+
+    const hand = [
+      new Card(Suit.Clubs, '9', 1),
+      new Card(Suit.Diamonds, 'J', 1),
+    ]
+    expect(trick.legalMoves(hand)).toEqual(hand)
+  })
+})
+
+describe('Trick.winner', () => {
+  it('highest trump wins over any lead-suit card', () => {
+    const trick = new Trick(Suit.Hearts)
+    trick.play(0, new Card(Suit.Spades, 'A', 1))
+    trick.play(1, new Card(Suit.Hearts, '9', 1))
+    trick.play(2, new Card(Suit.Spades, '10', 1))
+    trick.play(3, new Card(Suit.Clubs, 'K', 1))
+    expect(trick.winner()).toBe(1)
+  })
+
+  it('highest lead-suit card wins when no trump was played', () => {
+    const trick = new Trick(Suit.Hearts)
+    trick.play(0, new Card(Suit.Spades, 'Q', 1))
+    trick.play(1, new Card(Suit.Clubs, 'A', 1)) // off-suit, doesn't count
+    trick.play(2, new Card(Suit.Spades, 'A', 1))
+    trick.play(3, new Card(Suit.Spades, 'J', 1))
+    expect(trick.winner()).toBe(2)
+  })
+
+  it('a tie between identical cards goes to whichever copy was played first', () => {
+    const trick = new Trick(Suit.Hearts)
+    trick.play(0, new Card(Suit.Spades, 'A', 1))
+    trick.play(1, new Card(Suit.Spades, 'A', 2)) // same rank/suit, second copy
+    trick.play(2, new Card(Suit.Spades, '9', 1))
+    trick.play(3, new Card(Suit.Spades, 'J', 1))
+    expect(trick.winner()).toBe(0)
+  })
+})
+
+describe('Trick.points', () => {
+  it('counts Ace/10/King at 10 each, Queen/Jack/9 at 0', () => {
+    const trick = new Trick(Suit.Hearts)
+    trick.play(0, new Card(Suit.Spades, 'A', 1))
+    trick.play(1, new Card(Suit.Spades, '10', 1))
+    trick.play(2, new Card(Suit.Spades, 'K', 1))
+    trick.play(3, new Card(Suit.Spades, 'Q', 1))
+    expect(trick.points()).toBe(30)
+  })
+
+  it('a trick of all non-point cards scores 0', () => {
+    const trick = new Trick(Suit.Hearts)
+    trick.play(0, new Card(Suit.Spades, 'Q', 1))
+    trick.play(1, new Card(Suit.Spades, 'J', 1))
+    trick.play(2, new Card(Suit.Spades, '9', 1))
+    trick.play(3, new Card(Suit.Clubs, 'Q', 1))
+    expect(trick.points()).toBe(0)
+  })
+})

--- a/web/src/engine/trick.ts
+++ b/web/src/engine/trick.ts
@@ -1,0 +1,111 @@
+// Trick — owns lead suit, trump, legal-move filtering, and winner
+// resolution. Ported from pinochle_engine.py's Trick class (frozen
+// Python reference).
+//
+// Trick doesn't know about Player/Team objects — plays are recorded by
+// PlayerIndex (0-3, matching clockwise table seating) so this module has
+// no dependency on however Round ends up representing players once
+// bidding/passing (#17) lands. round.ts's teamOf() maps a PlayerIndex to
+// its team.
+
+import type { Card, Suit } from './card'
+
+export type PlayerIndex = 0 | 1 | 2 | 3
+
+const POINT_RANKS = new Set(['A', '10', 'K'])
+
+export interface TrickPlay {
+  readonly player: PlayerIndex
+  readonly card: Card
+}
+
+export class Trick {
+  readonly trumpSuit: Suit
+  readonly plays: TrickPlay[] = []
+
+  constructor(trumpSuit: Suit) {
+    this.trumpSuit = trumpSuit
+  }
+
+  /** Suit of the first card played this trick, or undefined before anyone has led. */
+  get leadSuit(): Suit | undefined {
+    return this.plays[0]?.card.suit
+  }
+
+  /**
+   * Legal-move filtering, per pinochle_rules.md Phase 4:
+   *   1. Leading: anything goes.
+   *   2. Must follow the lead suit if able.
+   *   3. Must beat the best lead-suit card on the table if able.
+   *   4. If void in lead suit, must play trump if able.
+   *   5. If playing trump because void, must beat the best trump on the
+   *      table if able.
+   *   6. Sluff: no lead-suit or trump cards in hand — anything goes.
+   */
+  legalMoves(hand: readonly Card[]): Card[] {
+    if (this.plays.length === 0) return [...hand] // leading: anything goes
+
+    const leadSuit = this.leadSuit as Suit
+    const leadCardsOnTable = this.plays
+      .filter((p) => p.card.suit === leadSuit)
+      .map((p) => p.card)
+    const trumpCardsOnTable = this.plays
+      .filter((p) => p.card.suit === this.trumpSuit)
+      .map((p) => p.card)
+
+    const hasLeadSuit = hand.filter((c) => c.suit === leadSuit)
+    if (hasLeadSuit.length > 0) {
+      const bestOnTable = maxByRank(leadCardsOnTable)
+      const beaters = hasLeadSuit.filter((c) => c.rankValue > bestOnTable.rankValue)
+      return beaters.length > 0 ? beaters : hasLeadSuit
+    }
+
+    const hasTrump = hand.filter((c) => c.suit === this.trumpSuit)
+    if (hasTrump.length > 0) {
+      if (trumpCardsOnTable.length > 0) {
+        const bestTrump = maxByRank(trumpCardsOnTable)
+        const beaters = hasTrump.filter((c) => c.rankValue > bestTrump.rankValue)
+        return beaters.length > 0 ? beaters : hasTrump
+      }
+      return hasTrump
+    }
+
+    return [...hand] // sluff — nothing of lead suit or trump
+  }
+
+  play(player: PlayerIndex, card: Card): void {
+    this.plays.push({ player, card })
+  }
+
+  /**
+   * Trick winner: highest trump if any trump was played, else highest
+   * card of the lead suit. Ties (the same physical rank/suit played
+   * twice) go to whichever copy was played first — `firstMaxByRank` only
+   * replaces the running winner on a strictly-greater rank, so the
+   * first-played copy naturally wins on equal rank, same as Python's
+   * `max()` (stable, keeps the first maximal element).
+   */
+  winner(): PlayerIndex {
+    const trumpPlays = this.plays.filter((p) => p.card.suit === this.trumpSuit)
+    const pool = trumpPlays.length > 0
+      ? trumpPlays
+      : this.plays.filter((p) => p.card.suit === this.leadSuit)
+    return firstMaxByRank(pool).player
+  }
+
+  /** Trick points (Ace/10/King = 10 each; Queen/Jack/9 = 0). Excludes the last-trick bonus — that's the caller's job. */
+  points(): number {
+    return this.plays.reduce(
+      (sum, p) => sum + (POINT_RANKS.has(p.card.rank) ? 10 : 0),
+      0,
+    )
+  }
+}
+
+function maxByRank(cards: readonly Card[]): Card {
+  return cards.reduce((best, c) => (c.rankValue > best.rankValue ? c : best))
+}
+
+function firstMaxByRank(plays: readonly TrickPlay[]): TrickPlay {
+  return plays.reduce((best, p) => (p.card.rankValue > best.card.rankValue ? p : best))
+}


### PR DESCRIPTION
## Summary

Ports the trick-taking and scoring pieces of `pinochle_engine.py` to TypeScript, matching the Python reference (and `pinochle_rules.md`) behavior exactly:

- **`web/src/engine/trick.ts`** — `Trick` class: lead-suit tracking, `legalMoves()` (follow-suit / beat-if-possible / trump-if-void / beat-trump-if-possible / sluff), `winner()` (highest trump else highest lead-suit card, first-played copy wins ties), `points()` (A/10/K = 10 each).
- **`web/src/engine/round.ts`** — `playTrickTakingPhase()` runs all 12 tricks (contract winner leads first, each trick's winner leads the next, +10 last-trick bonus on trick 12) and `scoreRound()` applies the contract check (bidding team scores `-bid` if their meld+trick total falls short; defenders always keep their own total). Also `teamOf()` for the fixed Player-0&2 / Player-1&3 seating split.
- **`web/src/engine/game.ts`** — `checkGameOutcome()`: the +-1000 win/loss threshold logic (bust check takes priority; bidding team wins ties when both cross +1000 in the same round).

## Scope note (blocking-dependency judgment call)

Per the issue, bidding/3-card-pass (#17) is out of scope here and may be landing concurrently — I didn't see it in this worktree, so no `Round`/`Player` shell existed yet to build on. Rather than invent a stateful `Round` orchestrator that could collide with #17's shape, `round.ts` is deliberately just the post-bid/post-pass pieces (trick-taking + contract scoring) as composable pure functions, taking `bidWinner`/`bid`/hands as plain inputs. It exposes a generic `ChooseCardFn` seam for trick-play strategy (real AI/human-input logic is a separate, later port) and uses simple `PlayerIndex` (0-3) / `TeamId` (0-1) types rather than `Player`/`Team` classes.

Whoever lands #17 (or wires up the full `Round`/`Game` orchestration next) should plug into this shape: deal -> bidding/passing (#17) -> `scoreMelds` (existing `melds.ts`, per player) -> `playTrickTakingPhase` -> `scoreRound` -> accumulate onto each team's total -> `checkGameOutcome`. Flagging this here in case #17's `Round` representation of players/hands needs to align with `PlayerIndex`/`Hands` as used in this PR.

## Test plan

- [x] `npm test` — 41 tests passing across `card`, `melds`, `trick`, `round`, `game`, and the existing `PlayingCard` component suite (vitest, already configured in `web/package.json`).
- [x] `npx tsc -b` — clean type-check.
- [x] `npm run lint` (oxlint) — clean.
- [x] `npm run build` — production build succeeds.
- [x] `playTrickTakingPhase` sanity-checked end-to-end against a full shuffled `Deck` (round.test.ts): 12 tricks played, exactly 250 total trick points distributed (240 point-cards + 10 last-trick bonus), leader rotation verified.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)