### PR TITLE
Add static table layout scaffold (seats, hands, trick area, scoreboard)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,12 @@
+import { Table } from './components/Table'
+import { buildMockTableState } from './mock/tableState'
+
+// buildMockTableState() is called once per module load (not per render) so
+// the demo table doesn't reshuffle every time App re-renders.
+const mockState = buildMockTableState()
+
 function App() {
-  return (
-    <div className="min-h-svh flex items-center justify-center bg-green-900 text-white">
-      <h1 className="text-3xl font-semibold">Pinochle</h1>
-    </div>
-  )
+  return <Table state={mockState} />
 }
 
 export default App

--- a/web/src/components/PlayingCard.tsx
+++ b/web/src/components/PlayingCard.tsx
@@ -1,16 +1,5 @@
-import { type Rank, Suit } from '../engine/card'
-
-// Code-drawn, not image assets — see issue #24. The four suit symbols
-// (♠♥♦♣) have solid cross-platform font coverage; the Unicode "Playing
-// Cards" block (🂡 etc.) does not and is deliberately not used here.
-const SUIT_GLYPH: Record<Suit, string> = {
-  [Suit.Spades]: '♠',
-  [Suit.Hearts]: '♥',
-  [Suit.Diamonds]: '♦',
-  [Suit.Clubs]: '♣',
-}
-
-const RED_SUITS: readonly Suit[] = [Suit.Hearts, Suit.Diamonds]
+import { type Rank, type Suit } from '../engine/card'
+import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
 
 export interface PlayingCardProps {
   suit: Suit

--- a/web/src/components/Scoreboard.tsx
+++ b/web/src/components/Scoreboard.tsx
@@ -1,0 +1,34 @@
+import type { Suit } from '../engine/card'
+import type { TeamId } from '../engine/round'
+import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
+
+export interface ScoreboardProps {
+  scoresByTeam: Record<TeamId, number>
+  currentBid: number
+  bidWinnerName: string
+  trumpSuit: Suit
+}
+
+/** Top strip: cumulative team scores, the standing bid, and trump. Stays
+ * mounted throughout bidding/passing/trick-play so those flows (separate
+ * issues) can render alongside it without needing their own scoreboard. */
+export function Scoreboard({ scoresByTeam, currentBid, bidWinnerName, trumpSuit }: ScoreboardProps) {
+  const trumpColor = RED_SUITS.includes(trumpSuit) ? 'text-red-400' : 'text-white'
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-1 bg-green-950 px-4 py-2 text-sm text-white shadow-md">
+      <span>
+        Team A: <span className="font-semibold">{scoresByTeam[0]}</span>
+      </span>
+      <span>
+        Team B: <span className="font-semibold">{scoresByTeam[1]}</span>
+      </span>
+      <span>
+        Bid: <span className="font-semibold">{currentBid}</span> ({bidWinnerName})
+      </span>
+      <span>
+        Trump: <span className={`text-lg font-semibold ${trumpColor}`}>{SUIT_GLYPH[trumpSuit]}</span>
+      </span>
+    </div>
+  )
+}

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -1,0 +1,71 @@
+import { type Rank, Suit } from '../engine/card'
+import { PlayingCard } from './PlayingCard'
+import type { SeatPosition, SeatState } from './tableTypes'
+
+export interface SeatProps {
+  seat: SeatState
+  position: SeatPosition
+  isHuman: boolean
+  isBidWinner: boolean
+}
+
+// Placeholder face used for AI seats' face-down fan. The suit/rank props
+// are required by PlayingCard but are never rendered when faceDown is
+// set, so these values are arbitrary — no hidden information leaks here.
+const FACE_DOWN_SUIT: Suit = Suit.Spades
+const FACE_DOWN_RANK: Rank = '9'
+
+const POSITION_LAYOUT: Record<SeatPosition, string> = {
+  bottom: 'flex-col items-center',
+  top: 'flex-col-reverse items-center',
+  left: 'flex-col items-center',
+  right: 'flex-col items-center',
+}
+
+/**
+ * One seat at the table. The human seat renders its full hand face-up
+ * with the real `PlayingCard` component; AI seats render a face-down fan
+ * sized to their card count — never the actual cards, since an AI's hand
+ * is hidden information from the human player's point of view.
+ */
+export function Seat({ seat, position, isHuman, isBidWinner }: SeatProps) {
+  return (
+    <div className={`flex gap-1 ${POSITION_LAYOUT[position]}`}>
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <span>{seat.name}</span>
+        {isBidWinner && (
+          <span className="rounded bg-amber-500/90 px-1.5 py-0.5 text-xs font-semibold text-amber-950">
+            Bid
+          </span>
+        )}
+        {!isHuman && (
+          <span className="text-xs text-white/70">{seat.hand.length} cards</span>
+        )}
+      </div>
+      {isHuman ? (
+        <div className="flex flex-wrap justify-center gap-1 overflow-x-auto">
+          {seat.hand.map((card) => (
+            <PlayingCard
+              key={card.toString()}
+              suit={card.suit}
+              rank={card.rank}
+              className="-ml-10 first:ml-0"
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex overflow-x-auto px-2">
+          {seat.hand.map((_, i) => (
+            <PlayingCard
+              key={i}
+              suit={FACE_DOWN_SUIT}
+              rank={FACE_DOWN_RANK}
+              faceDown
+              className={`-ml-14 first:ml-0 ${i % 2 === 0 ? '-rotate-6' : 'rotate-6'}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -1,0 +1,55 @@
+import { Scoreboard } from './Scoreboard'
+import { Seat } from './Seat'
+import { seatPosition, type SeatPosition, type TableState } from './tableTypes'
+import { TrickArea } from './TrickArea'
+
+export interface TableProps {
+  state: TableState
+}
+
+const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
+  top: 'col-start-2 row-start-1',
+  left: 'col-start-1 row-start-2',
+  right: 'col-start-3 row-start-2',
+  bottom: 'col-start-2 row-start-3',
+}
+
+/**
+ * Static table layout scaffold (#33): four seats around a center trick
+ * area, with a scoreboard strip up top. No interaction yet — bid/pass
+ * and trick-play controls (separate issues) will mount into this shell,
+ * most likely inside/near the human seat and the TrickArea respectively.
+ */
+export function Table({ state }: TableProps) {
+  const { seats, humanPlayer, trick, trumpSuit, currentBid, bidWinner, scoresByTeam } = state
+  const bidWinnerSeat = seats.find((seat) => seat.player === bidWinner)
+
+  return (
+    <div className="flex min-h-svh flex-col bg-green-900 text-white">
+      <Scoreboard
+        scoresByTeam={scoresByTeam}
+        currentBid={currentBid}
+        bidWinnerName={bidWinnerSeat?.name ?? `Player ${bidWinner}`}
+        trumpSuit={trumpSuit}
+      />
+      <div className="grid flex-1 grid-cols-[1fr_2fr_1fr] grid-rows-[1fr_2fr_1fr] items-center justify-items-center gap-4 p-4">
+        {seats.map((seat) => (
+          <div
+            key={seat.player}
+            className={POSITION_GRID_CLASS[seatPosition(seat.player, humanPlayer)]}
+          >
+            <Seat
+              seat={seat}
+              position={seatPosition(seat.player, humanPlayer)}
+              isHuman={seat.player === humanPlayer}
+              isBidWinner={seat.player === bidWinner}
+            />
+          </div>
+        ))}
+        <div className="col-start-2 row-start-2">
+          <TrickArea trick={trick} humanPlayer={humanPlayer} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/TrickArea.tsx
+++ b/web/src/components/TrickArea.tsx
@@ -1,0 +1,33 @@
+import type { PlayerIndex, TrickPlay } from '../engine/trick'
+import { PlayingCard } from './PlayingCard'
+import { seatPosition, type SeatPosition } from './tableTypes'
+
+export interface TrickAreaProps {
+  trick: readonly TrickPlay[]
+  humanPlayer: PlayerIndex
+}
+
+const POSITION_CLASS: Record<SeatPosition, string> = {
+  top: 'col-start-2 row-start-1',
+  left: 'col-start-1 row-start-2',
+  right: 'col-start-3 row-start-2',
+  bottom: 'col-start-2 row-start-3',
+}
+
+/**
+ * Center-of-table area: the cards played so far in the current trick,
+ * each placed on the side of the center matching its player's seat. Empty
+ * until a seat has played, so a trick in progress shows 1-3 cards and a
+ * completed-but-not-yet-cleared trick shows all 4.
+ */
+export function TrickArea({ trick, humanPlayer }: TrickAreaProps) {
+  return (
+    <div className="grid aspect-square w-full max-w-72 grid-cols-3 grid-rows-3 items-center justify-items-center rounded-full bg-green-950/40">
+      {trick.map((play) => (
+        <div key={play.player} className={POSITION_CLASS[seatPosition(play.player, humanPlayer)]}>
+          <PlayingCard suit={play.card.suit} rank={play.card.rank} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/suitGlyphs.ts
+++ b/web/src/components/suitGlyphs.ts
@@ -1,0 +1,15 @@
+import { Suit } from '../engine/card'
+
+// Code-drawn, not image assets — see issue #24. The four suit symbols
+// (♠♥♦♣) have solid cross-platform font coverage; the Unicode "Playing
+// Cards" block (🂡 etc.) does not and is deliberately not used here.
+// Shared between PlayingCard and any other component that needs to show
+// a suit (e.g. the scoreboard's trump indicator).
+export const SUIT_GLYPH: Record<Suit, string> = {
+  [Suit.Spades]: '♠',
+  [Suit.Hearts]: '♥',
+  [Suit.Diamonds]: '♦',
+  [Suit.Clubs]: '♣',
+}
+
+export const RED_SUITS: readonly Suit[] = [Suit.Hearts, Suit.Diamonds]

--- a/web/src/components/tableTypes.ts
+++ b/web/src/components/tableTypes.ts
@@ -1,0 +1,48 @@
+// Shared prop shapes for the table layout scaffold (#33). Built from the
+// real engine types (card.ts/trick.ts/round.ts) rather than ad-hoc UI
+// types, so a later issue (bid/pass UI, trick-play UI, a live game loop)
+// can hand this component tree actual Round/Game state without changing
+// these shapes — only where the values come from changes.
+
+import type { Card, Suit } from '../engine/card'
+import type { TeamId } from '../engine/round'
+import type { PlayerIndex, TrickPlay } from '../engine/trick'
+
+/** One seat at the table. `hand` is the real per-player Card list; seats
+ * other than `TableState['humanPlayer']` only ever render `hand.length`
+ * (face-down fan / count), never the cards themselves, since a real
+ * player's hand is hidden information. */
+export interface SeatState {
+  readonly player: PlayerIndex
+  readonly name: string
+  readonly hand: readonly Card[]
+}
+
+export interface TableState {
+  readonly seats: readonly [SeatState, SeatState, SeatState, SeatState]
+  readonly humanPlayer: PlayerIndex
+  /** Cards played so far in the current trick, in play order. */
+  readonly trick: readonly TrickPlay[]
+  readonly trumpSuit: Suit
+  readonly currentBid: number
+  readonly bidWinner: PlayerIndex
+  readonly scoresByTeam: Record<TeamId, number>
+}
+
+/** Table position, independent of PlayerIndex — the human seat is always
+ * `'bottom'`, with the other three seats rotated clockwise around it so
+ * partners (per round.ts's teamOf, players 2 apart) land opposite each
+ * other regardless of which PlayerIndex is the human. */
+export type SeatPosition = 'bottom' | 'left' | 'top' | 'right'
+
+const POSITIONS_CLOCKWISE_FROM_HUMAN: readonly SeatPosition[] = [
+  'bottom',
+  'left',
+  'top',
+  'right',
+]
+
+export function seatPosition(player: PlayerIndex, humanPlayer: PlayerIndex): SeatPosition {
+  const offset = (player - humanPlayer + 4) % 4
+  return POSITIONS_CLOCKWISE_FROM_HUMAN[offset]
+}

--- a/web/src/mock/tableState.ts
+++ b/web/src/mock/tableState.ts
@@ -1,0 +1,57 @@
+// Static demo state for the table layout scaffold (#33). Built from the
+// real engine types (Deck/Card/Trick) rather than hand-rolled fixtures,
+// so this file — and this file alone — is what a later issue needs to
+// replace with a live Round/Game once bidding/passing/trick-play (#17
+// and friends) actually drive the table; Table/Seat/TrickArea/Scoreboard
+// don't need to change.
+
+import { Deck, Suit } from '../engine/card'
+import type { TableState } from '../components/tableTypes'
+import { Trick } from '../engine/trick'
+import type { PlayerIndex } from '../engine/trick'
+
+const SEAT_NAMES: Record<PlayerIndex, string> = {
+  0: 'You',
+  1: 'West',
+  2: 'Partner',
+  3: 'East',
+}
+
+const HUMAN_PLAYER: PlayerIndex = 0
+const BID_WINNER: PlayerIndex = 0
+const TRUMP_SUIT: Suit = Suit.Hearts
+const CURRENT_BID = 340
+
+export function buildMockTableState(): TableState {
+  const deck = new Deck()
+  deck.shuffle()
+  const hands = deck.deal()
+
+  // Show a trick already in progress: the two seats after the human have
+  // led and followed, so the center area and the remaining hand sizes
+  // stay consistent with each other.
+  const trick = new Trick(TRUMP_SUIT)
+  const leadPlayer: PlayerIndex = 2
+  const secondPlayer: PlayerIndex = 3
+  const leadCard = hands[leadPlayer].pop()
+  const secondCard = hands[secondPlayer].pop()
+  if (leadCard) trick.play(leadPlayer, leadCard)
+  if (secondCard) trick.play(secondPlayer, secondCard)
+
+  const seats: TableState['seats'] = [
+    { player: 0, name: SEAT_NAMES[0], hand: hands[0] },
+    { player: 1, name: SEAT_NAMES[1], hand: hands[1] },
+    { player: 2, name: SEAT_NAMES[2], hand: hands[2] },
+    { player: 3, name: SEAT_NAMES[3], hand: hands[3] },
+  ]
+
+  return {
+    seats,
+    humanPlayer: HUMAN_PLAYER,
+    trick: trick.plays,
+    trumpSuit: TRUMP_SUIT,
+    currentBid: CURRENT_BID,
+    bidWinner: BID_WINNER,
+    scoresByTeam: { 0: 180, 1: 220 },
+  }
+}


### PR DESCRIPTION
## Summary
- `Table`, `Seat`, `TrickArea`, and `Scoreboard` components implement the static table scaffold: 4 seats arranged around a center trick area (bottom = human, others = AI), a scoreboard strip (team scores, current bid, trump), matching #33's scope.
- The human seat renders a full face-up hand with the existing `PlayingCard` component; AI seats render a face-down fan sized to their card count (never the actual cards — hidden information).
- Props are built from the real engine types (`card.ts`/`trick.ts`/`round.ts`) via a new `web/src/components/tableTypes.ts`, so later issues (bid/pass UI, trick-play UI) can swap in live `Round`/`Game` state without reshaping these components.
- `web/src/mock/tableState.ts` builds a demo `TableState` using the real `Deck`/`Trick` classes (shuffled hands, a trick already in progress) so `App.tsx` has something concrete to render.
- Moved the suit-glyph map out of `PlayingCard.tsx` into a small shared `suitGlyphs.ts` (reused by `Scoreboard`'s trump indicator) to avoid an oxlint `only-export-components` warning from a non-component export.

No interaction yet (no click handlers, no game loop) — this is the layout shell later issues mount their controls into.

## Test plan
- [x] `npm test` — all 69 tests pass (no new tests needed; this is a layout scaffold, existing `PlayingCard` coverage is unchanged)
- [x] `npm run build` — typecheck + production build succeed
- [x] `npm run lint` (oxlint) — no warnings/errors
- [x] Manually verified in a dev-server browser preview: scoreboard strip, human hand face-up, 3 AI seats with face-down fans + card counts, center trick area showing in-progress trick cards

Closes #33