### PR TITLE
Port PlayTracker + chooseLeadCard to TypeScript

### DIFF
--- a/web/src/engine/tracker.test.ts
+++ b/web/src/engine/tracker.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { Card, Suit } from './card'
+import { chooseLeadCard, PlayTracker } from './tracker'
+
+describe('PlayTracker', () => {
+  it('starts with nothing played', () => {
+    const tracker = new PlayTracker()
+    expect(tracker.playedCount(Suit.Spades, 'A')).toBe(0)
+  })
+
+  it('accumulates played counts per suit/rank, up to 2 copies', () => {
+    const tracker = new PlayTracker()
+    tracker.record(new Card(Suit.Spades, 'A', 1))
+    expect(tracker.playedCount(Suit.Spades, 'A')).toBe(1)
+    tracker.record(new Card(Suit.Spades, 'A', 2))
+    expect(tracker.playedCount(Suit.Spades, 'A')).toBe(2)
+  })
+
+  it('keeps suit/rank counts independent of each other', () => {
+    const tracker = new PlayTracker()
+    tracker.record(new Card(Suit.Spades, 'A', 1))
+    expect(tracker.playedCount(Suit.Hearts, 'A')).toBe(0)
+    expect(tracker.playedCount(Suit.Spades, 'K')).toBe(0)
+  })
+})
+
+describe('chooseLeadCard', () => {
+  it('priority 1: leads an unsecured trump Ace over everything else', () => {
+    const hand = [
+      new Card(Suit.Spades, 'A', 1), // trump, only 1 copy in hand, other copy unplayed
+      new Card(Suit.Hearts, 'A', 1),
+      new Card(Suit.Hearts, 'A', 2), // secure double ace, would otherwise be a safe card
+    ]
+    const tracker = new PlayTracker()
+    const led = chooseLeadCard(hand, Suit.Spades, tracker)
+    expect(led.suit).toBe(Suit.Spades)
+    expect(led.rank).toBe('A')
+  })
+
+  it('a trump Ace is not "unsecured" once its partner copy has already been played', () => {
+    const hand = [new Card(Suit.Spades, 'A', 1), new Card(Suit.Clubs, '9', 1)]
+    const tracker = new PlayTracker()
+    tracker.record(new Card(Suit.Spades, 'A', 2)) // the other copy is already gone
+    const led = chooseLeadCard(hand, Suit.Spades, tracker)
+    // Falls through past priority 1 - the remaining Ace is now safe (rank A
+    // is always safe), so it's still the pick, just via priority 3.
+    expect(led.suit).toBe(Suit.Spades)
+    expect(led.rank).toBe('A')
+  })
+
+  it('priority 2: leads an unsecured non-trump Ace, preferring the longest suit', () => {
+    const hand = [
+      new Card(Suit.Hearts, 'A', 1), // unsecured, Hearts length 1
+      new Card(Suit.Clubs, 'A', 1), // unsecured, Clubs length 2
+      new Card(Suit.Clubs, '9', 1),
+    ]
+    const tracker = new PlayTracker()
+    const led = chooseLeadCard(hand, Suit.Spades, tracker) // trump not present in hand
+    expect(led.suit).toBe(Suit.Clubs)
+    expect(led.rank).toBe('A')
+  })
+
+  it('priority 3: leads a safe card, cascading top-down by rank', () => {
+    const hand = [
+      new Card(Suit.Hearts, 'A', 1), // secure double ace -> safe, highest rank
+      new Card(Suit.Hearts, 'A', 2),
+      new Card(Suit.Clubs, '9', 1), // not safe: higher clubs ranks unaccounted for
+    ]
+    const tracker = new PlayTracker()
+    const led = chooseLeadCard(hand, Suit.Spades, tracker)
+    expect(led.suit).toBe(Suit.Hearts)
+    expect(led.rank).toBe('A')
+  })
+
+  it('priority 3: within the same rank tier, prefers the longer suit', () => {
+    // Both suits have all 5 higher ranks accounted for (all in hand), so the
+    // 9s of each suit are equally "safe" - the tiebreak is suit length.
+    const hand = [
+      new Card(Suit.Hearts, '9', 1),
+      new Card(Suit.Hearts, 'J', 1),
+      new Card(Suit.Hearts, 'Q', 1),
+      new Card(Suit.Hearts, 'K', 1),
+      new Card(Suit.Hearts, '10', 1),
+      new Card(Suit.Hearts, 'A', 1),
+      new Card(Suit.Hearts, 'A', 2),
+      new Card(Suit.Clubs, '9', 1),
+      new Card(Suit.Clubs, 'J', 1),
+      new Card(Suit.Clubs, 'Q', 1),
+      new Card(Suit.Clubs, 'K', 1),
+      new Card(Suit.Clubs, '10', 1),
+    ]
+    const tracker = new PlayTracker()
+    const led = chooseLeadCard(hand, Suit.Spades, tracker)
+    // Hearts (7 cards) is longer than Clubs (5 cards); both suits' 9s are
+    // safe (every higher card is in hand), so Hearts' 9 wins the tiebreak.
+    // But the Hearts Aces outrank everything by rank cascade first.
+    expect(led.suit).toBe(Suit.Hearts)
+    expect(led.rank).toBe('A')
+  })
+
+  it('priority 4: with no aces or safe cards, leads junk (non-point, non-trump), shortest suit first', () => {
+    const hand = [
+      new Card(Suit.Diamonds, 'J', 1), // Diamonds length 1
+      new Card(Suit.Hearts, '9', 1), // Hearts length 2
+      new Card(Suit.Hearts, '9', 2),
+    ]
+    const tracker = new PlayTracker()
+    const led = chooseLeadCard(hand, Suit.Spades, tracker)
+    expect(led.suit).toBe(Suit.Diamonds)
+    expect(led.rank).toBe('J')
+  })
+
+  it('priority 5: falls back to non-point trump when only trump/point cards remain', () => {
+    const hand = [
+      new Card(Suit.Spades, '9', 1), // trump, non-point, not safe
+      new Card(Suit.Hearts, '10', 1), // point card, not safe
+    ]
+    const tracker = new PlayTracker()
+    const led = chooseLeadCard(hand, Suit.Spades, tracker)
+    expect(led.suit).toBe(Suit.Spades)
+    expect(led.rank).toBe('9')
+  })
+
+  it('last resort: leads the lowest-ranked card when every option is a point card', () => {
+    const hand = [
+      new Card(Suit.Hearts, '10', 1), // non-trump point card
+      new Card(Suit.Spades, 'K', 1), // trump point card, lower rank than 10
+    ]
+    const tracker = new PlayTracker()
+    const led = chooseLeadCard(hand, Suit.Spades, tracker)
+    expect(led.suit).toBe(Suit.Spades)
+    expect(led.rank).toBe('K')
+  })
+})

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -1,0 +1,112 @@
+// Card-counting tracker + lead-card AI — ported from pinochle_engine.py's
+// PlayTracker class and choose_lead_card function (frozen Python
+// reference).
+//
+// PlayTracker accumulates played-card counts across a round; both the
+// lead-card strategy here and the follow-card strategy (#32, not yet
+// ported) consume the same tracker instance. Its public shape is kept
+// deliberately small - `record` / `playedCount` are all either strategy
+// currently needs.
+
+import { type Card, RANK_VALUE, RANKS, type Rank, type Suit } from './card'
+
+const POINT_RANKS = new Set(['A', '10', 'K'])
+
+/** Tracks cards played so far this round, across all 4 hands. */
+export class PlayTracker {
+  private readonly played = new Map<string, number>()
+
+  private static key(suit: Suit, rank: Rank): string {
+    return `${suit}:${rank}`
+  }
+
+  record(card: Card): void {
+    const key = PlayTracker.key(card.suit, card.rank)
+    this.played.set(key, (this.played.get(key) ?? 0) + 1)
+  }
+
+  playedCount(suit: Suit, rank: Rank): number {
+    return this.played.get(PlayTracker.key(suit, rank)) ?? 0
+  }
+}
+
+function handCount(hand: readonly Card[], suit: Suit, rank: Rank): number {
+  return hand.reduce((count, c) => count + (c.suit === suit && c.rank === rank ? 1 : 0), 0)
+}
+
+function suitLength(hand: readonly Card[], suit: Suit): number {
+  return hand.reduce((count, c) => count + (c.suit === suit ? 1 : 0), 0)
+}
+
+/**
+ * A card is safe to lead once every higher-ranked card in its suit is
+ * accounted for - either already played, or still in your own hand (a
+ * card you hold yourself can't beat you).
+ */
+function isSafe(card: Card, hand: readonly Card[], tracker: PlayTracker): boolean {
+  if (card.rank === 'A') return true
+  const idx = RANK_VALUE[card.rank]
+  for (const rank of RANKS) {
+    const value = RANK_VALUE[rank]
+    if (value > idx) {
+      const accounted = tracker.playedCount(card.suit, rank) + handCount(hand, card.suit, rank)
+      if (accounted < 2) return false
+    }
+  }
+  return true
+}
+
+/**
+ * Exactly 1 copy of this Ace in hand, and the other copy hasn't been
+ * played yet - a live liability that needs to move before someone else's
+ * lead traps you into losing it to the tie-break rule.
+ */
+function isUnsecuredAce(card: Card, hand: readonly Card[], tracker: PlayTracker): boolean {
+  if (card.rank !== 'A') return false
+  if (handCount(hand, card.suit, 'A') !== 1) return false // 0 copies (n/a) or 2 copies (secure double, no rush)
+  return tracker.playedCount(card.suit, 'A') === 0
+}
+
+/**
+ * Choose what to lead when you have control. Priority:
+ *   1. Unsecured trump Ace
+ *   2. Other unsecured Aces (longest suit first)
+ *   3. Safe cards, cascading top-down by rank (longest suit first within a rank)
+ *   4. Junk lead (non-point, non-trump) to surrender - shortest suit first
+ *   5. Non-point trump as a last resort before giving up a point card
+ */
+export function chooseLeadCard(hand: readonly Card[], trump: Suit, tracker: PlayTracker): Card {
+  const trumpAces = hand.filter((c) => c.suit === trump && c.rank === 'A' && isUnsecuredAce(c, hand, tracker))
+  if (trumpAces.length > 0) return trumpAces[0]
+
+  const otherUnsecuredAces = hand.filter(
+    (c) => c.rank === 'A' && c.suit !== trump && isUnsecuredAce(c, hand, tracker),
+  )
+  if (otherUnsecuredAces.length > 0) {
+    otherUnsecuredAces.sort((a, b) => suitLength(hand, b.suit) - suitLength(hand, a.suit))
+    return otherUnsecuredAces[0]
+  }
+
+  const safeCards = hand.filter((c) => isSafe(c, hand, tracker))
+  if (safeCards.length > 0) {
+    safeCards.sort((a, b) => {
+      const byRank = RANK_VALUE[b.rank] - RANK_VALUE[a.rank]
+      return byRank !== 0 ? byRank : suitLength(hand, b.suit) - suitLength(hand, a.suit)
+    })
+    return safeCards[0]
+  }
+
+  const junk = hand.filter((c) => !POINT_RANKS.has(c.rank) && c.suit !== trump)
+  if (junk.length > 0) {
+    junk.sort((a, b) => suitLength(hand, a.suit) - suitLength(hand, b.suit))
+    return junk[0]
+  }
+
+  const junkTrump = hand.filter((c) => !POINT_RANKS.has(c.rank) && c.suit === trump)
+  if (junkTrump.length > 0) {
+    junkTrump.sort((a, b) => suitLength(hand, a.suit) - suitLength(hand, b.suit))
+    return junkTrump[0]
+  }
+
+  return hand.reduce((lowest, c) => (RANK_VALUE[c.rank] < RANK_VALUE[lowest.rank] ? c : lowest))
+}


### PR DESCRIPTION
## Summary
- Ports `PlayTracker` (pinochle_engine.py:421-432) and `choose_lead_card` (pinochle_engine.py:469-510), plus the `is_safe`/`is_unsecured_ace` helpers they depend on, to `web/src/engine/tracker.ts`.
- `PlayTracker`'s public shape (`record(card)` / `playedCount(suit, rank)`) is kept minimal and matches the frozen Python reference exactly - it's what both `chooseLeadCard` here and the eventual follow-card strategy (#32) need, nothing more.
- Added `web/src/engine/tracker.test.ts`, mirroring the Python cascade's priority tiers: unsecured trump Ace -> other unsecured Aces (longest suit first) -> safe cards (rank cascade, longest suit tiebreak) -> non-trump junk (shortest suit first) -> trump junk -> lowest-rank fallback.

Closes #31

## Test plan
- [x] `npm test` (80/80 passing, including 11 new tracker tests)
- [x] `npm run build`
- [x] `npm run lint` (oxlint, clean)