### PR TITLE
Move Trump to the leftmost position in the scoreboard

### DIFF
--- a/web/src/components/Scoreboard.tsx
+++ b/web/src/components/Scoreboard.tsx
@@ -20,6 +20,12 @@ export function Scoreboard({ scoresByTeam, currentBid, bidWinnerName, trumpSuit 
   return (
     <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-1 bg-green-950 px-4 py-2 text-sm text-white shadow-md">
       <span>
+        Trump:{' '}
+        <span className={`text-lg font-semibold ${trumpColor}`}>
+          {trumpSuit ? SUIT_GLYPH[trumpSuit] : '—'}
+        </span>
+      </span>
+      <span>
         Team A: <span className="font-semibold">{scoresByTeam[0]}</span>
       </span>
       <span>
@@ -28,12 +34,6 @@ export function Scoreboard({ scoresByTeam, currentBid, bidWinnerName, trumpSuit 
       <span>
         Bid: <span className="font-semibold">{currentBid || '—'}</span>
         {bidWinnerName ? ` (${bidWinnerName})` : ''}
-      </span>
-      <span>
-        Trump:{' '}
-        <span className={`text-lg font-semibold ${trumpColor}`}>
-          {trumpSuit ? SUIT_GLYPH[trumpSuit] : '—'}
-        </span>
       </span>
     </div>
   )


### PR DESCRIPTION
## Summary
Per user feedback: reorders `Scoreboard.tsx` so Trump renders first (leftmost), before Team A/Team B/Bid. A fixed leftmost position makes it quick to find at a glance, so no additional "just declared" highlight/marker was added on top of it.

## Test plan
- [x] `npm test` — 205/205 passing (no Scoreboard test exists; this is a pure JSX reorder, no behavior change)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] Manually verified in the browser: Trump now renders leftmost in the scoreboard strip