### PR TITLE
Build trick-play interaction flow UI

### DIFF
--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -1,3 +1,4 @@
+import type { Card } from '../engine/card'
 import { type Rank, Suit } from '../engine/card'
 import { PlayingCard } from './PlayingCard'
 import type { SeatPosition, SeatState } from './tableTypes'
@@ -7,6 +8,12 @@ export interface SeatProps {
   position: SeatPosition
   isHuman: boolean
   isBidWinner: boolean
+  /** Trick-play (#35): legal cards for the human's turn to play, and the
+   * callback to fire on a legal card's click/tap. Legal cards render
+   * highlighted and clickable; illegal ones render dimmed and disabled.
+   * Omit entirely to render the hand as plain, non-interactive cards (the
+   * auction phases, or any AI seat). */
+  playable?: { legalCards: readonly Card[]; onPlay: (card: Card) => void }
 }
 
 // Placeholder face used for AI seats' face-down fan. The suit/rank props
@@ -28,7 +35,7 @@ const POSITION_LAYOUT: Record<SeatPosition, string> = {
  * sized to their card count — never the actual cards, since an AI's hand
  * is hidden information from the human player's point of view.
  */
-export function Seat({ seat, position, isHuman, isBidWinner }: SeatProps) {
+export function Seat({ seat, position, isHuman, isBidWinner, playable }: SeatProps) {
   return (
     <div className={`flex gap-1 ${POSITION_LAYOUT[position]}`}>
       <div className="flex items-center gap-2 text-sm font-medium">
@@ -44,14 +51,33 @@ export function Seat({ seat, position, isHuman, isBidWinner }: SeatProps) {
       </div>
       {isHuman ? (
         <div className="flex flex-wrap justify-center gap-1 overflow-x-auto">
-          {seat.hand.map((card) => (
-            <PlayingCard
-              key={card.toString()}
-              suit={card.suit}
-              rank={card.rank}
-              className="-ml-10 first:ml-0"
-            />
-          ))}
+          {seat.hand.map((card) => {
+            const cardFace = <PlayingCard suit={card.suit} rank={card.rank} />
+            if (!playable) {
+              return (
+                <div key={card.toString()} className="-ml-10 first:ml-0">
+                  {cardFace}
+                </div>
+              )
+            }
+            const isLegal = playable.legalCards.includes(card)
+            return (
+              <button
+                key={card.toString()}
+                type="button"
+                disabled={!isLegal}
+                onClick={() => playable.onPlay(card)}
+                aria-label={`Play ${card.rank} of ${card.suit}`}
+                className={`-ml-10 first:ml-0 rounded-lg transition-transform ${
+                  isLegal
+                    ? 'cursor-pointer ring-2 ring-amber-400 hover:-translate-y-2'
+                    : 'cursor-not-allowed opacity-40'
+                }`}
+              >
+                {cardFace}
+              </button>
+            )
+          })}
         </div>
       ) : (
         <div className="flex overflow-x-auto px-2">

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -29,7 +29,8 @@ const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
  * most likely inside/near the human seat and the TrickArea respectively.
  */
 export function Table({ state, overlay, logPanel }: TableProps) {
-  const { seats, humanPlayer, trick, trumpSuit, currentBid, bidWinner, scoresByTeam } = state
+  const { seats, humanPlayer, trick, trumpSuit, currentBid, bidWinner, scoresByTeam, humanPlayable, trickWinner } =
+    state
   const bidWinnerSeat = bidWinner === null ? undefined : seats.find((seat) => seat.player === bidWinner)
 
   return (
@@ -51,11 +52,12 @@ export function Table({ state, overlay, logPanel }: TableProps) {
               position={seatPosition(seat.player, humanPlayer)}
               isHuman={seat.player === humanPlayer}
               isBidWinner={seat.player === bidWinner}
+              playable={seat.player === humanPlayer ? humanPlayable : undefined}
             />
           </div>
         ))}
         <div className="col-start-2 row-start-2">
-          <TrickArea trick={trick} humanPlayer={humanPlayer} />
+          <TrickArea trick={trick} humanPlayer={humanPlayer} winningPlayer={trickWinner} />
         </div>
       </div>
       {logPanel && <div className="absolute top-16 right-2">{logPanel}</div>}

--- a/web/src/components/TrickArea.tsx
+++ b/web/src/components/TrickArea.tsx
@@ -5,6 +5,10 @@ import { seatPosition, type SeatPosition } from './tableTypes'
 export interface TrickAreaProps {
   trick: readonly TrickPlay[]
   humanPlayer: PlayerIndex
+  /** Trick-play (#35): highlights the just-completed trick's winning card
+   * while it settles, before TrickPlayFlow clears it for the next trick.
+   * null/undefined outside that pause (nothing highlighted). */
+  winningPlayer?: PlayerIndex | null
 }
 
 const POSITION_CLASS: Record<SeatPosition, string> = {
@@ -20,11 +24,16 @@ const POSITION_CLASS: Record<SeatPosition, string> = {
  * until a seat has played, so a trick in progress shows 1-3 cards and a
  * completed-but-not-yet-cleared trick shows all 4.
  */
-export function TrickArea({ trick, humanPlayer }: TrickAreaProps) {
+export function TrickArea({ trick, humanPlayer, winningPlayer }: TrickAreaProps) {
   return (
     <div className="grid aspect-square w-full max-w-72 grid-cols-3 grid-rows-3 items-center justify-items-center rounded-full bg-green-950/40">
       {trick.map((play) => (
-        <div key={play.player} className={POSITION_CLASS[seatPosition(play.player, humanPlayer)]}>
+        <div
+          key={play.player}
+          className={`rounded-lg ${POSITION_CLASS[seatPosition(play.player, humanPlayer)]} ${
+            play.player === winningPlayer ? 'ring-4 ring-amber-400' : ''
+          }`}
+        >
           <PlayingCard suit={play.card.suit} rank={play.card.rank} />
         </div>
       ))}

--- a/web/src/components/TrickLog.test.tsx
+++ b/web/src/components/TrickLog.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Card, Suit } from '../engine/card'
+import { TrickLog } from './TrickLog'
+import type { TrickPlayLogEntry } from './trickPlayTypes'
+
+afterEach(cleanup)
+
+describe('TrickLog', () => {
+  it('renders nothing when there are no entries', () => {
+    const { container } = render(<TrickLog entries={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders every entry, formatted', () => {
+    const entries: TrickPlayLogEntry[] = [
+      { kind: 'card-play', player: 0, name: 'You', card: new Card(Suit.Hearts, 'A', 1), isLead: true },
+      { kind: 'trick-won', player: 2, name: 'Partner', points: 10, trickNumber: 0 },
+    ]
+    render(<TrickLog entries={entries} />)
+    expect(screen.getByText('You led the A of Hearts')).not.toBeNull()
+    expect(screen.getByText('Partner won the trick (10 points)')).not.toBeNull()
+  })
+
+  it('shows the most recent entry first', () => {
+    const entries: TrickPlayLogEntry[] = [
+      { kind: 'card-play', player: 0, name: 'You', card: new Card(Suit.Hearts, 'A', 1), isLead: true },
+      { kind: 'card-play', player: 1, name: 'West', card: new Card(Suit.Hearts, '9', 1), isLead: false },
+    ]
+    render(<TrickLog entries={entries} />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[0].textContent).toBe('West played the 9 of Hearts')
+    expect(items[1].textContent).toBe('You led the A of Hearts')
+  })
+})

--- a/web/src/components/TrickLog.tsx
+++ b/web/src/components/TrickLog.tsx
@@ -1,0 +1,31 @@
+import { formatTrickPlayLogEntry, type TrickPlayLogEntry } from './trickPlayTypes'
+
+export interface TrickLogProps {
+  /** Oldest-first; rendered newest-first so the latest event is always visible without scrolling. */
+  entries: readonly TrickPlayLogEntry[]
+}
+
+/**
+ * Visible feed of trick-play events (#35) — every card played (human and
+ * AI alike) and every trick's winner shows up here as it happens, so a
+ * human player can follow the hand instead of just watching cards and
+ * hand counts change silently underneath them. Mirrors AuctionLog's
+ * layout/behavior for the auction/pass phase.
+ */
+export function TrickLog({ entries }: TrickLogProps) {
+  if (entries.length === 0) return null
+
+  const newestFirst = [...entries].reverse()
+
+  return (
+    <div className="pointer-events-none w-full max-w-xs">
+      <ol className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded-lg bg-black/60 p-3 text-xs text-white shadow-lg">
+        {newestFirst.map((entry, i) => (
+          <li key={newestFirst.length - i} className={i === 0 ? 'font-semibold' : 'text-white/70'}>
+            {formatTrickPlayLogEntry(entry)}
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}

--- a/web/src/components/TrickPlayFlow.test.tsx
+++ b/web/src/components/TrickPlayFlow.test.tsx
@@ -1,0 +1,154 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Card, Deck, Suit } from '../engine/card'
+import type { Hands } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+import { AI_PLAY_DELAY_MS, TrickPlayFlow } from './TrickPlayFlow'
+import type { TrickPlayResult } from './trickPlayTypes'
+
+const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'You', 1: 'West', 2: 'Partner', 3: 'East' }
+const SCORES = { 0: 0, 1: 0 }
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('TrickPlayFlow (component)', () => {
+  it('highlights only legal cards for the human, forcing a follow of the lead suit', () => {
+    vi.useFakeTimers()
+
+    const humanHand = [new Card(Suit.Hearts, 'A', 1), new Card(Suit.Spades, '9', 1)]
+    const hands: Hands = [
+      humanHand,
+      [new Card(Suit.Hearts, '9', 1)], // West — leads, single card, forced
+      [new Card(Suit.Clubs, '9', 1)], // Partner — sluffs, single card, forced
+      [new Card(Suit.Diamonds, '9', 1)], // East — sluffs, single card, forced
+    ]
+    const onComplete = vi.fn()
+
+    render(
+      <TrickPlayFlow
+        hands={hands}
+        trumpSuit={Suit.Spades}
+        bidWinner={1}
+        bid={300}
+        seatNames={SEAT_NAMES}
+        humanPlayer={0}
+        scoresByTeam={SCORES}
+        onComplete={onComplete}
+      />,
+    )
+
+    // West leads, then Partner and East follow — each is an AI turn with a
+    // brief delay before it resolves.
+    act(() => vi.advanceTimersByTime(AI_PLAY_DELAY_MS))
+    act(() => vi.advanceTimersByTime(AI_PLAY_DELAY_MS))
+    act(() => vi.advanceTimersByTime(AI_PLAY_DELAY_MS))
+
+    expect(screen.getByText('West led the 9 of Hearts')).not.toBeNull()
+    expect(screen.getByText('Partner played the 9 of Clubs')).not.toBeNull()
+    expect(screen.getByText('East played the 9 of Diamonds')).not.toBeNull()
+
+    // Now it's the human's turn: holding the lead suit (Hearts), they must
+    // follow it — the Ace is legal/clickable, the Spades 9 is not.
+    const aceButton = screen.getByRole('button', { name: 'Play A of H' })
+    const nineButton = screen.getByRole('button', { name: 'Play 9 of S' })
+    expect(aceButton.hasAttribute('disabled')).toBe(false)
+    expect(nineButton.hasAttribute('disabled')).toBe(true)
+
+    fireEvent.click(aceButton)
+
+    expect(screen.getByText('You played the A of Hearts')).not.toBeNull()
+    // The human's Ace beats West's 9 of Hearts, and nobody played trump —
+    // the human's team (0, since human is player 0) wins the trick.
+    expect(screen.getByText('You won the trick (10 points)')).not.toBeNull()
+  })
+
+  it('never lets the human play an illegal card by clicking a disabled button', () => {
+    vi.useFakeTimers()
+
+    const humanHand = [new Card(Suit.Hearts, 'A', 1), new Card(Suit.Spades, '9', 1)]
+    const hands: Hands = [
+      humanHand,
+      [new Card(Suit.Hearts, '9', 1)],
+      [new Card(Suit.Clubs, '9', 1)],
+      [new Card(Suit.Diamonds, '9', 1)],
+    ]
+
+    render(
+      <TrickPlayFlow
+        hands={hands}
+        trumpSuit={Suit.Spades}
+        bidWinner={1}
+        bid={300}
+        seatNames={SEAT_NAMES}
+        humanPlayer={0}
+        scoresByTeam={SCORES}
+      />,
+    )
+
+    act(() => vi.advanceTimersByTime(AI_PLAY_DELAY_MS))
+    act(() => vi.advanceTimersByTime(AI_PLAY_DELAY_MS))
+    act(() => vi.advanceTimersByTime(AI_PLAY_DELAY_MS))
+
+    const nineButton = screen.getByRole('button', { name: 'Play 9 of S' })
+    fireEvent.click(nineButton)
+
+    // The illegal Spades 9 is untouched — the trick still only has 3 plays,
+    // no card-play entry was logged for it.
+    expect(screen.queryByText('You played the 9 of Spades')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Play 9 of S' })).not.toBeNull()
+  })
+
+  it('plays a full round end-to-end, alternating human clicks with delayed AI auto-play, and reports the trick result', () => {
+    vi.useFakeTimers()
+
+    // Full, real 48-card deck (unshuffled — order doesn't matter, only
+    // that it's a legitimate deal) so the round can run all 12 tricks to
+    // completion without either engine (real Trick.legalMoves) or AI
+    // (real chooseLeadCard/chooseFollowCard) ever seeing an empty hand
+    // mid-round.
+    const hands = new Deck().deal()
+    const onComplete = vi.fn()
+
+    render(
+      <TrickPlayFlow
+        hands={hands}
+        trumpSuit={Suit.Hearts}
+        bidWinner={0}
+        bid={300}
+        seatNames={SEAT_NAMES}
+        humanPlayer={0}
+        scoresByTeam={SCORES}
+        onComplete={onComplete}
+      />,
+    )
+
+    let guard = 0
+    while (onComplete.mock.calls.length === 0 && guard < 500) {
+      guard++
+      const playable = screen
+        .queryAllByRole('button', { name: /^Play / })
+        .find((button) => !button.hasAttribute('disabled'))
+      if (playable) {
+        fireEvent.click(playable)
+      } else {
+        // Either an AI turn or the post-trick settle pause is in flight —
+        // advancing past the longer of the two delays flushes whichever
+        // is pending.
+        act(() => vi.advanceTimersByTime(1200))
+      }
+    }
+
+    expect(guard).toBeLessThan(500) // sanity: the loop actually terminated, not just gave up
+    expect(onComplete).toHaveBeenCalledOnce()
+
+    const result = onComplete.mock.calls[0][0] as TrickPlayResult
+    expect(result.trickWinners).toHaveLength(12)
+    // 24 point-cards (A/10/K x 4 suits x 2 copies) worth 10 each, plus the
+    // +10 last-trick bonus — the full round's points always sum to this,
+    // regardless of who won which trick.
+    expect(result.trickPointsByTeam[0] + result.trickPointsByTeam[1]).toBe(250)
+  })
+})

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useReducer, useRef } from 'react'
+import type { Card, Suit } from '../engine/card'
+import type { Hands, TeamId } from '../engine/round'
+import { chooseFollowCard, chooseLeadCard, PlayTracker } from '../engine/tracker'
+import type { PlayerIndex } from '../engine/trick'
+import { Table } from './Table'
+import type { TableState } from './tableTypes'
+import { TrickLog } from './TrickLog'
+import { buildTrick, initTrickPlayState, teammatesOf, trickPlayReducer } from './trickPlayReducer'
+import type { TrickPlayResult } from './trickPlayTypes'
+
+export interface TrickPlayFlowProps {
+  hands: Hands
+  trumpSuit: Suit
+  bidWinner: PlayerIndex
+  /** The agreed contract amount — display-only here (Scoreboard), same
+   * value AuctionResult.bid carries out of the auction phase. */
+  bid: number
+  seatNames: Record<PlayerIndex, string>
+  humanPlayer: PlayerIndex
+  scoresByTeam: Record<TeamId, number>
+  /** Fired once, when all 12 tricks have been played, with the trick-point
+   * contribution each team makes to a live Round orchestrator's (#47)
+   * `scoreRound` call. */
+  onComplete?: (result: TrickPlayResult) => void
+}
+
+// Brief pauses so AI turns and trick resolution read as a real hand being
+// played rather than the state jumping silently — #35's core requirement.
+// Exported (not just local) so tests can drive fake timers by these exact
+// values instead of hardcoding a duplicate copy of them.
+export const AI_PLAY_DELAY_MS = 700
+export const TRICK_SETTLE_MS = 1200
+
+/**
+ * Drives the trick-taking phase (#35): legal-move highlighting on the
+ * human's hand, playing a card into the center trick area, settling a
+ * completed trick on its winner, and advancing turn order across all 12
+ * tricks. Mounted into the Table scaffold (#33) — the same logPanel slot
+ * AuctionFlow (#34) uses for its log, plus a further extension to
+ * Table/Seat (`humanPlayable`/`trickWinner`) so the human's own hand cards
+ * are directly clickable (legal ones highlighted, illegal ones dimmed)
+ * rather than routed through a modal overlay control, since trick-play
+ * only ever needs the human to pick one card from their own hand instead
+ * of entering an amount or naming a suit.
+ *
+ * AI turns resolve via the real chooseLeadCard/chooseFollowCard
+ * (tracker.ts, #31/#32) — not a mock — after a short delay, and always log
+ * a visible TrickLog entry; no AI decision happens silently, same
+ * principle AuctionFlow's AuctionLog follows for the auction/pass phase.
+ */
+export function TrickPlayFlow({
+  hands,
+  trumpSuit,
+  bidWinner,
+  bid,
+  seatNames,
+  humanPlayer,
+  scoresByTeam,
+  onComplete,
+}: TrickPlayFlowProps) {
+  const [state, dispatch] = useReducer(
+    trickPlayReducer,
+    undefined,
+    () => initTrickPlayState(hands, trumpSuit, bidWinner, seatNames),
+  )
+  // Accumulates every card played so far this round (tracker.ts's
+  // PlayTracker) — mutated directly alongside each PLAY_CARD dispatch
+  // rather than derived from reducer state, since it's an append-only
+  // strategy input the AI reads, not something any render needs back.
+  const trackerRef = useRef(new PlayTracker())
+  const completedRef = useRef(false)
+
+  // Resolve AI turns automatically, after a brief delay so the play reads
+  // as a real decision rather than an instant jump. Runs after every state
+  // change; only actually schedules a play when it's an AI seat's turn.
+  useEffect(() => {
+    if (state.phase !== 'playing' || state.turn === humanPlayer) return
+    const player = state.turn
+    const timer = setTimeout(() => {
+      const hand = state.hands[player]
+      const trick = buildTrick(state.trumpSuit, state.currentTrick)
+      const legal = trick.legalMoves(hand)
+      const card =
+        state.currentTrick.length === 0
+          ? chooseLeadCard(hand, state.trumpSuit, trackerRef.current)
+          : chooseFollowCard(hand, legal, state.currentTrick, state.trumpSuit, teammatesOf(player), trackerRef.current)
+      trackerRef.current.record(card)
+      dispatch({ type: 'PLAY_CARD', player, card })
+    }, AI_PLAY_DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [state, humanPlayer])
+
+  // Once a trick completes, pause so the human can see all 4 cards and the
+  // winner highlight before it's cleared for the next trick.
+  useEffect(() => {
+    if (state.phase !== 'trick-complete') return
+    const timer = setTimeout(() => dispatch({ type: 'CLEAR_TRICK' }), TRICK_SETTLE_MS)
+    return () => clearTimeout(timer)
+  }, [state.phase, state.trickWinners.length])
+
+  // Fire onComplete exactly once, when all 12 tricks are done.
+  useEffect(() => {
+    if (state.phase !== 'complete' || completedRef.current) return
+    completedRef.current = true
+    onComplete?.({ trickPointsByTeam: state.trickPointsByTeam, trickWinners: state.trickWinners })
+  }, [state, onComplete])
+
+  const legalMovesForHuman = useMemo(() => {
+    if (state.phase !== 'playing' || state.turn !== humanPlayer) return null
+    const trick = buildTrick(state.trumpSuit, state.currentTrick)
+    return trick.legalMoves(state.hands[humanPlayer])
+  }, [state, humanPlayer])
+
+  const tableState: TableState = useMemo(() => {
+    const seatFor = (p: PlayerIndex) => ({ player: p, name: seatNames[p], hand: state.hands[p] })
+    const seats: TableState['seats'] = [seatFor(0), seatFor(1), seatFor(2), seatFor(3)]
+    const humanPlayable: TableState['humanPlayable'] = legalMovesForHuman
+      ? {
+          legalCards: legalMovesForHuman,
+          onPlay: (card: Card) => {
+            trackerRef.current.record(card)
+            dispatch({ type: 'PLAY_CARD', player: humanPlayer, card })
+          },
+        }
+      : undefined
+
+    return {
+      seats,
+      humanPlayer,
+      trick: state.currentTrick,
+      trumpSuit: state.trumpSuit,
+      currentBid: bid,
+      bidWinner: state.bidWinner,
+      scoresByTeam,
+      humanPlayable,
+      trickWinner: state.phase === 'trick-complete' ? (state.trickWinners.at(-1) ?? null) : null,
+    }
+  }, [state, seatNames, humanPlayer, bid, scoresByTeam, legalMovesForHuman])
+
+  return <Table state={tableState} logPanel={<TrickLog entries={state.log} />} />
+}

--- a/web/src/components/tableTypes.ts
+++ b/web/src/components/tableTypes.ts
@@ -29,6 +29,16 @@ export interface TableState {
   /** null before the auction (#34) has a winner. */
   readonly bidWinner: PlayerIndex | null
   readonly scoresByTeam: Record<TeamId, number>
+  /** Trick-play (#35): legal cards for the human's turn to play, and the
+   * callback to fire when one of them is clicked/tapped. Omitted outside
+   * the human's trick-play turn (auction phases, AI turns, mid-settle) —
+   * the human's hand then renders as plain, non-interactive cards, same as
+   * during the auction. */
+  readonly humanPlayable?: { readonly legalCards: readonly Card[]; readonly onPlay: (card: Card) => void }
+  /** Trick-play (#35): the just-completed trick's winner, highlighted in
+   * TrickArea while it settles before being cleared for the next trick.
+   * null/undefined outside that settle pause. */
+  readonly trickWinner?: PlayerIndex | null
 }
 
 /** Table position, independent of PlayerIndex — the human seat is always

--- a/web/src/components/trickPlayReducer.test.ts
+++ b/web/src/components/trickPlayReducer.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { Card, Suit } from '../engine/card'
+import type { PlayerIndex } from '../engine/trick'
+import {
+  buildTrick,
+  initTrickPlayState,
+  teammatesOf,
+  trickPlayReducer,
+  type TrickPlayState,
+} from './trickPlayReducer'
+
+const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'You', 1: 'West', 2: 'Partner', 3: 'East' }
+
+function baseState(bidWinner: PlayerIndex = 0): TrickPlayState {
+  const hands = [[], [], [], []] as [Card[], Card[], Card[], Card[]]
+  return initTrickPlayState(hands, Suit.Hearts, bidWinner, SEAT_NAMES)
+}
+
+/** Plays a full 4-card trick (all Hearts = trump) so tests don't have to
+ * repeat the same 4 PLAY_CARD dispatches to reach 'trick-complete'. */
+function playFullTrick(state: TrickPlayState): TrickPlayState {
+  let next = state
+  const cards: [PlayerIndex, Card][] = [
+    [0, new Card(Suit.Hearts, 'A', 1)], // 10 points, highest trump — wins
+    [1, new Card(Suit.Hearts, '9', 1)],
+    [2, new Card(Suit.Hearts, 'J', 1)],
+    [3, new Card(Suit.Hearts, 'Q', 1)],
+  ]
+  for (const [player, card] of cards) {
+    next = trickPlayReducer(next, { type: 'PLAY_CARD', player, card })
+  }
+  return next
+}
+
+describe('trickPlayReducer', () => {
+  it('starts with the bid winner leading trick 0', () => {
+    const state = baseState(2)
+    expect(state.leader).toBe(2)
+    expect(state.turn).toBe(2)
+    expect(state.trickNumber).toBe(0)
+    expect(state.phase).toBe('playing')
+  })
+
+  it('advances turn and logs each card played before the trick completes', () => {
+    let state = baseState(0)
+    const card = new Card(Suit.Hearts, 'A', 1)
+    state = trickPlayReducer(state, { type: 'PLAY_CARD', player: 0, card })
+    expect(state.turn).toBe(1)
+    expect(state.phase).toBe('playing')
+    expect(state.currentTrick).toEqual([{ player: 0, card }])
+    expect(state.log).toEqual([{ kind: 'card-play', player: 0, name: 'You', card, isLead: true }])
+  })
+
+  it('logs a follow (non-lead) play once the trick has started', () => {
+    let state = baseState(0)
+    state = trickPlayReducer(state, { type: 'PLAY_CARD', player: 0, card: new Card(Suit.Hearts, 'A', 1) })
+    const followCard = new Card(Suit.Hearts, '9', 1)
+    state = trickPlayReducer(state, { type: 'PLAY_CARD', player: 1, card: followCard })
+    expect(state.log.at(-1)).toEqual({ kind: 'card-play', player: 1, name: 'West', card: followCard, isLead: false })
+  })
+
+  it('ignores a play from a player whose turn it is not', () => {
+    const state = baseState(0)
+    const next = trickPlayReducer(state, { type: 'PLAY_CARD', player: 1, card: new Card(Suit.Hearts, 'A', 1) })
+    expect(next).toBe(state)
+  })
+
+  it('removes the played card from the players hand', () => {
+    const card = new Card(Suit.Hearts, 'A', 1)
+    let state = baseState(0)
+    state = { ...state, hands: [[card], [], [], []] }
+    state = trickPlayReducer(state, { type: 'PLAY_CARD', player: 0, card })
+    expect(state.hands[0]).toEqual([])
+  })
+
+  it('resolves the trick winner/points and settles once the 4th card is played', () => {
+    const state = playFullTrick(baseState(0))
+    expect(state.phase).toBe('trick-complete')
+    expect(state.trickWinners).toEqual([0])
+    expect(state.trickPointsByTeam).toEqual({ 0: 10, 1: 0 })
+    expect(state.log.at(-1)).toEqual({ kind: 'trick-won', player: 0, name: 'You', points: 10, trickNumber: 0 })
+  })
+
+  it('ignores PLAY_CARD once the trick has settled (waiting for CLEAR_TRICK)', () => {
+    const settled = playFullTrick(baseState(0))
+    const unchanged = trickPlayReducer(settled, {
+      type: 'PLAY_CARD',
+      player: 0,
+      card: new Card(Suit.Spades, '9', 1),
+    })
+    expect(unchanged).toBe(settled)
+  })
+
+  it('CLEAR_TRICK advances to the next trick, led by the previous winner', () => {
+    let state = playFullTrick(baseState(0))
+    state = trickPlayReducer(state, { type: 'CLEAR_TRICK' })
+    expect(state.phase).toBe('playing')
+    expect(state.currentTrick).toEqual([])
+    expect(state.leader).toBe(0)
+    expect(state.turn).toBe(0)
+    expect(state.trickNumber).toBe(1)
+  })
+
+  it('ignores CLEAR_TRICK while a trick is still in progress', () => {
+    const state = baseState(0)
+    const unchanged = trickPlayReducer(state, { type: 'CLEAR_TRICK' })
+    expect(unchanged).toBe(state)
+  })
+
+  it('adds the last-trick bonus to whichever team wins trick 12, then completes on CLEAR_TRICK', () => {
+    let state = baseState(0)
+    state = { ...state, trickNumber: 11 }
+    state = playFullTrick(state)
+    // 10 (the Ace) + 10 (last-trick bonus) = 20
+    expect(state.trickPointsByTeam).toEqual({ 0: 20, 1: 0 })
+    state = trickPlayReducer(state, { type: 'CLEAR_TRICK' })
+    expect(state.phase).toBe('complete')
+  })
+})
+
+describe('teammatesOf', () => {
+  it('pairs a player with their partner, matching round.ts teamOf', () => {
+    expect(teammatesOf(0)).toEqual([0, 2])
+    expect(teammatesOf(1)).toEqual([1, 3])
+    expect(teammatesOf(2)).toEqual([2, 0])
+    expect(teammatesOf(3)).toEqual([3, 1])
+  })
+})
+
+describe('buildTrick', () => {
+  it('replays plain TrickPlay data into a live Trick with the right winner', () => {
+    const trick = buildTrick(Suit.Hearts, [
+      { player: 0, card: new Card(Suit.Spades, 'K', 1) },
+      { player: 1, card: new Card(Suit.Spades, '10', 1) },
+    ])
+    expect(trick.winner()).toBe(1)
+  })
+})

--- a/web/src/components/trickPlayReducer.ts
+++ b/web/src/components/trickPlayReducer.ts
@@ -1,0 +1,160 @@
+// Trick-play state machine backing TrickPlayFlow.tsx (#35). Split into its
+// own module (rather than living in TrickPlayFlow.tsx) so the component
+// file only exports the component — oxlint's react/only-export-components
+// rule flags mixed component+logic exports since it breaks fast refresh
+// (same reason auctionReducer.ts is split out from AuctionFlow.tsx).
+//
+// Mirrors round.ts's playTrickTakingPhase loop (frozen reference for the
+// rules: Trick.legalMoves/winner/points, teamOf, the 12th-trick bonus) but
+// broken into individual PLAY_CARD/CLEAR_TRICK actions instead of running
+// all 12 tricks synchronously in one call — the UI needs to pause after
+// each AI play (a brief delay, #35) and after each completed trick (so the
+// human can see who won before it's cleared), which a single blocking
+// function can't do. playTrickTakingPhase itself stays the source of truth
+// for headless/non-UI callers; this reducer reimplements the same
+// per-trick resolution one play at a time.
+
+import type { Card, Suit } from '../engine/card'
+import { partnerOf, teamOf, type Hands, type TeamId } from '../engine/round'
+import { type PlayerIndex, Trick, type TrickPlay } from '../engine/trick'
+import type { TrickPlayLogEntry } from './trickPlayTypes'
+
+const TRICK_COUNT = 12
+const LAST_TRICK_BONUS = 10 // team that wins the 12th trick gets +10, matches round.ts
+
+export type TrickPlayPhase = 'playing' | 'trick-complete' | 'complete'
+
+export interface TrickPlayState {
+  readonly hands: Hands
+  readonly trumpSuit: Suit
+  readonly bidWinner: PlayerIndex
+  readonly seatNames: Record<PlayerIndex, string>
+  /** 0-indexed trick counter (0..11), matching round.ts's TRICK_COUNT loop. */
+  readonly trickNumber: number
+  /** Leader of the *current* trick (the previous trick's winner, or the bid winner for trick 0). */
+  readonly leader: PlayerIndex
+  /** Whose turn it is to play next, within the current trick. */
+  readonly turn: PlayerIndex
+  /** Plays made so far in the current trick, in play order (0-4 entries). */
+  readonly currentTrick: readonly TrickPlay[]
+  /** Winning player of each completed trick, in order. */
+  readonly trickWinners: readonly PlayerIndex[]
+  readonly trickPointsByTeam: Record<TeamId, number>
+  readonly phase: TrickPlayPhase
+  readonly log: readonly TrickPlayLogEntry[]
+}
+
+export type TrickPlayAction =
+  | { readonly type: 'PLAY_CARD'; readonly player: PlayerIndex; readonly card: Card }
+  | { readonly type: 'CLEAR_TRICK' }
+
+export function initTrickPlayState(
+  hands: Hands,
+  trumpSuit: Suit,
+  bidWinner: PlayerIndex,
+  seatNames: Record<PlayerIndex, string>,
+): TrickPlayState {
+  return {
+    hands,
+    trumpSuit,
+    bidWinner,
+    seatNames,
+    trickNumber: 0,
+    leader: bidWinner,
+    turn: bidWinner,
+    currentTrick: [],
+    trickWinners: [],
+    trickPointsByTeam: { 0: 0, 1: 0 },
+    phase: 'playing',
+    log: [],
+  }
+}
+
+/** Rebuilds a live Trick instance from plain TrickPlay data, so legal-move
+ * filtering and winner/points resolution can reuse trick.ts's rules
+ * instead of duplicating them here. Cheap enough to call on every render —
+ * at most 3 plays to replay before the 4th is added. */
+export function buildTrick(trumpSuit: Suit, plays: readonly TrickPlay[]): Trick {
+  const trick = new Trick(trumpSuit)
+  for (const p of plays) trick.play(p.player, p.card)
+  return trick
+}
+
+/** Teammates (self + partner) for `player`, per round.ts's fixed seating —
+ * the shape chooseFollowCard (tracker.ts) wants for its "is my team
+ * already winning this trick" check. */
+export function teammatesOf(player: PlayerIndex): PlayerIndex[] {
+  return [player, partnerOf(player)]
+}
+
+export function trickPlayReducer(state: TrickPlayState, action: TrickPlayAction): TrickPlayState {
+  switch (action.type) {
+    case 'PLAY_CARD': {
+      if (state.phase !== 'playing' || action.player !== state.turn) return state
+      const { player, card } = action
+      const hands = state.hands.map((h, i) => (i === player ? h.filter((c) => c !== card) : h)) as Hands
+      const currentTrick: TrickPlay[] = [...state.currentTrick, { player, card }]
+      const log: TrickPlayLogEntry[] = [
+        ...state.log,
+        {
+          kind: 'card-play',
+          player,
+          name: state.seatNames[player],
+          card,
+          isLead: state.currentTrick.length === 0,
+        },
+      ]
+
+      if (currentTrick.length < 4) {
+        return { ...state, hands, currentTrick, log, turn: ((player + 1) % 4) as PlayerIndex }
+      }
+
+      // 4th card of the trick — resolve the winner and settle (pause on
+      // 'trick-complete'; the caller clears it via CLEAR_TRICK once the
+      // human has had a moment to see who won).
+      const trick = buildTrick(state.trumpSuit, currentTrick)
+      const winner = trick.winner()
+      const isLastTrick = state.trickNumber === TRICK_COUNT - 1
+      const points = trick.points() + (isLastTrick ? LAST_TRICK_BONUS : 0)
+      const winningTeam = teamOf(winner)
+      const trickPointsByTeam = {
+        ...state.trickPointsByTeam,
+        [winningTeam]: state.trickPointsByTeam[winningTeam] + points,
+      }
+      const trickWinners = [...state.trickWinners, winner]
+      const finalLog: TrickPlayLogEntry[] = [
+        ...log,
+        { kind: 'trick-won', player: winner, name: state.seatNames[winner], points, trickNumber: state.trickNumber },
+      ]
+
+      return {
+        ...state,
+        hands,
+        currentTrick,
+        trickPointsByTeam,
+        trickWinners,
+        log: finalLog,
+        phase: 'trick-complete',
+      }
+    }
+    case 'CLEAR_TRICK': {
+      if (state.phase !== 'trick-complete') return state
+      const winner = state.trickWinners[state.trickWinners.length - 1]
+      const nextTrickNumber = state.trickNumber + 1
+      if (nextTrickNumber >= TRICK_COUNT) {
+        return { ...state, phase: 'complete', currentTrick: [] }
+      }
+      // The winner of the trick just settled leads the next one.
+      return {
+        ...state,
+        phase: 'playing',
+        currentTrick: [],
+        leader: winner,
+        turn: winner,
+        trickNumber: nextTrickNumber,
+      }
+    }
+    default:
+      return state
+  }
+}

--- a/web/src/components/trickPlayTypes.test.ts
+++ b/web/src/components/trickPlayTypes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { Card, Suit } from '../engine/card'
+import { formatTrickPlayLogEntry } from './trickPlayTypes'
+
+describe('formatTrickPlayLogEntry', () => {
+  it('formats a lead card-play entry', () => {
+    const text = formatTrickPlayLogEntry({
+      kind: 'card-play',
+      player: 0,
+      name: 'You',
+      card: new Card(Suit.Hearts, 'A', 1),
+      isLead: true,
+    })
+    expect(text).toBe('You led the A of Hearts')
+  })
+
+  it('formats a follow card-play entry', () => {
+    const text = formatTrickPlayLogEntry({
+      kind: 'card-play',
+      player: 1,
+      name: 'West',
+      card: new Card(Suit.Spades, '9', 1),
+      isLead: false,
+    })
+    expect(text).toBe('West played the 9 of Spades')
+  })
+
+  it('formats a trick-won entry', () => {
+    const text = formatTrickPlayLogEntry({ kind: 'trick-won', player: 2, name: 'Partner', points: 20, trickNumber: 3 })
+    expect(text).toBe('Partner won the trick (20 points)')
+  })
+
+  it('singularizes a 1-point trick', () => {
+    // Not a real scoring outcome (only 0/10-point cards exist) but the
+    // singular/plural branch should still be correct if it ever happens.
+    const text = formatTrickPlayLogEntry({ kind: 'trick-won', player: 3, name: 'East', points: 1, trickNumber: 11 })
+    expect(text).toBe('East won the trick (1 point)')
+  })
+})

--- a/web/src/components/trickPlayTypes.ts
+++ b/web/src/components/trickPlayTypes.ts
@@ -1,0 +1,58 @@
+// Shared data shapes for the trick-play flow (#35). Built from the real
+// engine types (card.ts/round.ts/trick.ts) rather than ad-hoc UI types,
+// same approach auctionTypes.ts took for the auction/pass flow (#34) — so
+// a live Round orchestrator (#47, once it lands) can drive this UI and
+// consume its result without the component/reducer shapes changing.
+
+import type { Card } from '../engine/card'
+import type { TeamId } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+import { SUIT_NAME } from './auctionTypes'
+
+/**
+ * One entry in the trick-play event log. Every card played — human and AI
+ * alike — and every completed trick's outcome gets an entry, so a human
+ * player can follow the hand as it's played instead of just watching
+ * seats/hands change silently underneath them. Same principle
+ * auctionTypes.ts's AuctionLogEntry follows for the auction/pass phase.
+ */
+export type TrickPlayLogEntry =
+  | {
+      readonly kind: 'card-play'
+      readonly player: PlayerIndex
+      readonly name: string
+      readonly card: Card
+      readonly isLead: boolean
+    }
+  | {
+      readonly kind: 'trick-won'
+      readonly player: PlayerIndex
+      readonly name: string
+      readonly points: number
+      readonly trickNumber: number
+    }
+
+/** Renders one log entry as a single line of human-readable text. Pure and
+ * exported on its own so TrickLog's formatting logic is unit-testable
+ * without mounting a component (mirrors formatAuctionLogEntry). */
+export function formatTrickPlayLogEntry(entry: TrickPlayLogEntry): string {
+  switch (entry.kind) {
+    case 'card-play':
+      return `${entry.name} ${entry.isLead ? 'led' : 'played'} the ${entry.card.rank} of ${SUIT_NAME[entry.card.suit]}`
+    case 'trick-won':
+      return `${entry.name} won the trick (${entry.points} point${entry.points === 1 ? '' : 's'})`
+  }
+}
+
+/**
+ * Everything a live Round orchestrator (#47) needs once all 12 tricks have
+ * been played: the trick-point contribution each team makes to
+ * `scoreRound` (round.ts) and the winner of each trick, in order. Mirrors
+ * round.ts's `TrickTakingResult` exactly — same data, just produced one
+ * play at a time (with UI pauses in between) instead of by a single
+ * blocking `playTrickTakingPhase` call.
+ */
+export interface TrickPlayResult {
+  readonly trickPointsByTeam: Record<TeamId, number>
+  readonly trickWinners: readonly PlayerIndex[]
+}


### PR DESCRIPTION
## Summary
- Adds `TrickPlayFlow`, the UI/interaction layer for the trick-taking phase (#35): clickable/highlighted legal-move cards on the human's hand, playing a card into the center trick area, settling a completed trick on its winner, and advancing turn order across all 12 tricks.
- Mirrors the bid/pass flow's structure (PR #44): a reducer-driven state machine (`trickPlayReducer.ts`), plain-data props (`trickPlayTypes.ts`), an orchestrator component (`TrickPlayFlow.tsx`) mounted into the existing `Table` scaffold, and a visible log of every AI action (`TrickLog.tsx`).
- AI plays use the real `chooseLeadCard`/`chooseFollowCard` (`engine/tracker.ts`, #31/#32) — no mock needed here, since #29 has since landed too. Each AI turn resolves after a brief delay (`AI_PLAY_DELAY_MS`), and a completed trick pauses (`TRICK_SETTLE_MS`) with a winner highlight before clearing, so a hand reads as being played rather than the state jumping silently.
- Extends `Table`/`Seat`/`TrickArea` (all additive, optional props) so the human's own hand cards are directly clickable — legal cards highlighted, illegal ones dimmed/disabled — rather than routed through a modal overlay control like the auction's `BiddingControls`/`TrumpSelector`/`PassSelector`, since trick-play only ever needs the human to pick one card from their own hand.
- `TrickPlayFlow` takes post-auction state (hands, trump, bid winner, bid, seat names, scores) as props and fires `onComplete` once with a `TrickPlayResult` (`trickPointsByTeam`/`trickWinners`, mirroring `round.ts`'s `TrickTakingResult`) — everything a future Round orchestrator (#47) needs to feed `scoreRound`. Not wired into `App.tsx`; that end-to-end game-loop wiring is #47's job.

## Test plan
- [x] `npm test` — all tests pass, including a new full-round end-to-end test (`TrickPlayFlow.test.tsx`) that plays a real, unshuffled 48-card deal through all 12 tricks (alternating human clicks with fake-timer-driven AI turns) and asserts the reported trick points sum to the expected 250 (240 point-cards + the 10 last-trick bonus) regardless of who won which trick.
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean.
- [x] Unit tests for `trickPlayReducer` (turn advancement, trick resolution/winner/points, last-trick bonus, settle/clear phase transitions, illegal-action no-ops) and `trickPlayTypes`/`TrickLog` (log formatting/ordering).
- [x] Component tests verifying legal-move highlighting (forced follow-suit card enabled, off-suit card disabled) and that clicking a disabled/illegal card is a no-op.

Closes #35