### PR TITLE
Document Double Run meld in pinochle_rules.md

### DIFF
--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -59,9 +59,14 @@ meld type — a second instance of a meld needs a second copy of the card.
 | Meld | Requirement | Points |
 |---|---|---|
 | Run | A, 10, K, Q, J of TrumpSuit | 150 |
+| Double Run | Both copies of A, 10, K, Q, J of TrumpSuit | 1500 |
 | Royal Marriage | K + Q of TrumpSuit | 40 |
 | Common Marriage | K + Q of a non-trump suit | 20 |
 | Dix | 9 of TrumpSuit | 10 |
+
+Double Run **replaces** the single Run — it is not 2 × 150 = 300. If you
+hold both copies of A, 10, K, Q, and J of TrumpSuit, you score 1500, not
+300 (same convention as Double Pinochle and the Arounds doubles below).
 
 ### Class B — Pinochle Melds
 


### PR DESCRIPTION
## Summary
- Adds Double Run to the Class A meld table in `pinochle_rules.md` (both copies of A-10-K-Q-J of TrumpSuit, 1500 pts)
- Adds a note that Double Run replaces the single Run rather than stacking (150 x 2 != 1500), matching the existing convention used for Double Pinochle and the Arounds doubles

Double Run is already implemented and asserted in `pinochle_engine.py` (`DOUBLE_RUN_VALUE = 1500`, `score_melds`); this brings the doc in line with the engine. No code changes.

Closes #9

## Test plan
- [x] Doc-only change; no code touched
- [x] Verified engine values (`DOUBLE_RUN_VALUE = 1500`, replaces single Run) against the new doc text