### PR TITLE
Port bid/trump decision loop to TS (chooseBid, chooseTrump)

### DIFF
--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from 'vitest'
-import { Card, Suit } from './card'
+import { describe, expect, it, vi } from 'vitest'
+import { Card, OPENING_BID, Suit } from './card'
 import {
   ACE_VALUE,
+  type AuctionContext,
   bestBaseBid,
   cappedBid,
+  chooseBid,
+  chooseTrump,
   computeBaseBid,
   computeCompetitiveAdjustment,
   computeMaxBid,
@@ -171,5 +174,173 @@ describe('bestBaseBid', () => {
     const { trump: bestTrump, total } = bestBaseBid(hand, 100, 50)
     const { total: rawTotal } = computeMaxBid(hand, bestTrump, 100, 50)
     expect(total).toBe(cappedBid(hand, bestTrump, rawTotal))
+  })
+})
+
+describe('chooseTrump', () => {
+  it('picks the same trump bestBaseBid would', () => {
+    const hand = [
+      ...RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1)),
+      new Card(Suit.Spades, '9', 1),
+      new Card(Suit.Diamonds, '9', 1),
+    ]
+    expect(chooseTrump(hand)).toBe(Suit.Hearts)
+  })
+})
+
+describe('chooseBid', () => {
+  // Weak hand: a lone off-trump 9. Ceiling stays well under
+  // OPENER_THRESHOLD no matter which suit bestBaseBid picks as trump.
+  const weakHand = [new Card(Suit.Hearts, '9', 1)]
+
+  // Base Bid 170 (Run 150 + 1 Ace worth 20) -> ceiling 300 at the default
+  // 0/0 score adjustment (+130 baseline). Below OPENER_THRESHOLD (320).
+  const runOnlyHand = RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1))
+
+  // Base Bid 210 (Run 150 + extra Royal Marriage 40 + Ace 20) -> ceiling
+  // 340 at the default 0/0 adjustment (+130 baseline). Clears both
+  // OPENER_THRESHOLD (320) and the 340 raise-support gate.
+  const strongHand = [
+    ...RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1)),
+    new Card(Suit.Hearts, 'K', 2),
+    new Card(Suit.Hearts, 'Q', 2),
+  ]
+
+  const baseContext = (overrides: Partial<AuctionContext> = {}): AuctionContext => ({
+    everBid: false,
+    passesSoFar: 0,
+    bidHistory: [],
+    dealer: 2,
+    scores: { 0: 0, 1: 0 },
+    ...overrides,
+  })
+
+  describe('without a context (fallback)', () => {
+    it('passes when the coin flip lands under 0.6', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.1)
+      expect(chooseBid(0, weakHand, 300, 10)).toBeNull()
+      vi.restoreAllMocks()
+    })
+
+    it('raises by minIncrement when the coin flip lands at/over 0.6', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.9)
+      expect(chooseBid(0, weakHand, 300, 10)).toBe(310)
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('no one has bid yet', () => {
+    it('opens when the ceiling clears OPENER_THRESHOLD', () => {
+      // Player 0's partner is player 2 (0<->2 seating); use dealer 1 so
+      // dealer-protection (which keys off the partner being dealer)
+      // doesn't fire here.
+      const context = baseContext({ dealer: 1 })
+      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context)).toBe(OPENING_BID)
+    })
+
+    it('passes when the ceiling does not clear OPENER_THRESHOLD', () => {
+      const context = baseContext({ dealer: 1 })
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context)).toBeNull()
+    })
+
+    it('always opens (dealer-protection) when partner is dealer and my score is >= 850 with opponent under 500', () => {
+      // Player 0's partner is player 2 (0<->2 seating).
+      const context = baseContext({ dealer: 2, scores: { 0: 850, 1: 400 } })
+      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBe(OPENING_BID)
+    })
+
+    it('does not trigger dealer-protection when the opponent score is not under 500', () => {
+      const context = baseContext({ dealer: 2, scores: { 0: 850, 1: 500 } })
+      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBeNull()
+    })
+
+    it('3rd bidder (2 passes so far) always opens cheap when my score is not above 800', () => {
+      const context = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
+      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBe(OPENING_BID)
+    })
+
+    it('3rd bidder falls back to the normal threshold once my score is above 800', () => {
+      // oppScore kept above 500 so the "closing out the game" competitive
+      // adjustment bucket (+100) doesn't kick in and change the ceiling -
+      // this test is purely about the passes_so_far===2 threshold gate.
+      const context = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 850, 1: 600 } })
+      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBeNull()
+      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context)).toBe(OPENING_BID)
+    })
+  })
+
+  describe('my team currently holds the bid', () => {
+    it('backs off once my partner has bid twice this auction', () => {
+      const context = baseContext({
+        everBid: true,
+        bidHistory: [
+          { player: 2, amount: 300 },
+          { player: 1, amount: 310 },
+          { player: 2, amount: 320 },
+        ],
+      })
+      expect(chooseBid(0, strongHand, 320, 10, context)).toBeNull()
+    })
+
+    it('matches a partner raise over my own earlier bid when the ceiling supports it', () => {
+      const context = baseContext({
+        everBid: true,
+        bidHistory: [
+          { player: 0, amount: 300 },
+          { player: 1, amount: 310 },
+          { player: 2, amount: 320 },
+        ],
+      })
+      expect(chooseBid(0, strongHand, 320, 10, context)).toBe(330)
+    })
+
+    it('backs off a partner raise over my own earlier bid when the ceiling does not support it', () => {
+      const context = baseContext({
+        everBid: true,
+        bidHistory: [
+          { player: 0, amount: 300 },
+          { player: 1, amount: 310 },
+          { player: 2, amount: 320 },
+        ],
+      })
+      expect(chooseBid(0, weakHand, 320, 10, context)).toBeNull()
+    })
+
+    it('leaves its own standing bid alone (last bidder was me, not partner)', () => {
+      const context = baseContext({
+        everBid: true,
+        bidHistory: [
+          { player: 1, amount: 300 },
+          { player: 0, amount: 310 },
+        ],
+      })
+      expect(chooseBid(0, strongHand, 310, 10, context)).toBeNull()
+    })
+  })
+
+  describe('the opponents currently hold the bid', () => {
+    it('raises when the next bid is within my ceiling', () => {
+      const context = baseContext({ everBid: true, bidHistory: [{ player: 1, amount: 300 }] })
+      expect(chooseBid(0, strongHand, 300, 10, context)).toBe(310)
+    })
+
+    it('passes when the next bid exceeds my ceiling', () => {
+      const context = baseContext({ everBid: true, bidHistory: [{ player: 1, amount: 300 }] })
+      expect(chooseBid(0, runOnlyHand, 300, 10, context)).toBeNull()
+    })
+
+    it('relaxes the ceiling to at least 330 once my partner has bid', () => {
+      const withoutPartnerBid = baseContext({ everBid: true, bidHistory: [{ player: 1, amount: 320 }] })
+      expect(chooseBid(0, runOnlyHand, 320, 10, withoutPartnerBid)).toBeNull()
+
+      const withPartnerBid = baseContext({
+        everBid: true,
+        bidHistory: [
+          { player: 2, amount: 300 },
+          { player: 1, amount: 320 },
+        ],
+      })
+      expect(chooseBid(0, runOnlyHand, 320, 10, withPartnerBid)).toBe(330)
+    })
   })
 })

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -1,11 +1,16 @@
-// Bid valuation — ported from pinochle_engine.py (frozen Python reference).
+// Bidding — ported from pinochle_engine.py (frozen Python reference).
 //
-// Layered: computeBaseBid (guaranteed + speculative hand value) ->
-// computeCompetitiveAdjustment (score-context) -> the 400-cap /
+// Two layers. Valuation: computeBaseBid (guaranteed + speculative hand
+// value) -> computeCompetitiveAdjustment (score-context) -> the 400-cap /
 // >300-meld-uncap rule (maxBid / cappedBid). bestBaseBid searches all 4
 // trump candidates and applies the cap to find the winning trump + ceiling.
+// Decision: chooseBid/chooseTrump wrap that valuation with the stateful
+// auction rules (dealer protection, 3rd-bidder-opens-cheap, when to raise
+// vs. pass) - ported from Player.choose_bid / Player.choose_trump. This
+// module only decides; it does not run an auction loop (that's a future
+// Round orchestrator, see round.ts's module docstring).
 
-import { type Card, GAME_WIN_SCORE, type Rank, Suit, SUITS } from './card'
+import { type Card, GAME_WIN_SCORE, OPENING_BID, type Rank, Suit, SUITS } from './card'
 import {
   AROUND_DOUBLE_MULTIPLIER,
   AROUND_VALUES,
@@ -19,6 +24,8 @@ import {
   RUN_VALUE,
   scoreMelds,
 } from './melds'
+import { partnerOf, type TeamId, teamOf } from './round'
+import type { PlayerIndex } from './trick'
 
 // -- Base Bid — the hand-strength number bidding decisions are built on.
 // Distinct from scoreMelds: this is a *speculative* valuation (near-run,
@@ -294,4 +301,138 @@ export function bestBaseBid(hand: readonly Card[], myScore = 0, oppScore = 0): B
   }
   // SUITS always has 4 entries, so best is always assigned above.
   return best as BestBidResult
+}
+
+// -- Auction decision wrapper — given the current bid, the minimum legal
+// raise, and the auction's running state, decide whether to open/raise/
+// pass. Sits on top of bestBaseBid/maxBid above: those answer "what's this
+// hand worth," this answers "given what's happened in the auction so far,
+// do I act on that valuation." --------------------------------------------
+
+export interface BidRecord {
+  readonly player: PlayerIndex
+  readonly amount: number
+}
+
+/**
+ * Running state of the current auction, assembled by whatever drives the
+ * bidding loop (see pinochle_engine.py's `Round._bidding_loop` for the
+ * reference shape) and handed to chooseBid on each active player's turn.
+ */
+export interface AuctionContext {
+  /** Has anyone bid yet this auction (as opposed to only passes so far)? */
+  readonly everBid: boolean
+  /** Passes seen so far, before this player's turn. */
+  readonly passesSoFar: number
+  /** Every bid placed this auction, in order. */
+  readonly bidHistory: readonly BidRecord[]
+  readonly dealer: PlayerIndex
+  /** Cumulative game score per team, going into this round. */
+  readonly scores: Record<TeamId, number>
+}
+
+/**
+ * Proficient bidding logic, built on Base Bid plus positional and
+ * score-context rules. Falls back to the old coin-flip placeholder if
+ * called without a context (keeps old call sites/tests working).
+ *
+ * Decision tiers:
+ *   - No one has bid yet this auction:
+ *     1. Dealer-protection: my partner is dealer and my score makes them
+ *        a target for a "pass out and stick them with FORCED_BID" play -
+ *        always open regardless of hand.
+ *     2. 3rd bidder (2 passes already, no one's bid) - always open to
+ *        deny the last player a cheap contract, unless my score is high
+ *        enough (>800) that I'd rather play it safe and only open if my
+ *        ceiling clears OPENER_THRESHOLD.
+ *     3. Otherwise, open only if my ceiling clears OPENER_THRESHOLD.
+ *   - My team currently holds the bid:
+ *     - Partner has already bid twice this auction - back off, they're
+ *       carrying it.
+ *     - Partner just raised over my own earlier bid - match it if my
+ *       ceiling supports at least 340, otherwise back off.
+ *     - Otherwise my own (or partner's) bid already stands - no need to
+ *       raise myself.
+ *   - The opponents currently hold the bid: raise to current + minIncrement
+ *     if that's within my ceiling (relaxed to at least 330 once my partner
+ *     has bid, since a partner bid is a signal worth backing), else pass.
+ */
+export function chooseBid(
+  player: PlayerIndex,
+  hand: readonly Card[],
+  currentBid: number,
+  minIncrement: number,
+  context?: AuctionContext,
+): number | null {
+  if (context === undefined) {
+    return Math.random() < 0.6 ? null : currentBid + minIncrement
+  }
+
+  const myTeam = teamOf(player)
+  const opponentTeam = (1 - myTeam) as TeamId
+  const myScore = context.scores[myTeam]
+  const oppScore = context.scores[opponentTeam]
+
+  const { trump, total: baseBid } = bestBaseBid(hand, myScore, oppScore)
+  const cap = maxBid(hand, trump)
+  const ceiling = cap === null ? baseBid : Math.min(baseBid, cap)
+
+  const partner = partnerOf(player)
+  const partnerIsDealer = partner === context.dealer
+
+  if (!context.everBid) {
+    // Dealer-protection.
+    if (partnerIsDealer && myScore >= 850 && oppScore < 500) {
+      return OPENING_BID
+    }
+
+    // 3rd bidder opens cheap.
+    if (context.passesSoFar === 2) {
+      if (myScore > 800) {
+        return ceiling >= OPENER_THRESHOLD ? OPENING_BID : null
+      }
+      return OPENING_BID
+    }
+
+    // Normal opener threshold.
+    return ceiling >= OPENER_THRESHOLD ? OPENING_BID : null
+  }
+
+  // Someone has already bid this auction.
+  const lastBidder = context.bidHistory[context.bidHistory.length - 1].player
+  const bidIsOurs = teamOf(lastBidder) === myTeam
+
+  if (bidIsOurs) {
+    const partnerBidCount = context.bidHistory.filter((b) => b.player === partner).length
+    const myOwnBids = context.bidHistory.filter((b) => b.player === player).map((b) => b.amount)
+
+    if (partnerBidCount >= 2) return null // partner's carrying it, back off
+
+    if (lastBidder === partner && myOwnBids.length > 0 && currentBid > myOwnBids[myOwnBids.length - 1]) {
+      // partner raised over my own earlier bid
+      return ceiling < 340 ? null : currentBid + minIncrement
+    }
+
+    return null // our own bid already stands, no need to raise ourselves
+  }
+
+  // Opponent currently holds the bid.
+  const partnerHasBid = context.bidHistory.some((b) => b.player === partner)
+  let effectiveCeiling = partnerHasBid ? Math.max(ceiling, 330) : ceiling
+  if (cap !== null) {
+    effectiveCeiling = Math.min(effectiveCeiling, cap)
+  }
+
+  const nextBid = currentBid + minIncrement
+  return nextBid <= effectiveCeiling ? nextBid : null
+}
+
+/**
+ * Uses the same per-suit Base Bid comparison as chooseBid, so trump
+ * selection reflects real speculative hand strength rather than raw card
+ * count.
+ */
+export function chooseTrump(hand: readonly Card[]): Suit {
+  const { trump } = bestBaseBid(hand)
+  return trump
 }

--- a/web/src/engine/round.ts
+++ b/web/src/engine/round.ts
@@ -22,6 +22,11 @@ export function teamOf(player: PlayerIndex): TeamId {
   return (player % 2) as TeamId
 }
 
+/** The other player on the same team, per the fixed seating (0<->2, 1<->3). */
+export function partnerOf(player: PlayerIndex): PlayerIndex {
+  return ((player + 2) % 4) as PlayerIndex
+}
+
 export type Hands = [Card[], Card[], Card[], Card[]]
 
 /**


### PR DESCRIPTION
## Summary

- Ports `Player.choose_bid` (pinochle_engine.py:817-886) and `Player.choose_trump` (888-893) to `web/src/engine/bidding.ts`, as the stateful auction decision wrapper on top of the already-ported valuation math (`bestBaseBid`, `maxBid`, `computeCompetitiveAdjustment`).
- `chooseBid(player, hand, currentBid, minIncrement, context?)` decides open/raise/pass given the running auction state (`everBid`, `passesSoFar`, `bidHistory`, `dealer`, per-team `scores`), including:
  - dealer-protection (always open if my partner is dealer and my score is >=850 with the opponent under 500)
  - 3rd-bidder-opens-cheap (2 passes already, no bid yet - open regardless of hand unless my score is above 800)
  - the normal `OPENER_THRESHOLD` gate
  - backing off once my partner is carrying the bid (2+ bids), matching a partner's raise over my own earlier bid only when the ceiling supports >=340
  - raising over an opponent's bid up to my ceiling, relaxed to at least 330 once my partner has also bid
  - falls back to the old coin-flip placeholder when called without a `context`, same pattern as `choosePassCards`'s fallback
- `chooseTrump(hand)` wraps `bestBaseBid` the same way `Player.choose_trump` does.
- Adds `partnerOf` to `round.ts` (the natural counterpart to `teamOf`, using the same fixed 0<->2 / 1<->3 seating) since the decision logic needs to identify a player's teammate from a `PlayerIndex`.
- Out of scope per the issue: wiring this into a live auction loop / UI - that's #20/#34.

## Test plan

- [x] `npm test` - 106/106 passing (34 new tests in `bidding.test.ts` covering every branch: fallback coin-flip, opener threshold, dealer-protection, 3rd-bidder-opens-cheap, my-team-holds-the-bid back-off/raise gating, and opponent-holds-the-bid raise/relaxed-ceiling)
- [x] `npm run build` - TypeScript compiles cleanly, Vite build succeeds
- [x] `npm run lint` - oxlint clean

Closes #29