### PR TITLE
Add fallback-padding parity tests for choosePassCards dispatcher

### DIFF
--- a/web/src/engine/passing.test.ts
+++ b/web/src/engine/passing.test.ts
@@ -114,4 +114,36 @@ describe('choosePassCards', () => {
     expect(choosePassCards(hand, 3, Suit.Spades, true)).toHaveLength(3)
     expect(choosePassCards(hand, 3, Suit.Spades, false)).toHaveLength(3)
   })
+
+  // Parity with the Python fallback-padding safety net (pinochle_engine.py:913-916):
+  // both bidderPassSelection and partnerPassSelection end in a catch-all "take
+  // anything left" tier, so in practice they always fill `count` on their own
+  // whenever the hand has at least `count` cards - the padding branch in
+  // choosePassCards is defensive and normally never adds anything. These tests
+  // exercise that branch directly via a hand smaller than `count`, where the
+  // strategy necessarily under-fills and there's nothing left in the pool to pad
+  // with. Python's `random.sample(remaining, count - len(chosen))` would raise
+  // ValueError there (sample size > population); the TS port degrades
+  // gracefully instead, returning every card the hand actually has.
+  it('degrades gracefully (no throw, no duplicates) when the hand has fewer cards than `count`', () => {
+    const hand = [new Card(Suit.Hearts, '9', 1), new Card(Suit.Clubs, '9', 1)]
+
+    const asBidder = choosePassCards(hand, 3, Suit.Spades, true)
+    expect(asBidder).toHaveLength(hand.length)
+    expect(new Set(asBidder).size).toBe(asBidder.length)
+    for (const c of asBidder) expect(hand).toContain(c)
+
+    const asPartner = choosePassCards(hand, 3, Suit.Spades, false)
+    expect(asPartner).toHaveLength(hand.length)
+    expect(new Set(asPartner).size).toBe(asPartner.length)
+    for (const c of asPartner) expect(hand).toContain(c)
+  })
+
+  it('never fabricates or duplicates cards when padding a single-card hand', () => {
+    const onlyCard = new Card(Suit.Diamonds, '9', 1)
+    const hand = [onlyCard]
+
+    expect(choosePassCards(hand, 3, Suit.Hearts, true)).toEqual([onlyCard])
+    expect(choosePassCards(hand, 3, Suit.Hearts, false)).toEqual([onlyCard])
+  })
 })


### PR DESCRIPTION
## Summary

Issue #30 asked for a `choosePassCards` dispatch wrapper in `web/src/engine/passing.ts` (pick DS vs HC category from trump suit, dispatch to `bidderPassSelection`/`partnerPassSelection` based on `is_bid_winner`, pad with random remaining cards if the strategy under-fills `count`) — mirroring `Player.choose_pass_cards` in `pinochle_engine.py:895-916`.

Turns out that dispatcher was already implemented, matching the Python reference exactly, as part of the earlier `1e7bbde` commit ("Port bid valuation and 3-card pass logic to TypeScript", which closed #17) — the issue itself just never got closed. Existing tests already covered the no-context random fallback, the bidder/partner dispatch, and full-hand counts, but nothing exercised the fallback-padding safety net (Python lines 913-916 / TS lines 285-288) specifically.

Both `bidderPassSelection` and `partnerPassSelection` end in their own catch-all "take anything left" tier, so in practice they always fill `count` on their own whenever the hand has at least `count` cards — the padding branch only actually does anything when the hand itself is smaller than `count`. This PR adds two tests for that edge, confirming the TS port degrades gracefully (no duplicate or fabricated cards, no throw) in a case where Python's `random.sample(remaining, count - len(chosen))` would raise `ValueError` (sample size larger than population).

- No changes to `web/src/engine/passing.ts` — the dispatcher was already correct.
- Added 2 parity tests to `web/src/engine/passing.test.ts`.

Closes #30

## Test plan

- [x] `npm test` — 82/82 tests passing (includes the 2 new tests)
- [x] `npm run build` — TypeScript compiles cleanly, Vite build succeeds
- [x] `npm run lint` — clean, no findings