### PR TITLE
Sort the human player's hand by suit and rank for display

### DIFF
--- a/web/src/components/PassSelector.tsx
+++ b/web/src/components/PassSelector.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { Card } from '../engine/card'
+import { sortHandForDisplay } from '../engine/card'
 import { PlayingCard } from './PlayingCard'
 
 export interface PassSelectorProps {
@@ -33,7 +34,7 @@ export function PassSelector({ hand, count, onConfirm }: PassSelectorProps) {
         Choose {count} cards to pass ({selected.length}/{count} selected)
       </h3>
       <div className="mt-3 flex flex-wrap justify-center gap-1">
-        {hand.map((card) => {
+        {sortHandForDisplay(hand).map((card) => {
           const isSelected = selected.includes(card)
           return (
             <button

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -1,5 +1,5 @@
 import type { Card } from '../engine/card'
-import { type Rank, Suit } from '../engine/card'
+import { type Rank, sortHandForDisplay, Suit } from '../engine/card'
 import { PlayingCard } from './PlayingCard'
 import type { SeatPosition, SeatState } from './tableTypes'
 
@@ -51,7 +51,7 @@ export function Seat({ seat, position, isHuman, isBidWinner, playable }: SeatPro
       </div>
       {isHuman ? (
         <div className="flex flex-wrap justify-center gap-1 overflow-x-auto">
-          {seat.hand.map((card) => {
+          {sortHandForDisplay(seat.hand).map((card) => {
             const cardFace = <PlayingCard suit={card.suit} rank={card.rank} />
             if (!playable) {
               return (

--- a/web/src/engine/card.test.ts
+++ b/web/src/engine/card.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { Card, Deck, RANKS, Suit } from './card'
+import { Card, Deck, RANKS, sortHandForDisplay, Suit } from './card'
 
 describe('Deck', () => {
   it('builds 48 unique cards, two copies of each suit/rank', () => {
@@ -51,5 +51,37 @@ describe('Card.beats', () => {
     const clubNine = new Card(Suit.Clubs, '9', 1)
     expect(spadeAce.beats(clubNine, Suit.Hearts)).toBe(false)
     expect(clubNine.beats(spadeAce, Suit.Hearts)).toBe(false)
+  })
+})
+
+describe('sortHandForDisplay', () => {
+  it('groups by suit (Spades, Diamonds, Clubs, Hearts) then ranks A high to 9 low within each suit', () => {
+    const hand = [
+      new Card(Suit.Hearts, '9', 1),
+      new Card(Suit.Clubs, 'A', 1),
+      new Card(Suit.Spades, 'J', 1),
+      new Card(Suit.Diamonds, '10', 1),
+      new Card(Suit.Hearts, 'A', 1),
+      new Card(Suit.Spades, 'A', 1),
+    ]
+    const sorted = sortHandForDisplay(hand)
+    expect(sorted.map((c) => `${c.rank}${c.suit}`)).toEqual([
+      'AS', 'JS', '10D', 'AC', 'AH', '9H',
+    ])
+  })
+
+  it('does not mutate the input array', () => {
+    const hand = [new Card(Suit.Hearts, '9', 1), new Card(Suit.Spades, 'A', 1)]
+    const original = [...hand]
+    sortHandForDisplay(hand)
+    expect(hand).toEqual(original)
+  })
+
+  it('orders duplicate copies of the same suit/rank deterministically by copyId', () => {
+    const hand = [
+      new Card(Suit.Spades, 'A', 2),
+      new Card(Suit.Spades, 'A', 1),
+    ]
+    expect(sortHandForDisplay(hand).map((c) => c.copyId)).toEqual([1, 2])
   })
 })

--- a/web/src/engine/card.ts
+++ b/web/src/engine/card.ts
@@ -73,6 +73,21 @@ export class Card {
   }
 }
 
+/**
+ * Sort a hand for human display only: grouped by suit (Spades, Diamonds,
+ * Clubs, Hearts — `SUITS` order), highest rank to lowest within each suit
+ * (A, 10, K, Q, J, 9). Purely a UI convenience — game logic never depends
+ * on hand order, so this is safe to apply anywhere a human's own hand
+ * renders without touching gameplay state.
+ */
+export function sortHandForDisplay(hand: readonly Card[]): Card[] {
+  return [...hand].sort((a, b) => {
+    if (a.suit !== b.suit) return SUITS.indexOf(a.suit) - SUITS.indexOf(b.suit)
+    if (a.rankValue !== b.rankValue) return b.rankValue - a.rankValue
+    return a.copyId - b.copyId
+  })
+}
+
 export class Deck {
   cards: Card[]
 


### PR DESCRIPTION
## Summary
Per user feedback: hand cards were rendered in raw deal order (looks random), making a hand hard to scan at a glance.

- Adds `sortHandForDisplay` to `web/src/engine/card.ts`: groups by suit in `SUITS` order (Spades, Diamonds, Clubs, Hearts), then ranks A high to 9 low within each suit (Pinochle's rank order, matching `RANK_VALUE`).
- Display-only — sorts a copy of the hand array, never mutates the underlying game state. Game logic (legal moves, meld scoring, etc.) never depended on hand order to begin with.
- Wired into the two places the human's own hand renders: `Seat.tsx` (table seat, both the plain and clickable/legal-move-highlighted variants) and `PassSelector.tsx` (3-card pass selection).

## Test plan
- [x] `npm test` — 205/205 passing, including 3 new `sortHandForDisplay` tests (suit/rank grouping, no-mutation, deterministic copy ordering)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] Manually verified in the browser: hand now renders grouped by suit (Spades, Diamonds, Clubs, Hearts) in A→9 order within each suit