### PR TITLE
Build round-summary and win/loss screens

### DIFF
--- a/web/src/components/GameOverScreen.test.tsx
+++ b/web/src/components/GameOverScreen.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GameOverData } from './scoreTypes'
+import { GameOverScreen } from './GameOverScreen'
+
+// See RoundSummary.test.tsx: no global `afterEach` is wired up for
+// @testing-library/react's automatic cleanup, so each render() here would
+// otherwise persist into the next test's DOM.
+afterEach(cleanup)
+
+const data: GameOverData = {
+  winningTeam: 0,
+  finalScoresByTeam: { 0: 1040, 1: 760 },
+}
+
+describe('GameOverScreen', () => {
+  it('announces the winning team', () => {
+    render(<GameOverScreen data={data} onNewGame={() => {}} />)
+    expect(screen.getByText('Team A wins!')).not.toBeNull()
+  })
+
+  it('renders both teams final scores', () => {
+    render(<GameOverScreen data={data} onNewGame={() => {}} />)
+    expect(screen.getByText('1040')).not.toBeNull()
+    expect(screen.getByText('760')).not.toBeNull()
+  })
+
+  it('calls onNewGame when the start-new-game button is clicked', () => {
+    const onNewGame = vi.fn()
+    render(<GameOverScreen data={data} onNewGame={onNewGame} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Start new game' }))
+    expect(onNewGame).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/GameOverScreen.tsx
+++ b/web/src/components/GameOverScreen.tsx
@@ -1,0 +1,47 @@
+import type { TeamId } from '../engine/round'
+import { TEAM_NAMES, type GameOverData } from './scoreTypes'
+
+export interface GameOverScreenProps {
+  data: GameOverData
+  onNewGame: () => void
+}
+
+const TEAM_IDS: readonly TeamId[] = [0, 1]
+
+/**
+ * Final win/loss overlay (#36), shown once a round's cumulative scores
+ * cross +-1000 and `checkGameOutcome` (game.ts) returns a winning team.
+ * Purely a rendering of `GameOverData` plus a "start new game" action —
+ * the caller (a future game-orchestrator issue) owns actually resetting
+ * game state when `onNewGame` fires.
+ */
+export function GameOverScreen({ data, onNewGame }: GameOverScreenProps) {
+  const { winningTeam, finalScoresByTeam } = data
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/70 p-4">
+      <div className="w-full max-w-sm rounded-lg bg-white p-6 text-center text-neutral-900 shadow-xl">
+        <h2 className="text-2xl font-bold">{TEAM_NAMES[winningTeam]} wins!</h2>
+
+        <dl className="mt-4 flex justify-center gap-8 text-sm">
+          {TEAM_IDS.map((team) => (
+            <div key={team}>
+              <dt className="text-neutral-500">{TEAM_NAMES[team]}</dt>
+              <dd className={`text-lg font-semibold ${team === winningTeam ? 'text-green-700' : ''}`}>
+                {finalScoresByTeam[team]}
+              </dd>
+            </div>
+          ))}
+        </dl>
+
+        <button
+          type="button"
+          onClick={onNewGame}
+          className="mt-6 w-full rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900"
+        >
+          Start new game
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/RoundSummary.test.tsx
+++ b/web/src/components/RoundSummary.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RoundSummaryData } from './scoreTypes'
+import { RoundSummary } from './RoundSummary'
+
+// No global `afterEach` is wired up for @testing-library/react's automatic
+// cleanup (vitest.config's `test` block doesn't set `globals: true`), so
+// each render() here would otherwise persist into the next test's DOM.
+afterEach(cleanup)
+
+const madeContractData: RoundSummaryData = {
+  meldPointsByTeam: { 0: 60, 1: 24 },
+  trickPointsByTeam: { 0: 130, 1: 120 },
+  roundScoreByTeam: { 0: 190, 1: 144 },
+  bidWinnerTeam: 0,
+  bid: 180,
+  cumulativeScoresByTeam: { 0: 610, 1: 524 },
+}
+
+const wentSetData: RoundSummaryData = {
+  meldPointsByTeam: { 0: 20, 1: 24 },
+  trickPointsByTeam: { 0: 100, 1: 150 },
+  roundScoreByTeam: { 0: -340, 1: 174 },
+  bidWinnerTeam: 0,
+  bid: 340,
+  cumulativeScoresByTeam: { 0: 80, 1: 554 },
+}
+
+describe('RoundSummary', () => {
+  it('renders meld, trick, round, and running scores for both teams', () => {
+    render(<RoundSummary data={madeContractData} />)
+    expect(screen.getByText('60')).not.toBeNull()
+    expect(screen.getByText('24')).not.toBeNull()
+    expect(screen.getByText('130')).not.toBeNull()
+    expect(screen.getByText('120')).not.toBeNull()
+    expect(screen.getByText('610')).not.toBeNull()
+    expect(screen.getByText('524')).not.toBeNull()
+  })
+
+  it('reports a made contract when the bidding team met their bid', () => {
+    render(<RoundSummary data={madeContractData} />)
+    expect(screen.getByText(/made their contract/)).not.toBeNull()
+  })
+
+  it('reports going set when the bidding team fell short of their bid', () => {
+    render(<RoundSummary data={wentSetData} />)
+    expect(screen.getByText(/went set/)).not.toBeNull()
+    expect(screen.getByText('-340')).not.toBeNull()
+  })
+
+  it('omits the continue button when onContinue is not supplied', () => {
+    render(<RoundSummary data={madeContractData} />)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('calls onContinue when the continue button is clicked', () => {
+    const onContinue = vi.fn()
+    render(<RoundSummary data={madeContractData} onContinue={onContinue} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(onContinue).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/RoundSummary.tsx
+++ b/web/src/components/RoundSummary.tsx
@@ -1,0 +1,97 @@
+import type { TeamId } from '../engine/round'
+import { TEAM_NAMES, type RoundSummaryData } from './scoreTypes'
+
+export interface RoundSummaryProps {
+  data: RoundSummaryData
+  /** Called when the player dismisses the summary to continue. Optional
+   * since this screen doesn't own round-advance logic (that's the
+   * trick-play/bid UI, separate issues) — omit to render without a
+   * continue control. */
+  onContinue?: () => void
+}
+
+const TEAM_IDS: readonly TeamId[] = [0, 1]
+
+/**
+ * End-of-round overlay (#36): meld + trick points per team for the round
+ * just completed, whether the bidding team made or went set on their
+ * contract, and the running game score after this round's points were
+ * added. Purely a rendering of `RoundSummaryData` — the caller (a future
+ * round-loop/game-orchestrator issue) decides when to show it and what
+ * `onContinue` does.
+ */
+export function RoundSummary({ data, onContinue }: RoundSummaryProps) {
+  const { meldPointsByTeam, trickPointsByTeam, roundScoreByTeam, bidWinnerTeam, bid, cumulativeScoresByTeam } = data
+  // scoreRound() only ever produces a negative net score for the bidding
+  // team, and only when they fell short of their bid ("going set").
+  const wentSet = roundScoreByTeam[bidWinnerTeam] < 0
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/60 p-4">
+      <div className="w-full max-w-sm rounded-lg bg-white p-6 text-neutral-900 shadow-xl">
+        <h2 className="text-lg font-semibold">Round summary</h2>
+        <p className="mt-1 text-sm text-neutral-600">
+          {TEAM_NAMES[bidWinnerTeam]} bid {bid} and{' '}
+          {wentSet ? 'went set' : 'made their contract'}.
+        </p>
+
+        <table className="mt-4 w-full text-sm">
+          <thead>
+            <tr className="text-left text-neutral-500">
+              <th className="font-normal" />
+              {TEAM_IDS.map((team) => (
+                <th key={team} className="pl-4 font-medium text-neutral-900">
+                  {TEAM_NAMES[team]}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="py-1 text-neutral-500">Meld</td>
+              {TEAM_IDS.map((team) => (
+                <td key={team} className="pl-4">
+                  {meldPointsByTeam[team]}
+                </td>
+              ))}
+            </tr>
+            <tr>
+              <td className="py-1 text-neutral-500">Tricks</td>
+              {TEAM_IDS.map((team) => (
+                <td key={team} className="pl-4">
+                  {trickPointsByTeam[team]}
+                </td>
+              ))}
+            </tr>
+            <tr className="border-t border-neutral-200 font-semibold">
+              <td className="py-1 text-neutral-500 font-normal">Round score</td>
+              {TEAM_IDS.map((team) => (
+                <td key={team} className="pl-4">
+                  {roundScoreByTeam[team]}
+                </td>
+              ))}
+            </tr>
+            <tr className="font-semibold">
+              <td className="py-1 text-neutral-500 font-normal">Game score</td>
+              {TEAM_IDS.map((team) => (
+                <td key={team} className="pl-4">
+                  {cumulativeScoresByTeam[team]}
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+
+        {onContinue && (
+          <button
+            type="button"
+            onClick={onContinue}
+            className="mt-6 w-full rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900"
+          >
+            Continue
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/scoreTypes.ts
+++ b/web/src/components/scoreTypes.ts
@@ -1,0 +1,42 @@
+// Shared prop shapes for the round-summary and game-over screens (#36).
+// Built from the real engine types (round.ts's TeamId/scoreRound,
+// game.ts's checkGameOutcome) rather than ad-hoc UI types, so a later
+// issue wiring a live Round/Game loop into these screens only needs to
+// supply these shapes — the components themselves don't change. Mirrors
+// the approach tableTypes.ts took for the table layout scaffold (#33).
+
+import type { TeamId } from '../engine/round'
+
+/** Display names for the two fixed teams — matches Scoreboard's "Team A" /
+ * "Team B" labels (Player 0 & 2 = Team A, Player 1 & 3 = Team B). */
+export const TEAM_NAMES: Record<TeamId, string> = {
+  0: 'Team A',
+  1: 'Team B',
+}
+
+/**
+ * Everything the round-summary screen needs to render one just-completed
+ * round: the meld/trick breakdown that fed `scoreRound()`, that function's
+ * net-points-per-team output, and each team's cumulative total afterward
+ * (the "running score" line). `bid`/`bidWinnerTeam` are included so the
+ * screen can say whether the bidding team made or went set on their
+ * contract, per round.ts's scoreRound rule (net score is -bid when set).
+ */
+export interface RoundSummaryData {
+  readonly meldPointsByTeam: Record<TeamId, number>
+  readonly trickPointsByTeam: Record<TeamId, number>
+  /** scoreRound()'s output: net points added to each team's cumulative
+   * total this round (negative for the bidding team if they went set). */
+  readonly roundScoreByTeam: Record<TeamId, number>
+  readonly bidWinnerTeam: TeamId
+  readonly bid: number
+  /** Cumulative totals after this round's score has been added. */
+  readonly cumulativeScoresByTeam: Record<TeamId, number>
+}
+
+/** Everything the win/loss screen needs once `checkGameOutcome` (game.ts)
+ * returns a non-null winner. */
+export interface GameOverData {
+  readonly winningTeam: TeamId
+  readonly finalScoresByTeam: Record<TeamId, number>
+}

--- a/web/src/mock/scoreState.ts
+++ b/web/src/mock/scoreState.ts
@@ -1,0 +1,40 @@
+// Static demo data for the round-summary and game-over screens (#36).
+// Built with the same shapes `scoreRound`/`checkGameOutcome` (engine/
+// round.ts, engine/game.ts) actually produce, so this file — and this
+// file alone — is what a later issue needs to replace once a live
+// round/game loop (bid/pass/trick-play UI, separate issues) drives these
+// screens for real. RoundSummary/GameOverScreen don't need to change.
+
+import type { GameOverData, RoundSummaryData } from '../components/scoreTypes'
+
+const BID_WINNER_TEAM = 0
+const BID = 340
+
+export function buildMockRoundSummary(): RoundSummaryData {
+  const meldPointsByTeam = { 0: 60, 1: 24 }
+  const trickPointsByTeam = { 0: 130, 1: 120 }
+  const bidTeamTotal = meldPointsByTeam[BID_WINNER_TEAM] + trickPointsByTeam[BID_WINNER_TEAM]
+  const roundScoreByTeam = {
+    0: bidTeamTotal < BID ? -BID : bidTeamTotal,
+    1: meldPointsByTeam[1] + trickPointsByTeam[1],
+  }
+
+  return {
+    meldPointsByTeam,
+    trickPointsByTeam,
+    roundScoreByTeam,
+    bidWinnerTeam: BID_WINNER_TEAM,
+    bid: BID,
+    cumulativeScoresByTeam: {
+      0: 420 + roundScoreByTeam[0],
+      1: 380 + roundScoreByTeam[1],
+    },
+  }
+}
+
+export function buildMockGameOver(): GameOverData {
+  return {
+    winningTeam: 0,
+    finalScoresByTeam: { 0: 1040, 1: 760 },
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `RoundSummary` — meld + trick points per team for the round just completed, whether the bidding team made or went set on their contract (per `scoreRound`'s `-bid` convention in `round.ts`), and the running game score.
- Adds `GameOverScreen` — final win/loss screen shown once `checkGameOutcome` (`game.ts`) returns a winning team, with a "Start new game" action.
- Both components render from plain data props (`RoundSummaryData` / `GameOverData` in the new `scoreTypes.ts`) built from the real engine's `TeamId`/score shapes, so a later game-loop issue can wire in live `Round`/`Game` state without changing these components — mirrors the approach `tableTypes.ts` took for the table layout scaffold (#33).
- Adds `mock/scoreState.ts` sample data for demoing/testing, following the `mock/tableState.ts` pattern.
- Component tests for both screens (meld/trick/round/running score rendering, made-contract vs. went-set text, button callbacks), using the same `@testing-library/react` setup as `PlayingCard.test.tsx`.

Trick-play/bid UI that actually drives round completion is out of scope per the issue — these screens just need round/game score data to render from.

Closes #36

## Test plan
- [x] `npm test` — 88/88 passing (11 files)
- [x] `npm run build` — typecheck + production build clean
- [x] `npm run lint` — oxlint clean