### PR TITLE
Port follow-card trick-play AI to TS (chooseFollowCard)

### DIFF
--- a/web/src/engine/tracker.test.ts
+++ b/web/src/engine/tracker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { Card, Suit } from './card'
-import { chooseLeadCard, PlayTracker } from './tracker'
+import type { TrickPlay } from './trick'
+import { chooseFollowCard, chooseLeadCard, PlayTracker } from './tracker'
 
 describe('PlayTracker', () => {
   it('starts with nothing played', () => {
@@ -130,5 +131,130 @@ describe('chooseLeadCard', () => {
     const led = chooseLeadCard(hand, Suit.Spades, tracker)
     expect(led.suit).toBe(Suit.Spades)
     expect(led.rank).toBe('K')
+  })
+})
+
+describe('chooseFollowCard', () => {
+  it('plays the only legal move without consulting any other context', () => {
+    const onlyCard = new Card(Suit.Hearts, '9', 1)
+    const played = chooseFollowCard([onlyCard], [onlyCard], [], Suit.Spades, [])
+    expect(played).toBe(onlyCard)
+  })
+
+  it('forced beat: every legal card already beats the winner - plays the lowest one that still wins', () => {
+    // Opponent (player 1) is winning with a weak 9 of the lead suit; both
+    // legal cards outrank it, so this is a forced beat regardless of who's
+    // winning - the cheapest winner is played to save bigger cards.
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, '9', 1) }]
+    const legalMoves = [new Card(Suit.Hearts, '10', 1), new Card(Suit.Hearts, 'A', 1)]
+    const hand = legalMoves
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('10')
+  })
+
+  it('feeds partner the highest King/10 when partner is winning and not every card is a forced beat', () => {
+    // Partner (player 0) is winning with a Queen; the 9 doesn't beat it, so
+    // this isn't a forced beat - falls through to the feed-partner tier.
+    const trickPlays: TrickPlay[] = [{ player: 0, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const legalMoves = [
+      new Card(Suit.Hearts, '9', 1),
+      new Card(Suit.Hearts, 'K', 1),
+      new Card(Suit.Hearts, '10', 1),
+    ]
+    const hand = legalMoves
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('10') // 10 outranks King, so it's the bigger feed
+  })
+
+  it('feeding partner with no King/10 available plays the lowest card instead (avoid donating a live Ace)', () => {
+    const trickPlays: TrickPlay[] = [{ player: 0, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const legalMoves = [new Card(Suit.Hearts, '9', 1), new Card(Suit.Hearts, 'J', 1)]
+    const hand = legalMoves
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('9')
+  })
+
+  it('opponent winning: plays the lowest non-point card rather than feeding them a point', () => {
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'K', 1) }]
+    const legalMoves = [
+      new Card(Suit.Hearts, 'J', 1), // non-point
+      new Card(Suit.Hearts, 'Q', 1), // non-point
+      new Card(Suit.Hearts, 'A', 1), // point, beats the King, but not forced (Q/J don't)
+    ]
+    const hand = legalMoves
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('J')
+  })
+
+  it('opponent winning with only point cards available: plays the lowest legal card', () => {
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'A', 1) }]
+    const legalMoves = [new Card(Suit.Hearts, '10', 1), new Card(Suit.Hearts, 'K', 1)]
+    const hand = legalMoves
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('K')
+  })
+
+  it('void in the lead suit, forced to trump, no tracker supplied: defaults to trump-secure and conserves the lowest trump', () => {
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'K', 1) }]
+    const legalMoves = [new Card(Suit.Spades, '9', 1), new Card(Suit.Spades, 'A', 1)]
+    const hand = legalMoves
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('9')
+  })
+
+  it('forced to trump, trump secure per tracker (all 12 copies accounted for): plays the lowest trump', () => {
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'K', 1) }]
+    const hand = [new Card(Suit.Spades, '9', 1), new Card(Suit.Spades, 'A', 1)]
+    const legalMoves = hand
+    const tracker = new PlayTracker()
+    for (const rank of ['J', 'Q', 'K', '10'] as const) {
+      tracker.record(new Card(Suit.Spades, rank, 1))
+      tracker.record(new Card(Suit.Spades, rank, 2))
+    }
+    tracker.record(new Card(Suit.Spades, '9', 2))
+    tracker.record(new Card(Suit.Spades, 'A', 2))
+    // 8 (J/Q/K/10 both copies) + 2 (spare 9/A copies) played, + 2 in hand = 12: fully accounted for.
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2], tracker)
+    expect(played.rank).toBe('9')
+  })
+
+  it('forced to trump, not secure per tracker, has a point trump available: surrenders the lowest point trump', () => {
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, '9', 1) }]
+    const hand = [new Card(Suit.Spades, 'J', 1), new Card(Suit.Spades, 'K', 1)]
+    const legalMoves = hand
+    const tracker = new PlayTracker() // nothing played -> nowhere near 12 accounted for
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2], tracker)
+    expect(played.rank).toBe('K')
+  })
+
+  it('forced to trump, not secure, no point trump available: plays the lowest trump', () => {
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, '9', 1) }]
+    const hand = [new Card(Suit.Spades, 'J', 1), new Card(Suit.Spades, '9', 1)]
+    const legalMoves = hand
+    const tracker = new PlayTracker()
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2], tracker)
+    expect(played.rank).toBe('9')
+  })
+
+  it('sluff (void in lead suit and trump): plays from the shortest suit', () => {
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'K', 1) }]
+    const hand = [
+      new Card(Suit.Clubs, '9', 1),
+      new Card(Suit.Clubs, '10', 1), // Clubs length 2
+      new Card(Suit.Diamonds, '9', 1), // Diamonds length 1 - shortest
+    ]
+    const legalMoves = hand
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.suit).toBe(Suit.Diamonds)
+    expect(played.rank).toBe('9')
+  })
+
+  it('sluff: when suit lengths tie, plays the lowest rank', () => {
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'K', 1) }]
+    const hand = [new Card(Suit.Clubs, '9', 1), new Card(Suit.Diamonds, 'A', 1)] // both suits length 1
+    const legalMoves = hand
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.suit).toBe(Suit.Clubs)
+    expect(played.rank).toBe('9')
   })
 })

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -1,14 +1,14 @@
-// Card-counting tracker + lead-card AI — ported from pinochle_engine.py's
-// PlayTracker class and choose_lead_card function (frozen Python
-// reference).
+// Card-counting tracker + lead-card/follow-card AI — ported from
+// pinochle_engine.py's PlayTracker class, choose_lead_card, and
+// choose_follow_card functions (frozen Python reference).
 //
 // PlayTracker accumulates played-card counts across a round; both the
-// lead-card strategy here and the follow-card strategy (#32, not yet
-// ported) consume the same tracker instance. Its public shape is kept
-// deliberately small - `record` / `playedCount` are all either strategy
-// currently needs.
+// lead-card strategy and the follow-card strategy here consume the same
+// tracker instance. Its public shape is kept deliberately small -
+// `record` / `playedCount` are all either strategy currently needs.
 
 import { type Card, RANK_VALUE, RANKS, type Rank, type Suit } from './card'
+import type { PlayerIndex, TrickPlay } from './trick'
 
 const POINT_RANKS = new Set(['A', '10', 'K'])
 
@@ -109,4 +109,108 @@ export function chooseLeadCard(hand: readonly Card[], trump: Suit, tracker: Play
   }
 
   return hand.reduce((lowest, c) => (RANK_VALUE[c.rank] < RANK_VALUE[lowest.rank] ? c : lowest))
+}
+
+function minByRank(cards: readonly Card[]): Card {
+  return cards.reduce((lowest, c) => (c.rankValue < lowest.rankValue ? c : lowest))
+}
+
+function maxByRank(cards: readonly Card[]): Card {
+  return cards.reduce((highest, c) => (c.rankValue > highest.rankValue ? c : highest))
+}
+
+/**
+ * Who's currently winning the trick-in-progress: highest trump if any
+ * trump has been played, else highest card of the lead suit. Ties go to
+ * whichever copy was played first (`reduce` only replaces the running
+ * winner on a strictly-greater rank), matching `Trick.winner`'s
+ * first-copy-wins behavior for the same reason.
+ */
+function currentWinner(trickPlays: readonly TrickPlay[], trump: Suit): TrickPlay {
+  const trumpPlays = trickPlays.filter((p) => p.card.suit === trump)
+  const pool = trumpPlays.length > 0
+    ? trumpPlays
+    : trickPlays.filter((p) => p.card.suit === trickPlays[0].card.suit)
+  return pool.reduce((best, p) => (p.card.rankValue > best.card.rankValue ? p : best))
+}
+
+/**
+ * Choose which legal card to play when following (not leading).
+ * `legalMoves` already has the mandatory beat-if-possible / trump-if-void
+ * rules applied by `Trick.legalMoves` - this only picks which one to use.
+ *
+ * `legalMoves` is always restricted to exactly one of three shapes by the
+ * rules, and each gets its own tiered strategy:
+ *   - Forced to follow a non-trump lead suit:
+ *       1. Forced beat (every legal card already beats the current
+ *          winner) - play the lowest one that still wins, saving bigger
+ *          cards for later.
+ *       2. Partner is currently winning - feed them points: the highest
+ *          King/10 available, or (if none) the lowest card, to avoid
+ *          donating a live Ace unless forced.
+ *       3. Otherwise - play the lowest non-point card, falling back to
+ *          the lowest legal card if only point cards are available.
+ *   - Forced to play trump (void in the lead suit):
+ *       1. Trump is secure (every copy - in hand plus already played -
+ *          is accounted for, i.e. no trump left unseen) - play the
+ *          lowest trump, conserving high trump for later control.
+ *       2. Not secure - surrender the lowest point trump if there is
+ *          one (get a liability out before it's trapped), else the
+ *          lowest trump.
+ *   - Sluff (void in both lead suit and trump): free choice across
+ *     suits - work toward voiding the shortest suit, lowest rank within
+ *     it.
+ */
+export function chooseFollowCard(
+  hand: readonly Card[],
+  legalMoves: readonly Card[],
+  trickPlays: readonly TrickPlay[],
+  trump: Suit,
+  myTeamPlayers: readonly PlayerIndex[],
+  tracker?: PlayTracker,
+): Card {
+  if (legalMoves.length === 1) return legalMoves[0]
+
+  const leadSuit = trickPlays.length > 0 ? trickPlays[0].card.suit : undefined
+  const winner = trickPlays.length > 0 ? currentWinner(trickPlays, trump) : undefined
+  const partnerWinning = winner !== undefined && myTeamPlayers.includes(winner.player)
+
+  const allLeadSuit = leadSuit !== undefined && legalMoves.every((c) => c.suit === leadSuit)
+  const allTrump = legalMoves.every((c) => c.suit === trump)
+
+  if (allLeadSuit && leadSuit !== trump) {
+    const forcedBeat = winner !== undefined && legalMoves.every((c) => c.rankValue > winner.card.rankValue)
+    if (forcedBeat) return minByRank(legalMoves)
+
+    if (partnerWinning) {
+      const feedCards = legalMoves.filter((c) => c.rank === 'K' || c.rank === '10')
+      if (feedCards.length > 0) return maxByRank(feedCards)
+      return minByRank(legalMoves) // avoid donating a live Ace unless forced
+    }
+
+    const nonPoints = legalMoves.filter((c) => !POINT_RANKS.has(c.rank))
+    if (nonPoints.length > 0) return minByRank(nonPoints)
+    return minByRank(legalMoves)
+  }
+
+  if (allTrump) {
+    let trumpSecure = true
+    if (tracker !== undefined) {
+      const playedTrump = RANKS.reduce((sum, r) => sum + tracker.playedCount(trump, r), 0)
+      const handTrump = suitLength(hand, trump)
+      trumpSecure = playedTrump + handTrump >= 12
+    }
+    if (trumpSecure) return minByRank(legalMoves)
+
+    const points = legalMoves.filter((c) => POINT_RANKS.has(c.rank))
+    if (points.length > 0) return minByRank(points)
+    return minByRank(legalMoves)
+  }
+
+  // sluff - free choice across suits, work toward a void in the shortest suit
+  const legalSorted = [...legalMoves].sort((a, b) => {
+    const bySuitLength = suitLength(hand, a.suit) - suitLength(hand, b.suit)
+    return bySuitLength !== 0 ? bySuitLength : a.rankValue - b.rankValue
+  })
+  return legalSorted[0]
 }


### PR DESCRIPTION
## Summary
- Ports `choose_follow_card` (pinochle_engine.py:511-558) - the follow-card trick-play strategy - to `chooseFollowCard` in `web/src/engine/tracker.ts`, alongside the already-ported `PlayTracker`/`chooseLeadCard` (#31). Also ports the `_current_winner` helper as `currentWinner`.
  - Note: the issue estimated ~300 lines (511-807) for this function; the actual `choose_follow_card` in the current frozen reference is ~48 lines (511-558). Ported it as it exists today rather than inventing extra scope.
- Preserves the three branches from the Python reference, in order: forced-follow of a non-trump lead suit (forced-beat -> feed partner's win with K/10 -> avoid donating points to an opponent's win), forced trump (conserve when secure per the tracker's card count -> surrender the lowest point trump when not secure), and free-choice sluff (work toward voiding the shortest suit).
- Added 12 new tests to `tracker.test.ts` covering each tier of all three branches, including the no-tracker-supplied default (trump treated as secure, matching the Python `tracker=None` fallback) and the suit-length/rank tiebreak in the sluff branch.

## Test plan
- [x] `npm test` (104/104 passing, including the new `chooseFollowCard` suite)
- [x] `npm run build`
- [x] `npm run lint` (oxlint, clean)

Closes #32
