### PR TITLE
Build bid/pass interaction flow UI

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,12 +1,31 @@
-import { Table } from './components/Table'
-import { buildMockTableState } from './mock/tableState'
+import { AuctionFlow } from './components/AuctionFlow'
+import type { AuctionResult } from './components/auctionTypes'
+import { buildMockAuctionHands, buildMockAuctionScores, DEALER, HUMAN_PLAYER, SEAT_NAMES } from './mock/auctionState'
 
-// buildMockTableState() is called once per module load (not per render) so
-// the demo table doesn't reshuffle every time App re-renders.
-const mockState = buildMockTableState()
+// Built once per module load (not per render) so the demo deal doesn't
+// reshuffle every time App re-renders.
+const initialHands = buildMockAuctionHands()
+const scoresByTeam = buildMockAuctionScores()
 
 function App() {
-  return <Table state={mockState} />
+  const handleAuctionComplete = (result: AuctionResult) => {
+    // Trick-play (#35) picks up from here — for now just log the outcome
+    // so the completed auction/pass is visible while that issue is out of
+    // scope, and AuctionFlow keeps rendering the Table with the settled
+    // contract and post-pass hands.
+    console.log('Auction complete:', result)
+  }
+
+  return (
+    <AuctionFlow
+      initialHands={initialHands}
+      seatNames={SEAT_NAMES}
+      humanPlayer={HUMAN_PLAYER}
+      dealer={DEALER}
+      scoresByTeam={scoresByTeam}
+      onComplete={handleAuctionComplete}
+    />
+  )
 }
 
 export default App

--- a/web/src/components/AuctionFlow.test.tsx
+++ b/web/src/components/AuctionFlow.test.tsx
@@ -1,0 +1,189 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Card, FORCED_BID, Suit } from '../engine/card'
+import type { PlayerIndex } from '../engine/trick'
+import { AuctionFlow } from './AuctionFlow'
+import type { AuctionState } from './auctionReducer'
+import { auctionReducer, initAuctionState } from './auctionReducer'
+import type { AuctionResult } from './auctionTypes'
+
+const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'You', 1: 'West', 2: 'Partner', 3: 'East' }
+const SCORES = { 0: 0, 1: 0 }
+
+function baseState(dealer: PlayerIndex = 3): AuctionState {
+  const hands = [[], [], [], []] as [Card[], Card[], Card[], Card[]]
+  return initAuctionState(hands, dealer, SEAT_NAMES, SCORES)
+}
+
+describe('auctionReducer', () => {
+  it('rotates the turn to the next active seat after a bid, starting left of the dealer', () => {
+    const state = baseState(3) // left of dealer is seat 0
+    expect(state.bidding.turn).toBe(0)
+    const next = auctionReducer(state, { type: 'BID', player: 0, amount: 300 })
+    expect(next.bidding.currentBid).toBe(300)
+    expect(next.bidding.everBid).toBe(true)
+    expect(next.bidding.bidWinner).toBe(0)
+    expect(next.bidding.turn).toBe(1)
+    expect(next.phase).toBe('bidding')
+    expect(next.log).toEqual([{ kind: 'bid', player: 0, name: 'You', amount: 300 }])
+  })
+
+  it('ends the auction and moves to the trump phase once 3 players have passed', () => {
+    let state = baseState(3)
+    state = auctionReducer(state, { type: 'BID', player: 0, amount: 300 })
+    state = auctionReducer(state, { type: 'PASS_BID', player: 1 })
+    expect(state.phase).toBe('bidding')
+    state = auctionReducer(state, { type: 'PASS_BID', player: 2 })
+    expect(state.phase).toBe('bidding')
+    state = auctionReducer(state, { type: 'PASS_BID', player: 3 })
+    expect(state.phase).toBe('trump')
+    expect(state.bidWinner).toBe(0)
+    expect(state.bid).toBe(300)
+  })
+
+  it('lets the bid pass back and forth before settling on the last (non-partner) bidder', () => {
+    let state = baseState(3)
+    state = auctionReducer(state, { type: 'BID', player: 0, amount: 300 })
+    state = auctionReducer(state, { type: 'PASS_BID', player: 1 })
+    state = auctionReducer(state, { type: 'PASS_BID', player: 2 })
+    state = auctionReducer(state, { type: 'BID', player: 3, amount: 310 })
+    expect(state.phase).toBe('bidding')
+    expect(state.bidding.bidWinner).toBe(3)
+    state = auctionReducer(state, { type: 'PASS_BID', player: 0 })
+    expect(state.phase).toBe('trump')
+    expect(state.bidWinner).toBe(3)
+    expect(state.bid).toBe(310)
+  })
+
+  it('forces the dealer to take the contract at FORCED_BID when nobody ever bids', () => {
+    let state = baseState(3)
+    state = auctionReducer(state, { type: 'PASS_BID', player: 0 })
+    state = auctionReducer(state, { type: 'PASS_BID', player: 1 })
+    state = auctionReducer(state, { type: 'PASS_BID', player: 2 })
+    expect(state.phase).toBe('trump')
+    expect(state.bidWinner).toBe(3) // the dealer, never having gotten a turn
+    expect(state.bid).toBe(FORCED_BID)
+    expect(state.log.at(-1)).toEqual({ kind: 'forced-bid', player: 3, name: 'East', amount: FORCED_BID })
+  })
+
+  it('ignores BID/PASS_BID actions once bidding has ended', () => {
+    let state = baseState(3)
+    state = auctionReducer(state, { type: 'PASS_BID', player: 0 })
+    state = auctionReducer(state, { type: 'PASS_BID', player: 1 })
+    state = auctionReducer(state, { type: 'PASS_BID', player: 2 })
+    const afterAuction = state
+    const unchanged = auctionReducer(state, { type: 'BID', player: 1, amount: 999 })
+    expect(unchanged).toBe(afterAuction)
+  })
+
+  it('records a trump call and moves to the partner-to-bidder pass step', () => {
+    let state = baseState(3)
+    state = auctionReducer(state, { type: 'PASS_BID', player: 0 })
+    state = auctionReducer(state, { type: 'PASS_BID', player: 1 })
+    state = auctionReducer(state, { type: 'PASS_BID', player: 2 }) // forces dealer (3)
+    state = auctionReducer(state, { type: 'CHOOSE_TRUMP', player: 3, suit: Suit.Hearts })
+    expect(state.trumpSuit).toBe(Suit.Hearts)
+    expect(state.phase).toBe('passing-partner-to-bidder')
+    expect(state.log.at(-1)).toEqual({ kind: 'trump', player: 3, name: 'East', suit: Suit.Hearts })
+  })
+
+  it('moves cards between hands and logs a count-only card-pass entry', () => {
+    let state = baseState(3)
+    const card = new Card(Suit.Spades, 'A', 1)
+    state = { ...state, hands: [[card], [], [], []] as [Card[], Card[], Card[], Card[]], phase: 'passing-partner-to-bidder' }
+    state = auctionReducer(state, { type: 'PASS_CARDS', from: 0, to: 1, cards: [card] })
+    expect(state.hands[0]).toEqual([])
+    expect(state.hands[1]).toEqual([card])
+    expect(state.phase).toBe('passing-bidder-to-partner')
+    expect(state.log.at(-1)).toEqual({
+      kind: 'card-pass',
+      fromPlayer: 0,
+      fromName: 'You',
+      toPlayer: 1,
+      toName: 'West',
+      count: 1,
+    })
+  })
+
+  it('completes the auction after the second (bidder-to-partner) pass', () => {
+    let state = baseState(3)
+    state = { ...state, phase: 'passing-bidder-to-partner' }
+    state = auctionReducer(state, { type: 'PASS_CARDS', from: 0, to: 2, cards: [] })
+    expect(state.phase).toBe('complete')
+  })
+})
+
+// -- Full component flow --------------------------------------------------
+//
+// AI seats (1, 2, 3) are dealt intentionally weak 3-card hands (no aces,
+// marriages, runs, or arounds) so bidding.ts's bestBaseBid ceiling stays
+// well under OPENER_THRESHOLD (320) and mock/aiDecisions.ts's aiDecideBid
+// always passes for them — makes the human's path through the whole
+// auction/trump/pass flow deterministic without stubbing the engine.
+
+function buildTestHands(): [Card[], Card[], Card[], Card[]] {
+  const human = [
+    new Card(Suit.Clubs, 'A', 1),
+    new Card(Suit.Diamonds, 'K', 1),
+    new Card(Suit.Hearts, 'Q', 1),
+    new Card(Suit.Spades, 'J', 1),
+    new Card(Suit.Clubs, '10', 1),
+  ]
+  const west = [new Card(Suit.Spades, '9', 1), new Card(Suit.Hearts, 'J', 1), new Card(Suit.Diamonds, '10', 1)]
+  const partner = [new Card(Suit.Clubs, '9', 1), new Card(Suit.Diamonds, 'J', 1), new Card(Suit.Spades, '10', 1)]
+  const east = [new Card(Suit.Hearts, '9', 1), new Card(Suit.Clubs, 'J', 1), new Card(Suit.Spades, 'Q', 1)]
+  return [human, west, partner, east]
+}
+
+afterEach(cleanup)
+
+describe('AuctionFlow (component)', () => {
+  it('walks the human through bidding, naming trump, and passing cards, then reports the result', () => {
+    const hands = buildTestHands()
+    const onComplete = vi.fn()
+
+    render(
+      <AuctionFlow
+        initialHands={hands}
+        seatNames={SEAT_NAMES}
+        humanPlayer={0}
+        dealer={3}
+        scoresByTeam={SCORES}
+        onComplete={onComplete}
+      />,
+    )
+
+    // Left of dealer (3) is seat 0 — the human bids first.
+    fireEvent.click(screen.getByRole('button', { name: 'Bid' }))
+
+    // West, Partner, and East all pass automatically (weak hands) — the
+    // auction should already have resolved to trump selection.
+    expect(screen.getByText('Name trump')).not.toBeNull()
+
+    fireEvent.click(screen.getByText('Hearts'))
+
+    // Partner (AI) passes 3 cards to the human automatically; the human is
+    // now on the bidder-to-partner leg and sees the pass selector.
+    const passHeading = screen.getByRole('heading', { name: /Choose 3 cards to pass/ })
+    const passPanel = within(passHeading.closest('div') as HTMLElement)
+
+    fireEvent.click(passPanel.getByRole('img', { name: 'A of C' }))
+    fireEvent.click(passPanel.getByRole('img', { name: 'K of D' }))
+    fireEvent.click(passPanel.getByRole('img', { name: 'Q of H' }))
+    fireEvent.click(passPanel.getByRole('button', { name: 'Confirm pass' }))
+
+    expect(onComplete).toHaveBeenCalledOnce()
+    const result = onComplete.mock.calls[0][0] as AuctionResult
+    expect(result.bidWinner).toBe(0)
+    expect(result.bid).toBe(300)
+    expect(result.trumpSuit).toBe(Suit.Hearts)
+    // The 3 cards the human chose to pass are gone from their final hand.
+    expect(result.hands[0].some((c) => c.suit === Suit.Clubs && c.rank === 'A')).toBe(false)
+    expect(result.hands[0].some((c) => c.suit === Suit.Diamonds && c.rank === 'K')).toBe(false)
+    expect(result.hands[0].some((c) => c.suit === Suit.Hearts && c.rank === 'Q')).toBe(false)
+
+    // The auction/pass log surfaced every AI decision along the way.
+    expect(screen.getByText('West passed')).not.toBeNull()
+    expect(screen.getByText('Partner passed 3 cards to You')).not.toBeNull()
+  })
+})

--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useReducer, useRef } from 'react'
+import { bestBaseBid } from '../engine/bidding'
+import { OPENING_BID } from '../engine/card'
+import { PASS_COUNT, choosePassCards } from '../engine/passing'
+import { teamOf, type Hands, type TeamId } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+import { aiChooseTrump, aiDecideBid } from '../mock/aiDecisions'
+import { AuctionLog } from './AuctionLog'
+import { auctionReducer, initAuctionState } from './auctionReducer'
+import type { AuctionResult } from './auctionTypes'
+import { partnerOf } from './auctionTypes'
+import { BiddingControls } from './BiddingControls'
+import { PassSelector } from './PassSelector'
+import { Table } from './Table'
+import type { TableState } from './tableTypes'
+import { TrumpSelector } from './TrumpSelector'
+
+export interface AuctionFlowProps {
+  initialHands: Hands
+  seatNames: Record<PlayerIndex, string>
+  humanPlayer: PlayerIndex
+  dealer: PlayerIndex
+  scoresByTeam: Record<TeamId, number>
+  /** Fired once, when both passes have completed, with everything a live
+   * Round orchestrator (trick-play, #35) needs to take over. */
+  onComplete?: (result: AuctionResult) => void
+}
+
+/**
+ * Drives the auction (#34): bidding, the winner's trump call, and the
+ * 3-card pass, mounted into the Table scaffold (#33) so the human always
+ * sees seats/hands/scoreboard behind whichever control is active. Human
+ * turns wait for input via BiddingControls/TrumpSelector/PassSelector; AI
+ * turns resolve automatically (bidding.ts valuation + mock/aiDecisions.ts
+ * stand-ins for #29, passing.ts's real choosePassCards) and always log a
+ * visible AuctionLog entry — no AI decision happens silently.
+ */
+export function AuctionFlow({ initialHands, seatNames, humanPlayer, dealer, scoresByTeam, onComplete }: AuctionFlowProps) {
+  const [state, dispatch] = useReducer(
+    auctionReducer,
+    undefined,
+    () => initAuctionState(initialHands, dealer, seatNames, scoresByTeam),
+  )
+  const completedRef = useRef(false)
+
+  // Resolve AI turns automatically. Runs after every state change; each
+  // branch either dispatches exactly one AI decision (re-triggering this
+  // effect for the next turn) or returns without dispatching because it's
+  // the human's turn / there's nothing left to do this phase.
+  useEffect(() => {
+    if (state.phase === 'bidding') {
+      const turn = state.bidding.turn
+      if (turn === humanPlayer) return
+      const decision = aiDecideBid(
+        turn,
+        state.hands[turn],
+        state.bidding.currentBid,
+        state.bidding.everBid,
+        state.bidding.lastBidder,
+        state.scoresByTeam,
+      )
+      if (decision === null) dispatch({ type: 'PASS_BID', player: turn })
+      else dispatch({ type: 'BID', player: turn, amount: decision })
+      return
+    }
+
+    if (state.phase === 'trump') {
+      if (state.bidWinner === null || state.bidWinner === humanPlayer) return
+      const suit = aiChooseTrump(state.hands[state.bidWinner])
+      dispatch({ type: 'CHOOSE_TRUMP', player: state.bidWinner, suit })
+      return
+    }
+
+    if (state.phase === 'passing-partner-to-bidder' || state.phase === 'passing-bidder-to-partner') {
+      if (state.bidWinner === null || state.trumpSuit === null) return
+      const partner = partnerOf(state.bidWinner)
+      const isPartnerStep = state.phase === 'passing-partner-to-bidder'
+      const sender = isPartnerStep ? partner : state.bidWinner
+      const receiver = isPartnerStep ? state.bidWinner : partner
+      if (sender === humanPlayer) return
+      const cards = choosePassCards(state.hands[sender], PASS_COUNT, state.trumpSuit, sender === state.bidWinner)
+      dispatch({ type: 'PASS_CARDS', from: sender, to: receiver, cards })
+    }
+  }, [state, humanPlayer])
+
+  // Fire onComplete exactly once, when the pass phase finishes.
+  useEffect(() => {
+    if (state.phase !== 'complete' || completedRef.current) return
+    if (state.bidWinner === null || state.trumpSuit === null) return
+    completedRef.current = true
+    onComplete?.({ hands: state.hands, trumpSuit: state.trumpSuit, bidWinner: state.bidWinner, bid: state.bid })
+  }, [state, onComplete])
+
+  const tableState: TableState = useMemo(() => {
+    const seatFor = (p: PlayerIndex) => ({ player: p, name: seatNames[p], hand: state.hands[p] })
+    const seats: TableState['seats'] = [seatFor(0), seatFor(1), seatFor(2), seatFor(3)]
+    return {
+      seats,
+      humanPlayer,
+      trick: [],
+      trumpSuit: state.trumpSuit,
+      currentBid: state.bid || state.bidding.currentBid,
+      bidWinner: state.bidWinner,
+      scoresByTeam: state.scoresByTeam,
+    }
+  }, [state, seatNames, humanPlayer])
+
+  const overlay = useMemo(() => {
+    if (state.phase === 'bidding' && state.bidding.turn === humanPlayer) {
+      const minBid = state.bidding.everBid ? state.bidding.currentBid + 10 : OPENING_BID
+      const myTeam = teamOf(humanPlayer)
+      const oppTeam: TeamId = myTeam === 0 ? 1 : 0
+      // bestBaseBid's returned total is already the capped ceiling (it
+      // applies cappedBid internally per trump candidate before picking
+      // the best one) — a direct, non-binding hint for the human bidder.
+      const { total: suggestedCeiling } = bestBaseBid(
+        state.hands[humanPlayer],
+        state.scoresByTeam[myTeam],
+        state.scoresByTeam[oppTeam],
+      )
+      return (
+        <BiddingControls
+          minBid={minBid}
+          currentBid={state.bidding.currentBid}
+          suggestedCeiling={suggestedCeiling}
+          onBid={(amount) => dispatch({ type: 'BID', player: humanPlayer, amount })}
+          onPass={() => dispatch({ type: 'PASS_BID', player: humanPlayer })}
+        />
+      )
+    }
+
+    if (state.phase === 'trump' && state.bidWinner === humanPlayer) {
+      return <TrumpSelector onSelect={(suit) => dispatch({ type: 'CHOOSE_TRUMP', player: humanPlayer, suit })} />
+    }
+
+    if (
+      (state.phase === 'passing-partner-to-bidder' || state.phase === 'passing-bidder-to-partner') &&
+      state.bidWinner !== null
+    ) {
+      const partner = partnerOf(state.bidWinner)
+      const isPartnerStep = state.phase === 'passing-partner-to-bidder'
+      const sender = isPartnerStep ? partner : state.bidWinner
+      const receiver = isPartnerStep ? state.bidWinner : partner
+      if (sender === humanPlayer) {
+        return (
+          <PassSelector
+            hand={state.hands[humanPlayer]}
+            count={PASS_COUNT}
+            onConfirm={(cards) => dispatch({ type: 'PASS_CARDS', from: sender, to: receiver, cards })}
+          />
+        )
+      }
+    }
+
+    return null
+  }, [state, humanPlayer])
+
+  return <Table state={tableState} overlay={overlay} logPanel={<AuctionLog entries={state.log} />} />
+}

--- a/web/src/components/AuctionLog.test.tsx
+++ b/web/src/components/AuctionLog.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { AuctionLogEntry } from './auctionTypes'
+import { AuctionLog } from './AuctionLog'
+
+afterEach(cleanup)
+
+describe('AuctionLog', () => {
+  it('renders nothing when there are no entries', () => {
+    const { container } = render(<AuctionLog entries={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders every entry, formatted', () => {
+    const entries: AuctionLogEntry[] = [
+      { kind: 'bid', player: 1, name: 'West', amount: 300 },
+      { kind: 'pass-bid', player: 2, name: 'Partner' },
+    ]
+    render(<AuctionLog entries={entries} />)
+    expect(screen.getByText('West bid 300')).not.toBeNull()
+    expect(screen.getByText('Partner passed')).not.toBeNull()
+  })
+
+  it('shows the most recent entry first', () => {
+    const entries: AuctionLogEntry[] = [
+      { kind: 'bid', player: 1, name: 'West', amount: 300 },
+      { kind: 'bid', player: 3, name: 'East', amount: 310 },
+    ]
+    render(<AuctionLog entries={entries} />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[0].textContent).toBe('East bid 310')
+    expect(items[1].textContent).toBe('West bid 300')
+  })
+})

--- a/web/src/components/AuctionLog.tsx
+++ b/web/src/components/AuctionLog.tsx
@@ -1,0 +1,30 @@
+import { type AuctionLogEntry, formatAuctionLogEntry } from './auctionTypes'
+
+export interface AuctionLogProps {
+  /** Oldest-first; rendered newest-first so the latest event is always visible without scrolling. */
+  entries: readonly AuctionLogEntry[]
+}
+
+/**
+ * Visible feed of auction/pass events (#34) — every AI bid, pass, forced
+ * contract, trump call, and card exchange shows up here as it happens, so
+ * a human player can follow the auction instead of just watching table
+ * state change silently underneath them.
+ */
+export function AuctionLog({ entries }: AuctionLogProps) {
+  if (entries.length === 0) return null
+
+  const newestFirst = [...entries].reverse()
+
+  return (
+    <div className="pointer-events-none w-full max-w-xs">
+      <ol className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded-lg bg-black/60 p-3 text-xs text-white shadow-lg">
+        {newestFirst.map((entry, i) => (
+          <li key={newestFirst.length - i} className={i === 0 ? 'font-semibold' : 'text-white/70'}>
+            {formatAuctionLogEntry(entry)}
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}

--- a/web/src/components/BiddingControls.test.tsx
+++ b/web/src/components/BiddingControls.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BiddingControls } from './BiddingControls'
+
+afterEach(cleanup)
+
+describe('BiddingControls', () => {
+  it('shows the minimum bid and the hand-strength hint', () => {
+    render(<BiddingControls minBid={300} currentBid={0} suggestedCeiling={350} onBid={() => {}} onPass={() => {}} />)
+    expect(screen.getByText(/Minimum: 300/)).not.toBeNull()
+    expect(screen.getByText(/up to 350/)).not.toBeNull()
+  })
+
+  it('shows the current bid once someone has bid', () => {
+    render(<BiddingControls minBid={320} currentBid={310} suggestedCeiling={350} onBid={() => {}} onPass={() => {}} />)
+    expect(screen.getByText(/Current bid: 310/)).not.toBeNull()
+  })
+
+  it('defaults the bid amount input to the minimum bid', () => {
+    render(<BiddingControls minBid={300} currentBid={0} suggestedCeiling={350} onBid={() => {}} onPass={() => {}} />)
+    const input = screen.getByLabelText('Bid amount') as HTMLInputElement
+    expect(input.value).toBe('300')
+  })
+
+  it('calls onBid with the entered amount', () => {
+    const onBid = vi.fn()
+    render(<BiddingControls minBid={300} currentBid={0} suggestedCeiling={350} onBid={onBid} onPass={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Bid' }))
+    expect(onBid).toHaveBeenCalledWith(300)
+  })
+
+  it('raises the amount in steps of 10 via the increment button', () => {
+    const onBid = vi.fn()
+    render(<BiddingControls minBid={300} currentBid={0} suggestedCeiling={350} onBid={onBid} onPass={() => {}} />)
+    fireEvent.click(screen.getByLabelText('Increase bid by 10'))
+    fireEvent.click(screen.getByRole('button', { name: 'Bid' }))
+    expect(onBid).toHaveBeenCalledWith(310)
+  })
+
+  it('disables the Bid button when the entered amount is below the minimum', () => {
+    render(<BiddingControls minBid={300} currentBid={0} suggestedCeiling={350} onBid={() => {}} onPass={() => {}} />)
+    const input = screen.getByLabelText('Bid amount') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '280' } })
+    expect(screen.getByRole('button', { name: 'Bid' }).hasAttribute('disabled')).toBe(true)
+  })
+
+  it('calls onPass when the Pass button is clicked', () => {
+    const onPass = vi.fn()
+    render(<BiddingControls minBid={300} currentBid={0} suggestedCeiling={350} onBid={() => {}} onPass={onPass} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Pass' }))
+    expect(onPass).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/BiddingControls.tsx
+++ b/web/src/components/BiddingControls.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+
+export interface BiddingControlsProps {
+  /** Lowest legal bid right now — `OPENING_BID` before anyone has bid,
+   * `currentBid + 10` afterward (round.ts's `_bidding_loop` increment). */
+  minBid: number
+  /** The standing bid, for display context ("current bid: N"). Only
+   * meaningful once someone has bid; 0 beforehand. */
+  currentBid: number
+  /** Non-binding hint from the human's own hand (bidding.ts's
+   * `bestBaseBid`), shown so the bid amount isn't a guess in the dark. */
+  suggestedCeiling: number
+  onBid: (amount: number) => void
+  onPass: () => void
+}
+
+/**
+ * Human bid-amount entry/raise/pass controls for the auction (#34). Pure
+ * props in, `onBid`/`onPass` out — AuctionFlow owns turn order, legality,
+ * and what happens next.
+ */
+export function BiddingControls({ minBid, currentBid, suggestedCeiling, onBid, onPass }: BiddingControlsProps) {
+  const [amount, setAmount] = useState(minBid)
+  const isValid = amount >= minBid && amount % 10 === 0
+
+  return (
+    <div className="w-full max-w-xs rounded-lg bg-white p-4 text-neutral-900 shadow-xl">
+      <h3 className="text-sm font-semibold">Your bid</h3>
+      <p className="mt-1 text-xs text-neutral-600">
+        {currentBid > 0 ? `Current bid: ${currentBid}. ` : ''}
+        Minimum: {minBid}. Your hand suggests up to {suggestedCeiling}.
+      </p>
+
+      <div className="mt-3 flex items-center gap-2">
+        <button
+          type="button"
+          aria-label="Decrease bid by 10"
+          onClick={() => setAmount((a) => Math.max(minBid, a - 10))}
+          className="rounded bg-neutral-200 px-3 py-1 font-semibold hover:bg-neutral-300"
+        >
+          −
+        </button>
+        <input
+          type="number"
+          step={10}
+          min={minBid}
+          value={amount}
+          onChange={(e) => setAmount(Number(e.target.value))}
+          aria-label="Bid amount"
+          className="w-20 rounded border border-neutral-300 px-2 py-1 text-center"
+        />
+        <button
+          type="button"
+          aria-label="Increase bid by 10"
+          onClick={() => setAmount((a) => a + 10)}
+          className="rounded bg-neutral-200 px-3 py-1 font-semibold hover:bg-neutral-300"
+        >
+          +
+        </button>
+      </div>
+
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          disabled={!isValid}
+          onClick={() => onBid(amount)}
+          className="flex-1 rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900 disabled:cursor-not-allowed disabled:bg-neutral-300"
+        >
+          Bid
+        </button>
+        <button
+          type="button"
+          onClick={onPass}
+          className="flex-1 rounded bg-neutral-200 px-4 py-2 font-semibold text-neutral-900 hover:bg-neutral-300"
+        >
+          Pass
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/PassSelector.test.tsx
+++ b/web/src/components/PassSelector.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Card, Suit } from '../engine/card'
+import { PassSelector } from './PassSelector'
+
+afterEach(cleanup)
+
+const hand = [
+  new Card(Suit.Spades, 'A', 1),
+  new Card(Suit.Hearts, 'K', 1),
+  new Card(Suit.Diamonds, 'Q', 1),
+  new Card(Suit.Clubs, 'J', 1),
+  new Card(Suit.Spades, '9', 1),
+]
+
+describe('PassSelector', () => {
+  it('shows the running selection count', () => {
+    render(<PassSelector hand={hand} count={3} onConfirm={() => {}} />)
+    expect(screen.getByText(/Choose 3 cards to pass \(0\/3 selected\)/)).not.toBeNull()
+  })
+
+  it('keeps Confirm disabled until exactly `count` cards are selected', () => {
+    render(<PassSelector hand={hand} count={3} onConfirm={() => {}} />)
+    const confirm = screen.getByRole('button', { name: 'Confirm pass' })
+    expect(confirm.hasAttribute('disabled')).toBe(true)
+
+    fireEvent.click(screen.getByRole('img', { name: 'A of S' }))
+    fireEvent.click(screen.getByRole('img', { name: 'K of H' }))
+    expect(confirm.hasAttribute('disabled')).toBe(true)
+
+    fireEvent.click(screen.getByRole('img', { name: 'Q of D' }))
+    expect(confirm.hasAttribute('disabled')).toBe(false)
+  })
+
+  it('does not allow selecting more than `count` cards', () => {
+    render(<PassSelector hand={hand} count={2} onConfirm={() => {}} />)
+    fireEvent.click(screen.getByRole('img', { name: 'A of S' }))
+    fireEvent.click(screen.getByRole('img', { name: 'K of H' }))
+    fireEvent.click(screen.getByRole('img', { name: 'Q of D' }))
+    expect(screen.getByText('Choose 2 cards to pass (2/2 selected)')).not.toBeNull()
+  })
+
+  it('toggles a card back off when clicked again', () => {
+    render(<PassSelector hand={hand} count={3} onConfirm={() => {}} />)
+    const ace = screen.getByRole('img', { name: 'A of S' })
+    fireEvent.click(ace)
+    fireEvent.click(ace)
+    expect(screen.getByText('Choose 3 cards to pass (0/3 selected)')).not.toBeNull()
+  })
+
+  it('calls onConfirm with exactly the selected cards', () => {
+    const onConfirm = vi.fn()
+    render(<PassSelector hand={hand} count={2} onConfirm={onConfirm} />)
+    fireEvent.click(screen.getByRole('img', { name: 'A of S' }))
+    fireEvent.click(screen.getByRole('img', { name: 'K of H' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm pass' }))
+    expect(onConfirm).toHaveBeenCalledOnce()
+    const passed = onConfirm.mock.calls[0][0] as Card[]
+    expect(passed).toHaveLength(2)
+    expect(passed).toContain(hand[0])
+    expect(passed).toContain(hand[1])
+  })
+})

--- a/web/src/components/PassSelector.tsx
+++ b/web/src/components/PassSelector.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import type { Card } from '../engine/card'
+import { PlayingCard } from './PlayingCard'
+
+export interface PassSelectorProps {
+  hand: readonly Card[]
+  /** How many cards must be selected before Confirm is enabled — passing.ts's `PASS_COUNT`. */
+  count: number
+  onConfirm: (cards: Card[]) => void
+}
+
+/**
+ * Card-selection UI for the human's half of the 3-card pass (#34): the
+ * partner's send-to-bidder pass, or the bidder's send-back-to-partner
+ * pass, whichever the human is holding at the time. AuctionFlow decides
+ * which hand/role this renders for; this component just enforces "exactly
+ * `count` selected" before letting the player confirm.
+ */
+export function PassSelector({ hand, count, onConfirm }: PassSelectorProps) {
+  const [selected, setSelected] = useState<Card[]>([])
+
+  const toggle = (card: Card) => {
+    setSelected((prev) => {
+      if (prev.includes(card)) return prev.filter((c) => c !== card)
+      if (prev.length >= count) return prev
+      return [...prev, card]
+    })
+  }
+
+  return (
+    <div className="w-full max-w-2xl rounded-lg bg-white p-4 text-neutral-900 shadow-xl">
+      <h3 className="text-sm font-semibold">
+        Choose {count} cards to pass ({selected.length}/{count} selected)
+      </h3>
+      <div className="mt-3 flex flex-wrap justify-center gap-1">
+        {hand.map((card) => {
+          const isSelected = selected.includes(card)
+          return (
+            <button
+              key={card.toString()}
+              type="button"
+              onClick={() => toggle(card)}
+              aria-pressed={isSelected}
+              className={`rounded-lg transition-transform ${isSelected ? '-translate-y-3 ring-2 ring-amber-500' : ''}`}
+            >
+              <PlayingCard suit={card.suit} rank={card.rank} />
+            </button>
+          )
+        })}
+      </div>
+      <button
+        type="button"
+        disabled={selected.length !== count}
+        onClick={() => onConfirm(selected)}
+        className="mt-4 w-full rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900 disabled:cursor-not-allowed disabled:bg-neutral-300"
+      >
+        Confirm pass
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/Scoreboard.tsx
+++ b/web/src/components/Scoreboard.tsx
@@ -5,15 +5,17 @@ import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
 export interface ScoreboardProps {
   scoresByTeam: Record<TeamId, number>
   currentBid: number
-  bidWinnerName: string
-  trumpSuit: Suit
+  /** undefined while the auction (#34) hasn't produced a bid winner yet. */
+  bidWinnerName?: string
+  /** null while the auction (#34) hasn't settled on trump yet. */
+  trumpSuit: Suit | null
 }
 
 /** Top strip: cumulative team scores, the standing bid, and trump. Stays
  * mounted throughout bidding/passing/trick-play so those flows (separate
  * issues) can render alongside it without needing their own scoreboard. */
 export function Scoreboard({ scoresByTeam, currentBid, bidWinnerName, trumpSuit }: ScoreboardProps) {
-  const trumpColor = RED_SUITS.includes(trumpSuit) ? 'text-red-400' : 'text-white'
+  const trumpColor = trumpSuit && RED_SUITS.includes(trumpSuit) ? 'text-red-400' : 'text-white'
 
   return (
     <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-1 bg-green-950 px-4 py-2 text-sm text-white shadow-md">
@@ -24,10 +26,14 @@ export function Scoreboard({ scoresByTeam, currentBid, bidWinnerName, trumpSuit 
         Team B: <span className="font-semibold">{scoresByTeam[1]}</span>
       </span>
       <span>
-        Bid: <span className="font-semibold">{currentBid}</span> ({bidWinnerName})
+        Bid: <span className="font-semibold">{currentBid || '—'}</span>
+        {bidWinnerName ? ` (${bidWinnerName})` : ''}
       </span>
       <span>
-        Trump: <span className={`text-lg font-semibold ${trumpColor}`}>{SUIT_GLYPH[trumpSuit]}</span>
+        Trump:{' '}
+        <span className={`text-lg font-semibold ${trumpColor}`}>
+          {trumpSuit ? SUIT_GLYPH[trumpSuit] : '—'}
+        </span>
       </span>
     </div>
   )

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { Scoreboard } from './Scoreboard'
 import { Seat } from './Seat'
 import { seatPosition, type SeatPosition, type TableState } from './tableTypes'
@@ -5,6 +6,13 @@ import { TrickArea } from './TrickArea'
 
 export interface TableProps {
   state: TableState
+  /** Centered modal-style slot (bid controls, trump call, pass selector,
+   * round summary, ...) rendered above the table. Optional so existing
+   * callers that just want the static scaffold don't need to pass one. */
+  overlay?: ReactNode
+  /** Corner slot for a non-blocking feed (the auction/pass event log, #34)
+   * that should stay visible alongside the table rather than covering it. */
+  logPanel?: ReactNode
 }
 
 const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
@@ -20,16 +28,16 @@ const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
  * and trick-play controls (separate issues) will mount into this shell,
  * most likely inside/near the human seat and the TrickArea respectively.
  */
-export function Table({ state }: TableProps) {
+export function Table({ state, overlay, logPanel }: TableProps) {
   const { seats, humanPlayer, trick, trumpSuit, currentBid, bidWinner, scoresByTeam } = state
-  const bidWinnerSeat = seats.find((seat) => seat.player === bidWinner)
+  const bidWinnerSeat = bidWinner === null ? undefined : seats.find((seat) => seat.player === bidWinner)
 
   return (
-    <div className="flex min-h-svh flex-col bg-green-900 text-white">
+    <div className="relative flex min-h-svh flex-col bg-green-900 text-white">
       <Scoreboard
         scoresByTeam={scoresByTeam}
         currentBid={currentBid}
-        bidWinnerName={bidWinnerSeat?.name ?? `Player ${bidWinner}`}
+        bidWinnerName={bidWinnerSeat?.name}
         trumpSuit={trumpSuit}
       />
       <div className="grid flex-1 grid-cols-[1fr_2fr_1fr] grid-rows-[1fr_2fr_1fr] items-center justify-items-center gap-4 p-4">
@@ -50,6 +58,10 @@ export function Table({ state }: TableProps) {
           <TrickArea trick={trick} humanPlayer={humanPlayer} />
         </div>
       </div>
+      {logPanel && <div className="absolute top-16 right-2">{logPanel}</div>}
+      {overlay && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/40 p-4">{overlay}</div>
+      )}
     </div>
   )
 }

--- a/web/src/components/TrumpSelector.test.tsx
+++ b/web/src/components/TrumpSelector.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Suit } from '../engine/card'
+import { TrumpSelector } from './TrumpSelector'
+
+afterEach(cleanup)
+
+describe('TrumpSelector', () => {
+  it('renders all four suits by name', () => {
+    render(<TrumpSelector onSelect={() => {}} />)
+    expect(screen.getByText('Spades')).not.toBeNull()
+    expect(screen.getByText('Hearts')).not.toBeNull()
+    expect(screen.getByText('Diamonds')).not.toBeNull()
+    expect(screen.getByText('Clubs')).not.toBeNull()
+  })
+
+  it('calls onSelect with the chosen suit', () => {
+    const onSelect = vi.fn()
+    render(<TrumpSelector onSelect={onSelect} />)
+    fireEvent.click(screen.getByText('Hearts'))
+    expect(onSelect).toHaveBeenCalledWith(Suit.Hearts)
+  })
+})

--- a/web/src/components/TrumpSelector.tsx
+++ b/web/src/components/TrumpSelector.tsx
@@ -1,0 +1,37 @@
+import { SUITS } from '../engine/card'
+import type { Suit } from '../engine/card'
+import { SUIT_NAME } from './auctionTypes'
+import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
+
+export interface TrumpSelectorProps {
+  onSelect: (suit: Suit) => void
+}
+
+/**
+ * Human trump call after winning the bid (#34). Shown once, right after
+ * the auction resolves in the human's favor — passing.ts's bidder/partner
+ * split needs `trumpSuit` before the pass phase can run.
+ */
+export function TrumpSelector({ onSelect }: TrumpSelectorProps) {
+  return (
+    <div className="w-full max-w-xs rounded-lg bg-white p-4 text-neutral-900 shadow-xl">
+      <h3 className="text-sm font-semibold">Name trump</h3>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        {SUITS.map((suit) => {
+          const colorClass = RED_SUITS.includes(suit) ? 'text-red-600' : 'text-neutral-900'
+          return (
+            <button
+              key={suit}
+              type="button"
+              onClick={() => onSelect(suit)}
+              className="flex items-center justify-center gap-2 rounded border border-neutral-300 px-3 py-2 font-semibold hover:bg-neutral-100"
+            >
+              <span className={`text-lg ${colorClass}`}>{SUIT_GLYPH[suit]}</span>
+              <span>{SUIT_NAME[suit]}</span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/auctionReducer.ts
+++ b/web/src/components/auctionReducer.ts
@@ -1,0 +1,186 @@
+// Auction/pass state machine backing AuctionFlow.tsx (#34). Split into its
+// own module (rather than living in AuctionFlow.tsx) so the component file
+// only exports the component — oxlint's react/only-export-components rule
+// flags mixed component+logic exports since it breaks fast refresh.
+//
+// Mirrors pinochle_engine.py's Round._bidding_loop / _passing_phase (frozen
+// Python reference; see round.ts's module docstring — the TS engine
+// doesn't reimplement bidding/passing itself, so this is UI-layer state,
+// not engine state). Turn order rotates clockwise from left of dealer; a
+// player who passes is out for the rest of the auction; the auction ends
+// after 3 passes, or the moment only one active bidder is left once
+// someone has actually bid. If nobody ever bids, the dealer is forced to
+// take it at FORCED_BID (card.ts).
+
+import { FORCED_BID, type Card, type Suit } from '../engine/card'
+import type { Hands, TeamId } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+import type { AuctionLogEntry } from './auctionTypes'
+
+interface BiddingSubstate {
+  readonly active: readonly [boolean, boolean, boolean, boolean]
+  readonly turn: PlayerIndex
+  readonly currentBid: number
+  readonly everBid: boolean
+  readonly passes: number
+  readonly bidWinner: PlayerIndex | null
+  readonly lastBidder: PlayerIndex | null
+}
+
+export type AuctionPhase =
+  | 'bidding'
+  | 'trump'
+  | 'passing-partner-to-bidder'
+  | 'passing-bidder-to-partner'
+  | 'complete'
+
+export interface AuctionState {
+  readonly hands: Hands
+  readonly dealer: PlayerIndex
+  readonly seatNames: Record<PlayerIndex, string>
+  readonly scoresByTeam: Record<TeamId, number>
+  readonly bidding: BiddingSubstate
+  readonly bidWinner: PlayerIndex | null
+  readonly bid: number
+  readonly trumpSuit: Suit | null
+  readonly phase: AuctionPhase
+  readonly log: readonly AuctionLogEntry[]
+}
+
+export type AuctionAction =
+  | { readonly type: 'BID'; readonly player: PlayerIndex; readonly amount: number }
+  | { readonly type: 'PASS_BID'; readonly player: PlayerIndex }
+  | { readonly type: 'CHOOSE_TRUMP'; readonly player: PlayerIndex; readonly suit: Suit }
+  | { readonly type: 'PASS_CARDS'; readonly from: PlayerIndex; readonly to: PlayerIndex; readonly cards: readonly Card[] }
+
+export function initAuctionState(
+  hands: Hands,
+  dealer: PlayerIndex,
+  seatNames: Record<PlayerIndex, string>,
+  scoresByTeam: Record<TeamId, number>,
+): AuctionState {
+  return {
+    hands,
+    dealer,
+    seatNames,
+    scoresByTeam,
+    bidding: {
+      active: [true, true, true, true],
+      turn: ((dealer + 1) % 4) as PlayerIndex,
+      currentBid: 0,
+      everBid: false,
+      passes: 0,
+      bidWinner: null,
+      lastBidder: null,
+    },
+    bidWinner: null,
+    bid: 0,
+    trumpSuit: null,
+    phase: 'bidding',
+    log: [],
+  }
+}
+
+function isBiddingOver(b: BiddingSubstate): boolean {
+  return b.passes >= 3 || (b.everBid && b.active.filter(Boolean).length === 1)
+}
+
+/** Next active seat starting from (and including) `from`, wrapping clockwise. */
+function nextActiveTurn(active: readonly boolean[], from: PlayerIndex): PlayerIndex {
+  let idx = from
+  for (let i = 0; i < 4; i++) {
+    if (active[idx]) return idx
+    idx = ((idx + 1) % 4) as PlayerIndex
+  }
+  return from
+}
+
+/** After a BID/PASS_BID updates `bidding`, checks whether the auction is
+ * over and, if so, finalizes the contract (including the forced-bid
+ * fallback) and advances to the trump phase; otherwise just hands the
+ * turn to the next active seat. */
+function resolveBiddingOutcome(state: AuctionState): AuctionState {
+  const { bidding } = state
+  if (!isBiddingOver(bidding)) {
+    return { ...state, bidding: { ...bidding, turn: nextActiveTurn(bidding.active, bidding.turn) } }
+  }
+  if (bidding.everBid && bidding.bidWinner !== null) {
+    return { ...state, phase: 'trump', bidWinner: bidding.bidWinner, bid: bidding.currentBid }
+  }
+  const name = state.seatNames[state.dealer]
+  const log: AuctionLogEntry[] = [
+    ...state.log,
+    { kind: 'forced-bid', player: state.dealer, name, amount: FORCED_BID },
+  ]
+  return { ...state, phase: 'trump', bidWinner: state.dealer, bid: FORCED_BID, log }
+}
+
+export function auctionReducer(state: AuctionState, action: AuctionAction): AuctionState {
+  switch (action.type) {
+    case 'BID': {
+      if (state.phase !== 'bidding') return state
+      const { player, amount } = action
+      const bidding: BiddingSubstate = {
+        ...state.bidding,
+        currentBid: amount,
+        everBid: true,
+        bidWinner: player,
+        lastBidder: player,
+        turn: ((player + 1) % 4) as PlayerIndex,
+      }
+      const log: AuctionLogEntry[] = [
+        ...state.log,
+        { kind: 'bid', player, name: state.seatNames[player], amount },
+      ]
+      return resolveBiddingOutcome({ ...state, bidding, log })
+    }
+    case 'PASS_BID': {
+      if (state.phase !== 'bidding') return state
+      const { player } = action
+      const active = [...state.bidding.active] as [boolean, boolean, boolean, boolean]
+      active[player] = false
+      const bidding: BiddingSubstate = {
+        ...state.bidding,
+        active,
+        passes: state.bidding.passes + 1,
+        turn: ((player + 1) % 4) as PlayerIndex,
+      }
+      const log: AuctionLogEntry[] = [...state.log, { kind: 'pass-bid', player, name: state.seatNames[player] }]
+      return resolveBiddingOutcome({ ...state, bidding, log })
+    }
+    case 'CHOOSE_TRUMP': {
+      if (state.phase !== 'trump') return state
+      const { player, suit } = action
+      const log: AuctionLogEntry[] = [
+        ...state.log,
+        { kind: 'trump', player, name: state.seatNames[player], suit },
+      ]
+      return { ...state, trumpSuit: suit, phase: 'passing-partner-to-bidder', log }
+    }
+    case 'PASS_CARDS': {
+      if (state.phase !== 'passing-partner-to-bidder' && state.phase !== 'passing-bidder-to-partner') return state
+      const { from, to, cards } = action
+      const hands = state.hands.map((h, i) => {
+        if (i === from) return h.filter((c) => !cards.includes(c))
+        if (i === to) return [...h, ...cards]
+        return h
+      }) as Hands
+      const log: AuctionLogEntry[] = [
+        ...state.log,
+        {
+          kind: 'card-pass',
+          fromPlayer: from,
+          fromName: state.seatNames[from],
+          toPlayer: to,
+          toName: state.seatNames[to],
+          count: cards.length,
+        },
+      ]
+      const nextPhase: AuctionPhase =
+        state.phase === 'passing-partner-to-bidder' ? 'passing-bidder-to-partner' : 'complete'
+      return { ...state, hands, log, phase: nextPhase }
+    }
+    default:
+      return state
+  }
+}

--- a/web/src/components/auctionTypes.test.ts
+++ b/web/src/components/auctionTypes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { Suit } from '../engine/card'
+import { formatAuctionLogEntry, partnerOf } from './auctionTypes'
+
+describe('formatAuctionLogEntry', () => {
+  it('formats a bid entry', () => {
+    expect(formatAuctionLogEntry({ kind: 'bid', player: 1, name: 'West', amount: 320 })).toBe('West bid 320')
+  })
+
+  it('formats a pass entry', () => {
+    expect(formatAuctionLogEntry({ kind: 'pass-bid', player: 2, name: 'Partner' })).toBe('Partner passed')
+  })
+
+  it('formats a forced-bid entry', () => {
+    expect(
+      formatAuctionLogEntry({ kind: 'forced-bid', player: 3, name: 'East', amount: 250 }),
+    ).toBe('East is stuck with the forced bid of 250 (everyone passed)')
+  })
+
+  it('formats a trump entry with the full suit name', () => {
+    expect(formatAuctionLogEntry({ kind: 'trump', player: 0, name: 'You', suit: Suit.Hearts })).toBe(
+      'You named Hearts trump',
+    )
+  })
+
+  it('formats a card-pass entry without naming the cards', () => {
+    const text = formatAuctionLogEntry({
+      kind: 'card-pass',
+      fromPlayer: 2,
+      fromName: 'Partner',
+      toPlayer: 0,
+      toName: 'You',
+      count: 3,
+    })
+    expect(text).toBe('Partner passed 3 cards to You')
+  })
+
+  it('singularizes a 1-card pass', () => {
+    const text = formatAuctionLogEntry({
+      kind: 'card-pass',
+      fromPlayer: 2,
+      fromName: 'Partner',
+      toPlayer: 0,
+      toName: 'You',
+      count: 1,
+    })
+    expect(text).toBe('Partner passed 1 card to You')
+  })
+})
+
+describe('partnerOf', () => {
+  it('pairs seats two apart, matching round.ts teamOf', () => {
+    expect(partnerOf(0)).toBe(2)
+    expect(partnerOf(1)).toBe(3)
+    expect(partnerOf(2)).toBe(0)
+    expect(partnerOf(3)).toBe(1)
+  })
+})

--- a/web/src/components/auctionTypes.ts
+++ b/web/src/components/auctionTypes.ts
@@ -1,0 +1,77 @@
+// Shared data shapes for the bid/pass auction flow (#34). Built from the
+// real engine types (bidding.ts/round.ts/passing.ts) rather than ad-hoc UI
+// types, same approach tableTypes.ts took for the table scaffold (#33) and
+// scoreTypes.ts took for the round-summary/game-over screens (#36): plain
+// data in, so a live Round orchestrator (once #17-style bidding/passing
+// lands in the engine, or issue #29's chooseBid/chooseTrump wrapper ships)
+// can drive this UI without the components themselves changing.
+
+import type { Card, Suit } from '../engine/card'
+import type { TeamId } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+
+/**
+ * One entry in the auction/pass event log. AI decisions are never silent —
+ * every bid, pass, forced contract, trump call, and card exchange gets an
+ * entry here so a human player can follow what happened without having to
+ * infer it from hand/table state changing underneath them. Pass entries
+ * deliberately omit which cards moved (`card-pass` only carries a count):
+ * passed cards are private between the sender and receiver, same as a real
+ * hand-off across the table, and the recipient's own hand already reflects
+ * the result when it's the human on one end of the exchange.
+ */
+export type AuctionLogEntry =
+  | { readonly kind: 'bid'; readonly player: PlayerIndex; readonly name: string; readonly amount: number }
+  | { readonly kind: 'pass-bid'; readonly player: PlayerIndex; readonly name: string }
+  | { readonly kind: 'forced-bid'; readonly player: PlayerIndex; readonly name: string; readonly amount: number }
+  | { readonly kind: 'trump'; readonly player: PlayerIndex; readonly name: string; readonly suit: Suit }
+  | {
+      readonly kind: 'card-pass'
+      readonly fromPlayer: PlayerIndex
+      readonly fromName: string
+      readonly toPlayer: PlayerIndex
+      readonly toName: string
+      readonly count: number
+    }
+
+export const SUIT_NAME: Record<Suit, string> = {
+  S: 'Spades',
+  H: 'Hearts',
+  D: 'Diamonds',
+  C: 'Clubs',
+}
+
+/** Renders one log entry as a single line of human-readable text. Pure and
+ * exported on its own so AuctionLog's formatting logic is unit-testable
+ * without mounting a component. */
+export function formatAuctionLogEntry(entry: AuctionLogEntry): string {
+  switch (entry.kind) {
+    case 'bid':
+      return `${entry.name} bid ${entry.amount}`
+    case 'pass-bid':
+      return `${entry.name} passed`
+    case 'forced-bid':
+      return `${entry.name} is stuck with the forced bid of ${entry.amount} (everyone passed)`
+    case 'trump':
+      return `${entry.name} named ${SUIT_NAME[entry.suit]} trump`
+    case 'card-pass':
+      return `${entry.fromName} passed ${entry.count} card${entry.count === 1 ? '' : 's'} to ${entry.toName}`
+  }
+}
+
+/** Everything a live Round orchestrator needs once the auction and pass
+ * phases finish: the post-pass hands, the agreed contract, and who holds
+ * it — the inputs `playTrickTakingPhase` (round.ts) expects. */
+export interface AuctionResult {
+  readonly hands: readonly [readonly Card[], readonly Card[], readonly Card[], readonly Card[]]
+  readonly trumpSuit: Suit
+  readonly bidWinner: PlayerIndex
+  readonly bid: number
+}
+
+/** Fixed team pairing, matches round.ts's `teamOf`. */
+export function partnerOf(player: PlayerIndex): PlayerIndex {
+  return ((player + 2) % 4) as PlayerIndex
+}
+
+export type ScoresByTeam = Record<TeamId, number>

--- a/web/src/components/tableTypes.ts
+++ b/web/src/components/tableTypes.ts
@@ -23,9 +23,11 @@ export interface TableState {
   readonly humanPlayer: PlayerIndex
   /** Cards played so far in the current trick, in play order. */
   readonly trick: readonly TrickPlay[]
-  readonly trumpSuit: Suit
+  /** null before the auction (#34) has settled on a trump suit. */
+  readonly trumpSuit: Suit | null
   readonly currentBid: number
-  readonly bidWinner: PlayerIndex
+  /** null before the auction (#34) has a winner. */
+  readonly bidWinner: PlayerIndex | null
   readonly scoresByTeam: Record<TeamId, number>
 }
 

--- a/web/src/mock/aiDecisions.ts
+++ b/web/src/mock/aiDecisions.ts
@@ -1,0 +1,61 @@
+// Stand-in AI bid/trump decisions for the auction flow UI (#34).
+//
+// Issue #29 (a stateful chooseBid/chooseTrump AI decision wrapper, mirroring
+// pinochle_engine.py's Player.choose_bid/choose_trump) may land separately
+// and isn't a dependency of this UI — these are deliberately simplified
+// heuristics built directly on bidding.ts's valuation math (bestBaseBid,
+// maxBid, OPENER_THRESHOLD) so the auction has *something* driving AI
+// seats today. AuctionFlow.tsx is the only caller; once #29 ships, swap
+// these two functions for the real wrapper there and this file goes away.
+//
+// Simplifications vs. the full Python Player.choose_bid: no dealer-
+// protection opener, no "3rd bidder always opens" rule, no partner-raised-
+// over-me re-raise logic. What's kept: the opener threshold, raising up to
+// the score-adjusted/capped ceiling, and never outbidding your own partner
+// (the one context rule that matters most for the auction not looking
+// broken — two AI teammates bidding each other up).
+
+import { bestBaseBid, maxBid, OPENER_THRESHOLD } from '../engine/bidding'
+import { type Card, OPENING_BID, type Suit } from '../engine/card'
+import { teamOf, type TeamId } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+
+const MIN_INCREMENT = 10
+
+/**
+ * Returns the amount to bid, or null to pass. `everBid`/`currentBid` follow
+ * round.ts's `_bidding_loop` convention: before anyone has bid, the only
+ * question is whether to open at `OPENING_BID`; afterward it's whether to
+ * raise by `MIN_INCREMENT`.
+ */
+export function aiDecideBid(
+  player: PlayerIndex,
+  hand: readonly Card[],
+  currentBid: number,
+  everBid: boolean,
+  lastBidder: PlayerIndex | null,
+  scoresByTeam: Record<TeamId, number>,
+): number | null {
+  const myTeam = teamOf(player)
+  const oppTeam = (myTeam === 0 ? 1 : 0) as TeamId
+  const { trump, total } = bestBaseBid(hand, scoresByTeam[myTeam], scoresByTeam[oppTeam])
+  const cap = maxBid(hand, trump)
+  const ceiling = cap === null ? total : Math.min(total, cap)
+
+  if (!everBid) {
+    return ceiling >= OPENER_THRESHOLD ? OPENING_BID : null
+  }
+
+  if (lastBidder !== null && teamOf(lastBidder) === myTeam) {
+    return null // never outbid your own partner
+  }
+
+  const nextBid = currentBid + MIN_INCREMENT
+  return nextBid <= ceiling ? nextBid : null
+}
+
+/** Best-suit-by-hand-value trump call, same valuation bestBaseBid already
+ * does internally to pick a bid — no separate scoring needed. */
+export function aiChooseTrump(hand: readonly Card[]): Suit {
+  return bestBaseBid(hand).trump
+}

--- a/web/src/mock/auctionState.ts
+++ b/web/src/mock/auctionState.ts
@@ -1,0 +1,29 @@
+// Static demo state for the auction flow UI (#34). Built from the real
+// engine types (Deck/Card) rather than hand-rolled fixtures, same approach
+// tableState.ts took for the table scaffold (#33) — this file is what a
+// later issue (a live game loop) needs to replace once dealing/rotation is
+// driven by an actual Game, not AuctionFlow's props/callers.
+
+import { Deck } from '../engine/card'
+import type { Hands, TeamId } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+
+export const SEAT_NAMES: Record<PlayerIndex, string> = {
+  0: 'You',
+  1: 'West',
+  2: 'Partner',
+  3: 'East',
+}
+
+export const HUMAN_PLAYER: PlayerIndex = 0
+export const DEALER: PlayerIndex = 3
+
+export function buildMockAuctionHands(): Hands {
+  const deck = new Deck()
+  deck.shuffle()
+  return deck.deal()
+}
+
+export function buildMockAuctionScores(): Record<TeamId, number> {
+  return { 0: 180, 1: 220 }
+}


### PR DESCRIPTION
## Summary
- Adds the auction UI: `BiddingControls` (bid-amount entry/raise/pass for the human) and `TrumpSelector` (trump call for whoever wins the bid), driven by `bidding.ts`'s valuation math (`bestBaseBid`) and a UI-layer state machine (`auctionReducer.ts`) that mirrors `pinochle_engine.py`'s `Round._bidding_loop` (turn rotation left-of-dealer, 3-pass auction end, dealer forced to `FORCED_BID` if nobody ever bids).
- Adds the 3-card pass UI: `PassSelector` lets the human pick exactly `PASS_COUNT` cards from their hand; the two-leg partner-to-bidder / bidder-to-partner exchange (`passing.ts`'s real `choosePassCards` for AI seats) is driven by the same state machine.
- Adds `AuctionLog` — every bid, pass, forced contract, trump call, and card exchange (AI or human) appends a visible log entry, so AI decisions are never silent. Card-pass entries deliberately omit which cards moved (count only) since passed cards are private between sender/receiver.
- Issue #29's stateful `chooseBid`/`chooseTrump` AI decision wrapper hasn't landed, so AI bid/trump decisions use a simplified stand-in (`mock/aiDecisions.ts`, built directly on `bidding.ts`'s `bestBaseBid`/`maxBid`/`OPENER_THRESHOLD`) — isolated to that one file so it's a small swap once #29 ships.
- All new components take plain data props (`auctionTypes.ts`), mirroring the `tableTypes.ts`/`scoreTypes.ts` approach from #33/#36, so a later live-Round issue can drive this UI without changing the components.
- Mounts into the existing `Table` scaffold (#33): widens `TableState`'s `trumpSuit`/`bidWinner` to nullable (there's no contract yet during bidding) and gives `Table` optional `overlay`/`logPanel` slots so the auction controls and log render over/alongside the seats instead of replacing them. `App.tsx` now runs `AuctionFlow` against mock dealt hands instead of the static demo table.

Trick-play (#35) picks up once the auction completes — `AuctionFlow`'s `onComplete` hands back the post-pass hands, trump, bid winner, and bid amount for that issue to consume.

Closes #34

## Test plan
- [x] `npm test` — 123/123 passing (17 files), including a full component-level walkthrough of bidding → trump call → pass in `AuctionFlow.test.tsx` with deliberately weak AI hands to keep the auction outcome deterministic
- [x] `npm run build` — typecheck + production build clean
- [x] `npm run lint` — oxlint clean
- [x] Manually verified in the browser (`npm run dev`): bid/raise/pass against 3 AI seats, forced trump selection when an AI wins the bid, AI-to-AI 3-card pass, and the log/scoreboard updating correctly throughout — no console errors