### PR TITLE
Add an in-game main menu with local autosave

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
-import { GameFlow } from './components/GameFlow'
+import { GameShell } from './components/GameShell'
 
 function App() {
-  return <GameFlow />
+  return <GameShell />
 }
 
 export default App

--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -4,6 +4,7 @@ import { OPENING_BID } from '../engine/card'
 import { PASS_COUNT, choosePassCards } from '../engine/passing'
 import { teamOf, type Hands, type TeamId } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
+import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { AuctionLog } from './AuctionLog'
 import { auctionReducer, initAuctionState } from './auctionReducer'
 import type { AuctionResult } from './auctionTypes'
@@ -25,6 +26,13 @@ export interface AuctionFlowProps {
   humanPlayer: PlayerIndex
   dealer: PlayerIndex
   scoresByTeam: Record<TeamId, number>
+  /** Opens the persistent mid-game menu (#54: New Game / Continue /
+   * Options) — rendered by Table.tsx as a small corner button. Omit to
+   * render without one (e.g. existing tests that don't exercise it). */
+  onOpenMenu?: () => void
+  /** Options toggles (#54) affecting rendering. Defaults to
+   * DEFAULT_OPTIONS (current pre-#54 behavior) when omitted. */
+  options?: GameOptions
   /** Fired once, when both passes have completed, with everything a live
    * Round orchestrator (trick-play, #35) needs to take over. */
   onComplete?: (result: AuctionResult) => void
@@ -39,7 +47,16 @@ export interface AuctionFlowProps {
  * (#29), passing.ts's real choosePassCards) and always log a visible
  * AuctionLog entry — no AI decision happens silently.
  */
-export function AuctionFlow({ initialHands, seatNames, humanPlayer, dealer, scoresByTeam, onComplete }: AuctionFlowProps) {
+export function AuctionFlow({
+  initialHands,
+  seatNames,
+  humanPlayer,
+  dealer,
+  scoresByTeam,
+  onOpenMenu,
+  options = DEFAULT_OPTIONS,
+  onComplete,
+}: AuctionFlowProps) {
   const [state, dispatch] = useReducer(
     auctionReducer,
     undefined,
@@ -127,6 +144,7 @@ export function AuctionFlow({ initialHands, seatNames, humanPlayer, dealer, scor
           minBid={minBid}
           currentBid={state.bidding.currentBid}
           suggestedCeiling={suggestedCeiling}
+          showBaseBidHint={options.showBaseBidHint}
           onBid={(amount) => dispatch({ type: 'BID', player: humanPlayer, amount })}
           onPass={() => dispatch({ type: 'PASS_BID', player: humanPlayer })}
         />
@@ -157,7 +175,15 @@ export function AuctionFlow({ initialHands, seatNames, humanPlayer, dealer, scor
     }
 
     return null
-  }, [state, humanPlayer])
+  }, [state, humanPlayer, options.showBaseBidHint])
 
-  return <Table state={tableState} overlay={overlay} logPanel={<AuctionLog entries={state.log} />} />
+  return (
+    <Table
+      state={tableState}
+      overlay={overlay}
+      logPanel={<AuctionLog entries={state.log} />}
+      onOpenMenu={onOpenMenu}
+      hideOpponentCards={options.hideOpponentCards}
+    />
+  )
 }

--- a/web/src/components/BiddingControls.test.tsx
+++ b/web/src/components/BiddingControls.test.tsx
@@ -50,4 +50,19 @@ describe('BiddingControls', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Pass' }))
     expect(onPass).toHaveBeenCalledOnce()
   })
+
+  it('hides the base-bid hint when showBaseBidHint is false (Options toggle, #54)', () => {
+    render(
+      <BiddingControls
+        minBid={300}
+        currentBid={0}
+        suggestedCeiling={350}
+        showBaseBidHint={false}
+        onBid={() => {}}
+        onPass={() => {}}
+      />,
+    )
+    expect(screen.getByText(/Minimum: 300/)).not.toBeNull()
+    expect(screen.queryByText(/suggests up to/)).toBeNull()
+  })
 })

--- a/web/src/components/BiddingControls.tsx
+++ b/web/src/components/BiddingControls.tsx
@@ -10,6 +10,10 @@ export interface BiddingControlsProps {
   /** Non-binding hint from the human's own hand (bidding.ts's
    * `bestBaseBid`), shown so the bid amount isn't a guess in the dark. */
   suggestedCeiling: number
+  /** Options toggle (#54): whether to show the "Your hand suggests up to
+   * N" sentence at all — players who want to bid on pure judgment can turn
+   * it off. Defaults to true (current/original behavior) when omitted. */
+  showBaseBidHint?: boolean
   onBid: (amount: number) => void
   onPass: () => void
 }
@@ -19,7 +23,14 @@ export interface BiddingControlsProps {
  * props in, `onBid`/`onPass` out — AuctionFlow owns turn order, legality,
  * and what happens next.
  */
-export function BiddingControls({ minBid, currentBid, suggestedCeiling, onBid, onPass }: BiddingControlsProps) {
+export function BiddingControls({
+  minBid,
+  currentBid,
+  suggestedCeiling,
+  showBaseBidHint = true,
+  onBid,
+  onPass,
+}: BiddingControlsProps) {
   const [amount, setAmount] = useState(minBid)
   const isValid = amount >= minBid && amount % 10 === 0
 
@@ -28,7 +39,7 @@ export function BiddingControls({ minBid, currentBid, suggestedCeiling, onBid, o
       <h3 className="text-sm font-semibold">Your bid</h3>
       <p className="mt-1 text-xs text-neutral-600">
         {currentBid > 0 ? `Current bid: ${currentBid}. ` : ''}
-        Minimum: {minBid}. Your hand suggests up to {suggestedCeiling}.
+        Minimum: {minBid}.{showBaseBidHint ? ` Your hand suggests up to ${suggestedCeiling}.` : ''}
       </p>
 
       <div className="mt-3 flex items-center gap-2">

--- a/web/src/components/GameFlow.tsx
+++ b/web/src/components/GameFlow.tsx
@@ -1,16 +1,28 @@
-import { useEffect, useReducer } from 'react'
+import { useCallback, useEffect, useReducer } from 'react'
 import { Deck } from '../engine/card'
 import { MISDEAL_NINE_THRESHOLD, nineCount } from '../engine/misdeal'
 import type { Hands } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
+import { clearSave, saveGame } from '../persistence/gameSave'
+import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { AuctionFlow } from './AuctionFlow'
-import { gameFlowReducer, HUMAN_PLAYER, initGameFlowState, INITIAL_DEALER, SEAT_NAMES } from './gameFlowReducer'
+import type { AuctionResult } from './auctionTypes'
+import {
+  gameFlowReducer,
+  HUMAN_PLAYER,
+  initGameFlowState,
+  INITIAL_DEALER,
+  SEAT_NAMES,
+  type GameFlowState,
+} from './gameFlowReducer'
 import { GameOverScreen } from './GameOverScreen'
 import { MisdealPrompt } from './MisdealPrompt'
 import { RoundSummary } from './RoundSummary'
 import { Table } from './Table'
 import type { TableState } from './tableTypes'
 import { TrickPlayFlow } from './TrickPlayFlow'
+import type { TrickPlayState } from './trickPlayReducer'
+import type { TrickPlayResult } from './trickPlayTypes'
 
 /**
  * Top-level round/game state machine (#47): deal -> misdeal check (house
@@ -25,8 +37,28 @@ import { TrickPlayFlow } from './TrickPlayFlow'
  * AuctionFlow, since a reshuffle has to happen before the auction even
  * starts and AuctionFlow only ever receives an already-finalized hand.
  */
-export function GameFlow() {
-  const [state, dispatch] = useReducer(gameFlowReducer, INITIAL_DEALER, initGameFlowState)
+export interface GameFlowProps {
+  /** Local autosave (#54): resume from a previously saved state (the main
+   * menu's "Continue") instead of starting a fresh deal. Omit to start a
+   * new game via the normal deal -> misdeal-check flow (also what existing
+   * callers/tests that don't know about #54 get). */
+  initialState?: GameFlowState
+  /** Options toggles (#54) affecting rendering. Defaults to
+   * DEFAULT_OPTIONS (current pre-#54 behavior) when omitted. */
+  options?: GameOptions
+  /** Opens the persistent mid-game menu (#54: New Game / Continue /
+   * Options) — threaded down to every Table.tsx render (dealing/misdeal,
+   * auction, trick-play) so a player is never stranded once a round has
+   * started. Omit to render without one. */
+  onOpenMenu?: () => void
+}
+
+export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }: GameFlowProps = {}) {
+  const [state, dispatch] = useReducer(
+    gameFlowReducer,
+    undefined,
+    () => initialState ?? initGameFlowState(INITIAL_DEALER),
+  )
 
   // Deal (or redeal) a fresh shuffled 48-card hand whenever entering the
   // 'dealing' phase — a fresh game start, a misdeal reshuffle, and the next
@@ -39,6 +71,41 @@ export function GameFlow() {
     const hands = deck.deal()
     dispatch({ type: 'HANDS_DEALT', hands })
   }, [state.phase])
+
+  // Local autosave (#54): checkpoint after every state change except
+  // 'dealing' (near-instant and hands are still empty there — the effect
+  // above resolves it before the next paint in practice, so skipping it
+  // just avoids a redundant/incomplete write). Every other phase change is
+  // a natural checkpoint: hands dealt, misdeal resolved, auction complete
+  // (trump/bid known), each trick-play checkpoint (see TRICK_CHECKPOINT
+  // below), round-summary, and game-over.
+  useEffect(() => {
+    if (state.phase === 'dealing') return
+    saveGame(state)
+  }, [state])
+
+  // Stable dispatch-wrapping callbacks (#54): TrickPlayFlow's onCheckpoint
+  // effect has no "already fired" guard — it's meant to fire once per
+  // trick, not once ever — so if this callback got a new identity every
+  // GameFlow render (as an inline arrow function here would), the effect
+  // would re-fire on every render, dispatch again, trigger another render,
+  // and loop forever. useReducer's dispatch is referentially stable across
+  // renders, so wrapping it in useCallback with no other dependencies keeps
+  // these callbacks stable too. AUCTION_COMPLETE/TRICK_COMPLETE don't
+  // strictly need this (their onComplete effects guard against re-firing
+  // with a ref), but it's cheap and keeps the pattern consistent.
+  const handleAuctionComplete = useCallback(
+    (result: AuctionResult) => dispatch({ type: 'AUCTION_COMPLETE', result }),
+    [],
+  )
+  const handleTrickComplete = useCallback(
+    (result: TrickPlayResult) => dispatch({ type: 'TRICK_COMPLETE', result }),
+    [],
+  )
+  const handleTrickCheckpoint = useCallback(
+    (snapshot: TrickPlayState) => dispatch({ type: 'TRICK_CHECKPOINT', snapshot }),
+    [],
+  )
 
   // Misdeal/reshuffle house rule (pinochle_rules.md): check each seat in
   // fixed order (mirrors human_play.py's `_check_misdeal` loop over
@@ -70,7 +137,9 @@ export function GameFlow() {
         humanPlayer={HUMAN_PLAYER}
         dealer={state.dealer}
         scoresByTeam={state.scoresByTeam}
-        onComplete={(result) => dispatch({ type: 'AUCTION_COMPLETE', result })}
+        onOpenMenu={onOpenMenu}
+        options={options}
+        onComplete={handleAuctionComplete}
       />
     )
   }
@@ -86,7 +155,15 @@ export function GameFlow() {
         seatNames={SEAT_NAMES}
         humanPlayer={HUMAN_PLAYER}
         scoresByTeam={state.scoresByTeam}
-        onComplete={(result) => dispatch({ type: 'TRICK_COMPLETE', result })}
+        // Local autosave (#54): resume mid-round from the last checkpoint
+        // when there is one (only set right after LOAD_SAVE resumed a save
+        // straight into this phase — a normal auction handoff clears it),
+        // otherwise TrickPlayFlow deals `hands` out fresh as before.
+        initialState={state.trickPlayCheckpoint ?? undefined}
+        onCheckpoint={handleTrickCheckpoint}
+        onOpenMenu={onOpenMenu}
+        options={options}
+        onComplete={handleTrickComplete}
       />
     )
   }
@@ -99,7 +176,16 @@ export function GameFlow() {
     return (
       <GameOverScreen
         data={state.gameOverData}
-        onNewGame={() => dispatch({ type: 'NEW_GAME', dealer: INITIAL_DEALER })}
+        onNewGame={() => {
+          // Local autosave (#54): the finished game's save would otherwise
+          // briefly linger on disk (the autosave effect above skips writes
+          // while phase === 'dealing', so it isn't overwritten until the
+          // next real checkpoint) — clear it explicitly so a refresh in
+          // that window can't offer "Continue" back into a game that's
+          // already over.
+          clearSave()
+          dispatch({ type: 'NEW_GAME', dealer: INITIAL_DEALER })
+        }}
       />
     )
   }
@@ -132,5 +218,12 @@ export function GameFlow() {
     />
   ) : undefined
 
-  return <Table state={tableState} overlay={overlay} />
+  return (
+    <Table
+      state={tableState}
+      overlay={overlay}
+      onOpenMenu={onOpenMenu}
+      hideOpponentCards={options.hideOpponentCards}
+    />
+  )
 }

--- a/web/src/components/GameShell.test.tsx
+++ b/web/src/components/GameShell.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Card, Deck, Suit } from '../engine/card'
+import { GameShell } from './GameShell'
+
+// Same deterministic-weak-hand approach GameFlow.test.tsx uses: no nines
+// means nobody's misdeal-eligible, so dealing lands straight in the
+// auction (dealer East (3), human (0) bids first).
+function weakHand(): Card[] {
+  return [new Card(Suit.Clubs, 'J', 1)]
+}
+
+function mockDeal(): void {
+  vi.spyOn(Deck.prototype, 'shuffle').mockImplementation(() => {})
+  vi.spyOn(Deck.prototype, 'deal').mockReturnValue([weakHand(), weakHand(), weakHand(), weakHand()])
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  window.localStorage.clear()
+})
+
+describe('GameShell', () => {
+  it('shows the start menu on load with Continue disabled when there is no save', () => {
+    render(<GameShell />)
+    expect(screen.getByText('Pinochle')).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Continue' }).hasAttribute('disabled')).toBe(true)
+  })
+
+  it('New Game deals straight into the auction', async () => {
+    mockDeal()
+    render(<GameShell />)
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+  })
+
+  it('autosaves during play, and a fresh mount can Continue back into it without redealing', async () => {
+    mockDeal()
+    const { unmount } = render(<GameShell />)
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+    unmount()
+
+    render(<GameShell />)
+    const continueButton = screen.getByRole('button', { name: 'Continue' })
+    expect(continueButton.hasAttribute('disabled')).toBe(false)
+    fireEvent.click(continueButton)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+    // Resuming reused the saved state rather than dealing a second time.
+    expect(Deck.prototype.deal).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens the mid-game menu via the persistent menu button, and Continue there just resumes', async () => {
+    mockDeal()
+    render(<GameShell />)
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+    expect(screen.getByText('Pinochle')).not.toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull()
+  })
+
+  it('confirms before New Game discards an in-progress save, and backs off if declined', async () => {
+    mockDeal()
+    render(<GameShell />)
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    expect(confirmSpy).toHaveBeenCalledOnce()
+    // Declined — the menu is still up, nothing was reset.
+    expect(screen.getByText('Pinochle')).not.toBeNull()
+  })
+
+  it('toggling "Hide opponent cards" in Options affects the next game rendered', async () => {
+    mockDeal()
+    render(<GameShell />)
+    fireEvent.click(screen.getByRole('button', { name: 'Options' }))
+    fireEvent.click(screen.getByLabelText('Hide opponent cards'))
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+    expect(screen.queryAllByLabelText('face-down card')).toHaveLength(0)
+  })
+})

--- a/web/src/components/GameShell.tsx
+++ b/web/src/components/GameShell.tsx
@@ -1,0 +1,104 @@
+// Top-level app shell (#54): owns the start-menu / in-game screen split,
+// the mid-game menu and Options overlays, and Options state itself — kept
+// separate from GameFlow.tsx (rather than folded into it) so GameFlow stays
+// exactly what it was before this issue: a pure "play one game" component
+// that existing tests can still render with zero props and get the
+// original straight-into-a-deal behavior. GameShell is the only thing that
+// decides *when* a GameFlow instance exists and what it starts from.
+//
+// New Game forces a genuinely fresh GameFlow instance via a changing
+// `key`, rather than reaching into GameFlow's reducer from outside — same
+// "reducer owns its own state" boundary GameFlow/AuctionFlow/TrickPlayFlow
+// already keep with each other (they only ever hand a result out through an
+// onComplete-style callback, never expose dispatch).
+
+import { useState } from 'react'
+import { clearSave, hasSavedGame, loadGame } from '../persistence/gameSave'
+import { loadOptions, saveOptions, type GameOptions } from '../persistence/options'
+import { GameFlow } from './GameFlow'
+import type { GameFlowState } from './gameFlowReducer'
+import { MainMenu } from './MainMenu'
+import { OptionsPanel } from './OptionsPanel'
+
+type Screen = 'start-menu' | 'game'
+
+export function GameShell() {
+  const [screen, setScreen] = useState<Screen>('start-menu')
+  // Bumped to force GameFlow to unmount/remount with a fresh reducer
+  // instance whenever New Game or Continue (re-)starts play.
+  const [mountKey, setMountKey] = useState(0)
+  const [resumeState, setResumeState] = useState<GameFlowState | null>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [optionsOpen, setOptionsOpen] = useState(false)
+  const [options, setOptions] = useState<GameOptions>(() => loadOptions())
+
+  function startNewGame(): void {
+    if (hasSavedGame() && !window.confirm('Start a new game? Your current saved game will be lost.')) {
+      return
+    }
+    clearSave()
+    setResumeState(null)
+    setMountKey((k) => k + 1)
+    setScreen('game')
+    setMenuOpen(false)
+  }
+
+  function continueGame(): void {
+    if (screen === 'game') {
+      // Already playing (the mid-game menu button opened this) — Continue
+      // just dismisses the menu back to the game in progress.
+      setMenuOpen(false)
+      return
+    }
+    const saved = loadGame()
+    if (!saved) return // Continue is disabled without a save; ignore stray calls.
+    setResumeState(saved)
+    setMountKey((k) => k + 1)
+    setScreen('game')
+  }
+
+  function updateOptions(next: GameOptions): void {
+    setOptions(next)
+    saveOptions(next)
+  }
+
+  if (screen === 'start-menu') {
+    return (
+      <>
+        <MainMenu
+          hasSave={hasSavedGame()}
+          onNewGame={startNewGame}
+          onContinue={continueGame}
+          onOptions={() => setOptionsOpen(true)}
+        />
+        {optionsOpen && (
+          <OptionsPanel options={options} onChange={updateOptions} onClose={() => setOptionsOpen(false)} />
+        )}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <GameFlow
+        key={mountKey}
+        initialState={resumeState ?? undefined}
+        options={options}
+        onOpenMenu={() => setMenuOpen(true)}
+      />
+      {menuOpen && (
+        <MainMenu
+          hasSave={hasSavedGame()}
+          onNewGame={startNewGame}
+          onContinue={continueGame}
+          onOptions={() => setOptionsOpen(true)}
+          onClose={() => setMenuOpen(false)}
+        />
+      )}
+      {optionsOpen && (
+        <OptionsPanel options={options} onChange={updateOptions} onClose={() => setOptionsOpen(false)} />
+      )}
+    </>
+  )
+}
+

--- a/web/src/components/MainMenu.test.tsx
+++ b/web/src/components/MainMenu.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MainMenu } from './MainMenu'
+
+afterEach(cleanup)
+
+describe('MainMenu', () => {
+  it('disables Continue when there is no save', () => {
+    render(<MainMenu hasSave={false} onNewGame={() => {}} onContinue={() => {}} onOptions={() => {}} />)
+    expect(screen.getByRole('button', { name: 'Continue' }).hasAttribute('disabled')).toBe(true)
+  })
+
+  it('enables Continue when a save exists, and calls onContinue when clicked', () => {
+    const onContinue = vi.fn()
+    render(<MainMenu hasSave onNewGame={() => {}} onContinue={onContinue} onOptions={() => {}} />)
+    const button = screen.getByRole('button', { name: 'Continue' })
+    expect(button.hasAttribute('disabled')).toBe(false)
+    fireEvent.click(button)
+    expect(onContinue).toHaveBeenCalledOnce()
+  })
+
+  it('calls onNewGame and onOptions from their respective buttons', () => {
+    const onNewGame = vi.fn()
+    const onOptions = vi.fn()
+    render(<MainMenu hasSave={false} onNewGame={onNewGame} onContinue={() => {}} onOptions={onOptions} />)
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Options' }))
+    expect(onNewGame).toHaveBeenCalledOnce()
+    expect(onOptions).toHaveBeenCalledOnce()
+  })
+
+  it('has no Exit item', () => {
+    render(<MainMenu hasSave onNewGame={() => {}} onContinue={() => {}} onOptions={() => {}} />)
+    expect(screen.queryByText(/exit/i)).toBeNull()
+  })
+
+  it('renders no "back to game" control when onClose is omitted (the full-screen start menu)', () => {
+    render(<MainMenu hasSave={false} onNewGame={() => {}} onContinue={() => {}} onOptions={() => {}} />)
+    expect(screen.queryByText('Back to game')).toBeNull()
+  })
+
+  it('renders a "back to game" control when onClose is provided (the mid-game overlay)', () => {
+    const onClose = vi.fn()
+    render(<MainMenu hasSave={false} onNewGame={() => {}} onContinue={() => {}} onOptions={() => {}} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Back to game'))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/MainMenu.tsx
+++ b/web/src/components/MainMenu.tsx
@@ -1,0 +1,70 @@
+// Main menu (#54): New Game / Continue / Options. Rendered full-screen by
+// GameShell.tsx on load (no save, or the player hasn't chosen yet), and
+// re-rendered as a mid-game overlay (with onClose set) when the player taps
+// Table.tsx's persistent menu button — same three actions either way, so a
+// player is never stranded once a round has started. Deliberately has no
+// "Exit" item: browsers can't reliably self-close a tab from JS, and the
+// primary target (ROADMAP.md) is a home-screen-launched iOS PWA, where
+// there's no "close the app" concept at all.
+
+export interface MainMenuProps {
+  /** Whether a resumable autosave exists — Continue is disabled without one. */
+  hasSave: boolean
+  /** Starts a fresh game. GameShell.tsx confirms with the player first if a
+   * save would be discarded — this callback fires only once that's settled. */
+  onNewGame: () => void
+  /** Resumes the saved game (full-screen context) or just dismisses the
+   * menu back to the game already in progress (mid-game overlay context) —
+   * GameShell.tsx picks the right behavior for each. */
+  onContinue: () => void
+  onOptions: () => void
+  /** Present only for the mid-game overlay — lets the player dismiss the
+   * menu without picking an item. Omitted for the full-screen start menu,
+   * where there's no game in progress yet to go back to. */
+  onClose?: () => void
+}
+
+export function MainMenu({ hasSave, onNewGame, onContinue, onOptions, onClose }: MainMenuProps) {
+  return (
+    <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/70 p-4">
+      <div className="w-full max-w-xs rounded-lg bg-white p-6 text-center text-neutral-900 shadow-xl">
+        <h1 className="text-xl font-bold">Pinochle</h1>
+
+        <div className="mt-6 flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={onNewGame}
+            className="w-full rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900"
+          >
+            New Game
+          </button>
+          <button
+            type="button"
+            disabled={!hasSave}
+            onClick={onContinue}
+            className="w-full rounded bg-neutral-200 px-4 py-2 font-semibold text-neutral-900 hover:bg-neutral-300 disabled:cursor-not-allowed disabled:bg-neutral-100 disabled:text-neutral-400"
+          >
+            Continue
+          </button>
+          <button
+            type="button"
+            onClick={onOptions}
+            className="w-full rounded bg-neutral-200 px-4 py-2 font-semibold text-neutral-900 hover:bg-neutral-300"
+          >
+            Options
+          </button>
+        </div>
+
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="mt-4 text-sm text-neutral-500 hover:text-neutral-700"
+          >
+            Back to game
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/OptionsPanel.test.tsx
+++ b/web/src/components/OptionsPanel.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_OPTIONS } from '../persistence/options'
+import { OptionsPanel } from './OptionsPanel'
+
+afterEach(cleanup)
+
+describe('OptionsPanel', () => {
+  it('reflects the current options in the two checkboxes', () => {
+    render(
+      <OptionsPanel
+        options={{ hideOpponentCards: true, showBaseBidHint: false }}
+        onChange={() => {}}
+        onClose={() => {}}
+      />,
+    )
+    expect((screen.getByLabelText('Hide opponent cards') as HTMLInputElement).checked).toBe(true)
+    expect((screen.getByLabelText('Show base-bid hint') as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('calls onChange with the hideOpponentCards toggle flipped, leaving the other field alone', () => {
+    const onChange = vi.fn()
+    render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={onChange} onClose={() => {}} />)
+    fireEvent.click(screen.getByLabelText('Hide opponent cards'))
+    expect(onChange).toHaveBeenCalledWith({ hideOpponentCards: true, showBaseBidHint: true })
+  })
+
+  it('calls onChange with the showBaseBidHint toggle flipped', () => {
+    const onChange = vi.fn()
+    render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={onChange} onClose={() => {}} />)
+    fireEvent.click(screen.getByLabelText('Show base-bid hint'))
+    expect(onChange).toHaveBeenCalledWith({ hideOpponentCards: false, showBaseBidHint: false })
+  })
+
+  it('calls onClose from the Done button', () => {
+    const onClose = vi.fn()
+    render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={() => {}} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('has no AI-difficulty or bid-window controls yet (explicitly out of scope for #54)', () => {
+    render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={() => {}} onClose={() => {}} />)
+    expect(screen.queryByText(/difficulty/i)).toBeNull()
+    expect(screen.queryByText(/bid window/i)).toBeNull()
+  })
+})

--- a/web/src/components/OptionsPanel.tsx
+++ b/web/src/components/OptionsPanel.tsx
@@ -1,0 +1,57 @@
+// Options panel (#54): exactly two toggles for this issue — hiding
+// opponents' face-down card fans (Seat.tsx) and the base-bid hint
+// (BiddingControls.tsx). Deliberately not here yet: an AI-difficulty picker
+// and a "bid window" hint based on assumed opponent skill, both out of
+// scope for #54 since they depend on AI difficulty tiers that don't exist
+// in the TS engine yet (bidding.ts only has the one Proficient strategy).
+// The layout below leaves room for those as a later addition rather than
+// stubbing UI for them now.
+
+import type { GameOptions } from '../persistence/options'
+
+export interface OptionsPanelProps {
+  options: GameOptions
+  onChange: (options: GameOptions) => void
+  onClose: () => void
+}
+
+export function OptionsPanel({ options, onChange, onClose }: OptionsPanelProps) {
+  return (
+    <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/70 p-4">
+      <div className="w-full max-w-xs rounded-lg bg-white p-6 text-neutral-900 shadow-xl">
+        <h2 className="text-lg font-bold">Options</h2>
+
+        <div className="mt-4 flex flex-col gap-3 text-left text-sm">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={options.hideOpponentCards}
+              onChange={(e) => onChange({ ...options, hideOpponentCards: e.target.checked })}
+            />
+            Hide opponent cards
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={options.showBaseBidHint}
+              onChange={(e) => onChange({ ...options, showBaseBidHint: e.target.checked })}
+            />
+            Show base-bid hint
+          </label>
+        </div>
+
+        {/* Room for an AI-difficulty picker and a bid-window hint once AI
+            difficulty tiers exist — see the comment at the top of this
+            file. Deliberately left blank, not stubbed. */}
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-6 w-full rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/Seat.test.tsx
+++ b/web/src/components/Seat.test.tsx
@@ -1,0 +1,36 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Card, Suit } from '../engine/card'
+import { Seat } from './Seat'
+import type { SeatState } from './tableTypes'
+
+afterEach(cleanup)
+
+function opponentSeat(cardCount: number): SeatState {
+  return {
+    player: 1,
+    name: 'West',
+    hand: Array.from({ length: cardCount }, () => new Card(Suit.Spades, '9', 1)),
+  }
+}
+
+describe('Seat', () => {
+  it('renders a face-down fan for an AI seat by default', () => {
+    render(<Seat seat={opponentSeat(3)} position="left" isHuman={false} isBidWinner={false} />)
+    expect(screen.getAllByLabelText('face-down card')).toHaveLength(3)
+    expect(screen.getByText('West')).not.toBeNull()
+  })
+
+  it('omits the face-down fan when hideOpponentHand is set (Options toggle, #54)', () => {
+    render(<Seat seat={opponentSeat(3)} position="left" isHuman={false} isBidWinner={false} hideOpponentHand />)
+    expect(screen.queryAllByLabelText('face-down card')).toHaveLength(0)
+    // The seat label/count stays visible — only the card fan is hidden.
+    expect(screen.getByText('West')).not.toBeNull()
+  })
+
+  it('never hides the human seat, regardless of hideOpponentHand', () => {
+    const humanSeat: SeatState = { player: 0, name: 'You', hand: [new Card(Suit.Hearts, 'A', 1)] }
+    render(<Seat seat={humanSeat} position="bottom" isHuman isBidWinner={false} hideOpponentHand />)
+    expect(screen.getByLabelText('A of H')).not.toBeNull()
+  })
+})

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -14,6 +14,10 @@ export interface SeatProps {
    * Omit entirely to render the hand as plain, non-interactive cards (the
    * auction phases, or any AI seat). */
   playable?: { legalCards: readonly Card[]; onPlay: (card: Card) => void }
+  /** Options toggle (#54): when true, an AI seat renders only its name/card
+   * count — the face-down fan is skipped entirely to save screen space.
+   * No-op for the human seat, which always renders its real hand. */
+  hideOpponentHand?: boolean
 }
 
 // Placeholder face used for AI seats' face-down fan. The suit/rank props
@@ -35,7 +39,7 @@ const POSITION_LAYOUT: Record<SeatPosition, string> = {
  * sized to their card count — never the actual cards, since an AI's hand
  * is hidden information from the human player's point of view.
  */
-export function Seat({ seat, position, isHuman, isBidWinner, playable }: SeatProps) {
+export function Seat({ seat, position, isHuman, isBidWinner, playable, hideOpponentHand }: SeatProps) {
   return (
     <div className={`flex gap-1 ${POSITION_LAYOUT[position]}`}>
       <div className="flex items-center gap-2 text-sm font-medium">
@@ -79,7 +83,7 @@ export function Seat({ seat, position, isHuman, isBidWinner, playable }: SeatPro
             )
           })}
         </div>
-      ) : (
+      ) : hideOpponentHand ? null : (
         <div className="flex overflow-x-auto px-2">
           {seat.hand.map((_, i) => (
             <PlayingCard

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -13,6 +13,16 @@ export interface TableProps {
   /** Corner slot for a non-blocking feed (the auction/pass event log, #34)
    * that should stay visible alongside the table rather than covering it. */
   logPanel?: ReactNode
+  /** Local autosave (#54): opens the persistent mid-game menu (New Game /
+   * Continue / Options) so a player is never stranded once a round has
+   * started. Rendered as a small corner button; omitted entirely (no
+   * button) when not provided. */
+  onOpenMenu?: () => void
+  /** Options toggle (#54): when true, don't render the West/Partner/East
+   * face-down card fans at all — just the seat label and board, to save
+   * screen space. UI-only preference, not game state, so it lives here
+   * rather than on TableState. */
+  hideOpponentCards?: boolean
 }
 
 const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
@@ -28,13 +38,23 @@ const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
  * and trick-play controls (separate issues) will mount into this shell,
  * most likely inside/near the human seat and the TrickArea respectively.
  */
-export function Table({ state, overlay, logPanel }: TableProps) {
+export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards }: TableProps) {
   const { seats, humanPlayer, trick, trumpSuit, currentBid, bidWinner, scoresByTeam, humanPlayable, trickWinner } =
     state
   const bidWinnerSeat = bidWinner === null ? undefined : seats.find((seat) => seat.player === bidWinner)
 
   return (
     <div className="relative flex min-h-svh flex-col bg-green-900 text-white">
+      {onOpenMenu && (
+        <button
+          type="button"
+          onClick={onOpenMenu}
+          aria-label="Open menu"
+          className="absolute top-2 left-2 z-10 rounded bg-black/40 px-2 py-1 text-xs font-semibold text-white hover:bg-black/60"
+        >
+          ☰ Menu
+        </button>
+      )}
       <Scoreboard
         scoresByTeam={scoresByTeam}
         currentBid={currentBid}
@@ -53,6 +73,7 @@ export function Table({ state, overlay, logPanel }: TableProps) {
               isHuman={seat.player === humanPlayer}
               isBidWinner={seat.player === bidWinner}
               playable={seat.player === humanPlayer ? humanPlayable : undefined}
+              hideOpponentHand={hideOpponentCards}
             />
           </div>
         ))}

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -3,10 +3,17 @@ import type { Card, Suit } from '../engine/card'
 import type { Hands, TeamId } from '../engine/round'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from '../engine/tracker'
 import type { PlayerIndex } from '../engine/trick'
+import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { Table } from './Table'
 import type { TableState } from './tableTypes'
 import { TrickLog } from './TrickLog'
-import { buildTrick, initTrickPlayState, teammatesOf, trickPlayReducer } from './trickPlayReducer'
+import {
+  buildTrick,
+  initTrickPlayState,
+  teammatesOf,
+  trickPlayReducer,
+  type TrickPlayState,
+} from './trickPlayReducer'
 import type { TrickPlayResult } from './trickPlayTypes'
 
 export interface TrickPlayFlowProps {
@@ -19,6 +26,22 @@ export interface TrickPlayFlowProps {
   seatNames: Record<PlayerIndex, string>
   humanPlayer: PlayerIndex
   scoresByTeam: Record<TeamId, number>
+  /** Local autosave (#54): resume from a saved trick-play checkpoint
+   * (GameFlowState.trickPlayCheckpoint) instead of dealing out `hands`
+   * fresh via initTrickPlayState. Only ever set by GameFlow.tsx's "Continue"
+   * path — a normal auction-to-trick-play handoff omits this. */
+  initialState?: TrickPlayState
+  /** Local autosave (#54): fired after each completed trick (never
+   * mid-trick or mid-AI-delay) with the current TrickPlayState, so
+   * GameFlow.tsx can checkpoint it — see GameFlowState.trickPlayCheckpoint. */
+  onCheckpoint?: (state: TrickPlayState) => void
+  /** Opens the persistent mid-game menu (#54: New Game / Continue /
+   * Options) — rendered by Table.tsx as a small corner button. Omit to
+   * render without one (e.g. existing tests that don't exercise it). */
+  onOpenMenu?: () => void
+  /** Options toggles (#54) affecting rendering. Defaults to
+   * DEFAULT_OPTIONS (current pre-#54 behavior) when omitted. */
+  options?: GameOptions
   /** Fired once, when all 12 tricks have been played, with the trick-point
    * contribution each team makes to a live Round orchestrator's (#47)
    * `scoreRound` call. */
@@ -57,12 +80,16 @@ export function TrickPlayFlow({
   seatNames,
   humanPlayer,
   scoresByTeam,
+  initialState,
+  onCheckpoint,
+  onOpenMenu,
+  options = DEFAULT_OPTIONS,
   onComplete,
 }: TrickPlayFlowProps) {
   const [state, dispatch] = useReducer(
     trickPlayReducer,
     undefined,
-    () => initTrickPlayState(hands, trumpSuit, bidWinner, seatNames),
+    () => initialState ?? initTrickPlayState(hands, trumpSuit, bidWinner, seatNames),
   )
   // Accumulates every card played so far this round (tracker.ts's
   // PlayTracker) — mutated directly alongside each PLAY_CARD dispatch
@@ -106,6 +133,16 @@ export function TrickPlayFlow({
     onComplete?.({ trickPointsByTeam: state.trickPointsByTeam, trickWinners: state.trickWinners })
   }, [state, onComplete])
 
+  // Local autosave (#54): checkpoint after each completed trick — i.e.
+  // whenever currentTrick is empty (a fresh trick just started, or all 12
+  // are done). Deliberately excludes mid-trick states (1-3 cards played)
+  // and the 'trick-complete' settle pause (currentTrick still has all 4
+  // cards until CLEAR_TRICK fires) — "not mid-animation", per #54.
+  useEffect(() => {
+    if (state.currentTrick.length > 0) return
+    onCheckpoint?.(state)
+  }, [state, onCheckpoint])
+
   const legalMovesForHuman = useMemo(() => {
     if (state.phase !== 'playing' || state.turn !== humanPlayer) return null
     const trick = buildTrick(state.trumpSuit, state.currentTrick)
@@ -138,5 +175,12 @@ export function TrickPlayFlow({
     }
   }, [state, seatNames, humanPlayer, bid, scoresByTeam, legalMovesForHuman])
 
-  return <Table state={tableState} logPanel={<TrickLog entries={state.log} />} />
+  return (
+    <Table
+      state={tableState}
+      logPanel={<TrickLog entries={state.log} />}
+      onOpenMenu={onOpenMenu}
+      hideOpponentCards={options.hideOpponentCards}
+    />
+  )
 }

--- a/web/src/components/gameFlowReducer.ts
+++ b/web/src/components/gameFlowReducer.ts
@@ -21,6 +21,7 @@ import { scoreRound, teamOf, type Hands, type TeamId } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
 import type { AuctionResult } from './auctionTypes'
 import type { GameOverData, RoundSummaryData } from './scoreTypes'
+import type { TrickPlayState } from './trickPlayReducer'
 import type { TrickPlayResult } from './trickPlayTypes'
 
 export type GameFlowPhase =
@@ -44,6 +45,14 @@ export interface GameFlowState {
   readonly auctionResult: AuctionResult | null
   readonly roundSummary: RoundSummaryData | null
   readonly gameOverData: GameOverData | null
+  /** Local autosave (#54): a snapshot of TrickPlayFlow's internal state,
+   * taken after each completed trick (never mid-trick/mid-AI-delay — see
+   * TrickPlayFlow.tsx's onCheckpoint). null outside the trick-play phase.
+   * On resume, GameFlow.tsx passes this to TrickPlayFlow as its
+   * `initialState`, bypassing the normal from-scratch deal-based init so a
+   * reload lands back on the exact trick in progress rather than the start
+   * of the round. */
+  readonly trickPlayCheckpoint: TrickPlayState | null
 }
 
 export type GameFlowAction =
@@ -54,6 +63,14 @@ export type GameFlowAction =
   | { readonly type: 'TRICK_COMPLETE'; readonly result: TrickPlayResult }
   | { readonly type: 'CONTINUE_ROUND' }
   | { readonly type: 'NEW_GAME'; readonly dealer: PlayerIndex }
+  /** Local autosave (#54): records a trick-play checkpoint (see
+   * GameFlowState.trickPlayCheckpoint) as trick-play progresses. */
+  | { readonly type: 'TRICK_CHECKPOINT'; readonly snapshot: TrickPlayState }
+  /** Local autosave (#54): replaces the whole state with a previously
+   * saved one (the main menu's "Continue"). A plain assignment rather than
+   * a merge — resuming should reproduce the saved game exactly, not layer
+   * onto whatever the reducer happened to be initialized with. */
+  | { readonly type: 'LOAD_SAVE'; readonly state: GameFlowState }
 
 // Static table config GameFlow.tsx renders with — split out here (rather
 // than exported alongside the component) so GameFlow.tsx only exports the
@@ -81,6 +98,7 @@ export function initGameFlowState(dealer: PlayerIndex): GameFlowState {
     auctionResult: null,
     roundSummary: null,
     gameOverData: null,
+    trickPlayCheckpoint: null,
   }
 }
 
@@ -110,6 +128,7 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         phase: 'misdeal-check',
         auctionResult: null,
         roundSummary: null,
+        trickPlayCheckpoint: null,
       }
     }
     case 'MISDEAL_ADVANCE': {
@@ -126,7 +145,11 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
     }
     case 'AUCTION_COMPLETE': {
       if (state.phase !== 'auction') return state
-      return { ...state, phase: 'trick-play', auctionResult: action.result }
+      // trickPlayCheckpoint is cleared (not carried over) here: this is a
+      // genuinely fresh trick-play phase driven by a real auction just
+      // finishing, not a resume-from-save — TrickPlayFlow.tsx will mount
+      // and re-checkpoint at trick 0 on its own once it does.
+      return { ...state, phase: 'trick-play', auctionResult: action.result, trickPlayCheckpoint: null }
     }
     case 'TRICK_COMPLETE': {
       if (state.phase !== 'trick-play' || state.auctionResult === null) return state
@@ -151,7 +174,13 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         bid,
         cumulativeScoresByTeam,
       }
-      return { ...state, phase: 'round-summary', roundSummary, scoresByTeam: cumulativeScoresByTeam }
+      return {
+        ...state,
+        phase: 'round-summary',
+        roundSummary,
+        scoresByTeam: cumulativeScoresByTeam,
+        trickPlayCheckpoint: null,
+      }
     }
     case 'CONTINUE_ROUND': {
       if (state.phase !== 'round-summary' || state.roundSummary === null) return state
@@ -180,7 +209,15 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         auctionResult: null,
         roundSummary: null,
         gameOverData: null,
+        trickPlayCheckpoint: null,
       }
+    }
+    case 'TRICK_CHECKPOINT': {
+      if (state.phase !== 'trick-play') return state
+      return { ...state, trickPlayCheckpoint: action.snapshot }
+    }
+    case 'LOAD_SAVE': {
+      return action.state
     }
     default:
       return state

--- a/web/src/persistence/gameSave.test.ts
+++ b/web/src/persistence/gameSave.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { Card, Suit } from '../engine/card'
+import type { GameFlowState } from '../components/gameFlowReducer'
+import { initGameFlowState } from '../components/gameFlowReducer'
+import { initTrickPlayState, trickPlayReducer } from '../components/trickPlayReducer'
+import type { AuctionResult } from '../components/auctionTypes'
+import { clearSave, hasSavedGame, loadGame, saveGame } from './gameSave'
+
+const SEAT_NAMES = { 0: 'You', 1: 'West', 2: 'Partner', 3: 'East' } as const
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+describe('game save persistence', () => {
+  it('reports no save and loads null when nothing has been saved yet', () => {
+    expect(hasSavedGame()).toBe(false)
+    expect(loadGame()).toBeNull()
+  })
+
+  it('round-trips a simple in-auction state, reviving real Card instances', () => {
+    const state: GameFlowState = {
+      ...initGameFlowState(3),
+      phase: 'auction',
+      hands: [
+        [new Card(Suit.Hearts, 'A', 1), new Card(Suit.Spades, '9', 1)],
+        [],
+        [],
+        [],
+      ],
+    }
+    saveGame(state)
+
+    expect(hasSavedGame()).toBe(true)
+    const loaded = loadGame()
+    expect(loaded).not.toBeNull()
+    expect(loaded!.phase).toBe('auction')
+    expect(loaded!.dealer).toBe(3)
+
+    // The revived card is a real Card instance — its class methods work,
+    // not just its plain suit/rank/copyId data.
+    const revivedCard = loaded!.hands[0][0]
+    expect(revivedCard).toBeInstanceOf(Card)
+    expect(revivedCard.rankValue).toBe(new Card(Suit.Hearts, 'A', 1).rankValue)
+    expect(revivedCard.equals(new Card(Suit.Hearts, 'A', 1))).toBe(true)
+    expect(revivedCard.toString()).toBe('AH_1')
+  })
+
+  it('round-trips an auctionResult, reviving its hands too', () => {
+    const auctionResult: AuctionResult = {
+      hands: [
+        [new Card(Suit.Diamonds, 'K', 2)],
+        [],
+        [],
+        [],
+      ],
+      trumpSuit: Suit.Diamonds,
+      bidWinner: 0,
+      bid: 320,
+    }
+    const state: GameFlowState = { ...initGameFlowState(3), phase: 'trick-play', auctionResult }
+    saveGame(state)
+
+    const loaded = loadGame()
+    expect(loaded!.auctionResult).not.toBeNull()
+    expect(loaded!.auctionResult!.trumpSuit).toBe(Suit.Diamonds)
+    const revived = loaded!.auctionResult!.hands[0][0]
+    expect(revived).toBeInstanceOf(Card)
+    expect(revived.beats(new Card(Suit.Diamonds, 'Q', 1), Suit.Diamonds)).toBe(true)
+  })
+
+  it('round-trips a trick-play checkpoint (trick-in-progress state), reviving cards in hands, currentTrick, and the log', () => {
+    // Drive a real trick to completion via trickPlayReducer, the same way
+    // TrickPlayFlow.tsx's onCheckpoint would capture state after the
+    // trick clears — this is exactly the shape GameFlowState.trickPlayCheckpoint holds.
+    const hands = [
+      [new Card(Suit.Hearts, 'A', 1)],
+      [new Card(Suit.Hearts, '9', 1)],
+      [new Card(Suit.Clubs, '9', 1)],
+      [new Card(Suit.Diamonds, '9', 1)],
+    ] as [Card[], Card[], Card[], Card[]]
+    let trickState = initTrickPlayState(hands, Suit.Spades, 1, SEAT_NAMES)
+    trickState = trickPlayReducer(trickState, { type: 'PLAY_CARD', player: 1, card: hands[1][0] })
+    trickState = trickPlayReducer(trickState, { type: 'PLAY_CARD', player: 2, card: hands[2][0] })
+    trickState = trickPlayReducer(trickState, { type: 'PLAY_CARD', player: 3, card: hands[3][0] })
+    trickState = trickPlayReducer(trickState, { type: 'PLAY_CARD', player: 0, card: hands[0][0] })
+    expect(trickState.phase).toBe('trick-complete')
+    trickState = trickPlayReducer(trickState, { type: 'CLEAR_TRICK' })
+    // A round is 12 tricks; only one was played above, so this just moves
+    // on to trick 2 rather than completing the whole round.
+    expect(trickState.phase).toBe('playing')
+    expect(trickState.trickNumber).toBe(1)
+
+    const state: GameFlowState = {
+      ...initGameFlowState(3),
+      phase: 'trick-play',
+      auctionResult: { hands, trumpSuit: Suit.Spades, bidWinner: 1, bid: 300 },
+      trickPlayCheckpoint: trickState,
+    }
+    saveGame(state)
+
+    const loaded = loadGame()!
+    const checkpoint = loaded.trickPlayCheckpoint!
+    expect(checkpoint).not.toBeNull()
+    expect(checkpoint.trickWinners).toEqual([0]) // human's Ace of Hearts wins
+    expect(checkpoint.log.length).toBeGreaterThan(0)
+
+    const cardPlayEntry = checkpoint.log.find((e) => e.kind === 'card-play')!
+    expect(cardPlayEntry.card).toBeInstanceOf(Card)
+    // All hands are now empty (the single card in each was played), but the
+    // reviver still runs over an empty array without error.
+    expect(checkpoint.hands.every((h) => h.length === 0)).toBe(true)
+  })
+
+  it('clearSave removes the save', () => {
+    saveGame(initGameFlowState(3))
+    expect(hasSavedGame()).toBe(true)
+    clearSave()
+    expect(hasSavedGame()).toBe(false)
+  })
+
+  it('treats corrupt JSON as no save', () => {
+    window.localStorage.setItem('pinochle:save:v1', '{not json')
+    expect(loadGame()).toBeNull()
+  })
+
+  it('treats a save from an unrecognized version as no save', () => {
+    window.localStorage.setItem(
+      'pinochle:save:v1',
+      JSON.stringify({ version: 999, state: initGameFlowState(3) }),
+    )
+    expect(loadGame()).toBeNull()
+  })
+})

--- a/web/src/persistence/gameSave.ts
+++ b/web/src/persistence/gameSave.ts
@@ -1,0 +1,134 @@
+// Local autosave (#54): persists enough of gameFlowReducer's state to
+// resume a game after a page reload — hands, scores, dealer, phase, trump,
+// bid, and trick-in-progress state (GameFlowState.trickPlayCheckpoint, a
+// TrickPlayState snapshot taken after each completed trick — never
+// mid-trick or mid-AI-delay, see TrickPlayFlow.tsx's onCheckpoint). Saved
+// to localStorage on this device only — this is an autosave, not
+// cross-device sync.
+//
+// Card instances don't survive a JSON.stringify/JSON.parse round trip as
+// real Card objects: JSON.parse hands back a plain {suit,rank,copyId}
+// object, missing Card's rankValue getter and its equals/beats/toString
+// methods that engine code (and reference-equality checks like
+// trickPlayReducer's PLAY_CARD, which removes a played card from a hand
+// via `c !== card`) depend on. Saving is safe as plain JSON.stringify
+// (Card's own enumerable fields already serialize correctly); loading
+// walks the parsed tree and reconstructs real Card instances everywhere
+// one appears, mirroring the exact shapes gameFlowReducer.ts /
+// trickPlayReducer.ts produce.
+
+import type { GameFlowState } from '../components/gameFlowReducer'
+import type { TrickPlayState } from '../components/trickPlayReducer'
+import type { TrickPlayLogEntry } from '../components/trickPlayTypes'
+import type { AuctionResult } from '../components/auctionTypes'
+import { Card, type Rank, type Suit } from '../engine/card'
+import type { Hands } from '../engine/round'
+import type { TrickPlay } from '../engine/trick'
+
+const SAVE_KEY = 'pinochle:save:v1'
+const SAVE_VERSION = 1
+
+interface SavedGame {
+  readonly version: number
+  readonly state: GameFlowState
+}
+
+/** True if a resumable save is present and parses — the main menu's
+ * "Continue" is only enabled when this is true. */
+export function hasSavedGame(): boolean {
+  return loadGame() !== null
+}
+
+/** Persists a checkpoint of `state` to localStorage. Swallows write
+ * failures (quota, private-browsing restrictions, no `window`) — a missed
+ * autosave is never worth crashing the game over. */
+export function saveGame(state: GameFlowState): void {
+  try {
+    const payload: SavedGame = { version: SAVE_VERSION, state }
+    window.localStorage.setItem(SAVE_KEY, JSON.stringify(payload))
+  } catch {
+    // see above
+  }
+}
+
+/** Reads and reconstructs the saved game, or null if there isn't one, it's
+ * from an incompatible version, or it fails to parse — never throws, so a
+ * corrupt/stale save just falls back to "no save" instead of breaking the
+ * main menu. */
+export function loadGame(): GameFlowState | null {
+  try {
+    const raw = window.localStorage.getItem(SAVE_KEY)
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (!isSavedGameShape(parsed) || parsed.version !== SAVE_VERSION) return null
+    return reviveGameFlowState(parsed.state)
+  } catch {
+    return null
+  }
+}
+
+/** Clears the save — New Game discards whatever was there. */
+export function clearSave(): void {
+  try {
+    window.localStorage.removeItem(SAVE_KEY)
+  } catch {
+    // see saveGame
+  }
+}
+
+function isSavedGameShape(value: unknown): value is SavedGame {
+  return typeof value === 'object' && value !== null && 'version' in value && 'state' in value
+}
+
+// ---- Card reconstruction ---------------------------------------------
+// JSON.parse only ever hands back plain data — these functions are the
+// only place a save turns that plain data back into real class instances.
+
+interface PlainCard {
+  readonly suit: Suit
+  readonly rank: Rank
+  readonly copyId: 1 | 2
+}
+
+function reviveCard(card: PlainCard): Card {
+  return new Card(card.suit, card.rank, card.copyId)
+}
+
+function reviveHands(hands: Hands): Hands {
+  return hands.map((hand) => hand.map((c) => reviveCard(c as unknown as PlainCard))) as Hands
+}
+
+function reviveTrickPlays(plays: readonly TrickPlay[]): TrickPlay[] {
+  return plays.map((p) => ({ player: p.player, card: reviveCard(p.card as unknown as PlainCard) }))
+}
+
+function reviveTrickPlayLog(log: readonly TrickPlayLogEntry[]): TrickPlayLogEntry[] {
+  return log.map((entry) =>
+    entry.kind === 'card-play' ? { ...entry, card: reviveCard(entry.card as unknown as PlainCard) } : entry,
+  )
+}
+
+function reviveTrickPlayState(snapshot: TrickPlayState): TrickPlayState {
+  return {
+    ...snapshot,
+    hands: reviveHands(snapshot.hands),
+    currentTrick: reviveTrickPlays(snapshot.currentTrick),
+    log: reviveTrickPlayLog(snapshot.log),
+  }
+}
+
+function reviveAuctionResult(result: AuctionResult): AuctionResult {
+  return {
+    ...result,
+    hands: reviveHands(result.hands as unknown as Hands) as unknown as AuctionResult['hands'],
+  }
+}
+
+function reviveGameFlowState(state: GameFlowState): GameFlowState {
+  return {
+    ...state,
+    hands: reviveHands(state.hands),
+    auctionResult: state.auctionResult ? reviveAuctionResult(state.auctionResult) : null,
+    trickPlayCheckpoint: state.trickPlayCheckpoint ? reviveTrickPlayState(state.trickPlayCheckpoint) : null,
+  }
+}

--- a/web/src/persistence/options.test.ts
+++ b/web/src/persistence/options.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { DEFAULT_OPTIONS, loadOptions, saveOptions } from './options'
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+describe('options persistence', () => {
+  it('falls back to DEFAULT_OPTIONS when nothing has been saved yet', () => {
+    expect(loadOptions()).toEqual(DEFAULT_OPTIONS)
+  })
+
+  it('round-trips a saved options value', () => {
+    saveOptions({ hideOpponentCards: true, showBaseBidHint: false })
+    expect(loadOptions()).toEqual({ hideOpponentCards: true, showBaseBidHint: false })
+  })
+
+  it('falls back to DEFAULT_OPTIONS on corrupt JSON', () => {
+    window.localStorage.setItem('pinochle:options:v1', '{not json')
+    expect(loadOptions()).toEqual(DEFAULT_OPTIONS)
+  })
+
+  it('fills in missing/malformed fields from DEFAULT_OPTIONS rather than failing outright', () => {
+    window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ hideOpponentCards: true }))
+    expect(loadOptions()).toEqual({ hideOpponentCards: true, showBaseBidHint: true })
+
+    window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ showBaseBidHint: 'nope' }))
+    expect(loadOptions()).toEqual(DEFAULT_OPTIONS)
+  })
+})

--- a/web/src/persistence/options.ts
+++ b/web/src/persistence/options.ts
@@ -1,0 +1,57 @@
+// Options toggles (#54), persisted separately from the game-state save
+// (gameSave.ts) since they're a standing preference rather than part of
+// any one game's progress — New Game/Continue never touch these, only the
+// Options panel does.
+
+const OPTIONS_KEY = 'pinochle:options:v1'
+
+export interface GameOptions {
+  /** Hide the West/Partner/East face-down card fans (Seat.tsx) entirely —
+   * just player + board, to save screen space. Off (fans shown) by
+   * default, matching current behavior before this option existed. */
+  readonly hideOpponentCards: boolean
+  /** Show BiddingControls' "Your hand suggests up to N" hint during the
+   * human's bidding turn. On by default, matching current behavior. */
+  readonly showBaseBidHint: boolean
+  // Deliberately not here yet (#54 scope): an AI-difficulty picker and a
+  // "bid window" hint based on assumed opponent skill. Both depend on AI
+  // difficulty tiers that don't exist in the TS engine yet — bidding.ts
+  // only has the one Proficient strategy. OptionsPanel.tsx leaves layout
+  // room for these; this type just doesn't carry them yet.
+}
+
+export const DEFAULT_OPTIONS: GameOptions = {
+  hideOpponentCards: false,
+  showBaseBidHint: true,
+}
+
+/** Reads saved options from localStorage, falling back to DEFAULT_OPTIONS
+ * (whole-object or per-field) if nothing's saved yet or the saved value is
+ * corrupt/unrecognized — never throws. */
+export function loadOptions(): GameOptions {
+  try {
+    const raw = window.localStorage.getItem(OPTIONS_KEY)
+    if (!raw) return DEFAULT_OPTIONS
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return DEFAULT_OPTIONS
+    const { hideOpponentCards, showBaseBidHint } = parsed as Partial<GameOptions>
+    return {
+      hideOpponentCards:
+        typeof hideOpponentCards === 'boolean' ? hideOpponentCards : DEFAULT_OPTIONS.hideOpponentCards,
+      showBaseBidHint: typeof showBaseBidHint === 'boolean' ? showBaseBidHint : DEFAULT_OPTIONS.showBaseBidHint,
+    }
+  } catch {
+    return DEFAULT_OPTIONS
+  }
+}
+
+/** Persists options to localStorage. Swallows write failures (quota,
+ * private-browsing restrictions) — an unsaved preference toggle is never
+ * worth crashing the game over. */
+export function saveOptions(options: GameOptions): void {
+  try {
+    window.localStorage.setItem(OPTIONS_KEY, JSON.stringify(options))
+  } catch {
+    // see above
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a start/pause menu (`MainMenu.tsx`) with New Game / Continue / Options — no Exit item (confirmed out of scope in #54: browsers can't reliably self-close a tab, and the target iOS-PWA platform has no "close the app" concept).
- Adds a persistent mid-game menu button (rendered by `Table.tsx`, threaded through `GameFlow`/`AuctionFlow`/`TrickPlayFlow`) so a player is never stranded once a round starts.
- Adds `localStorage` autosave (`persistence/gameSave.ts`) of `gameFlowReducer`'s state at natural checkpoints — hands dealt, misdeal resolved, auction complete, each completed trick (`GameFlowState.trickPlayCheckpoint`, fed by a new `onCheckpoint` callback on `TrickPlayFlow`), round-summary, and game-over. Never mid-trick or mid-AI-delay.
- Adds an Options panel (`OptionsPanel.tsx`) with exactly two toggles, persisted separately (`persistence/options.ts`): **Hide opponent cards** (skips the face-down fan in `Seat.tsx`) and **Show base-bid hint** (`BiddingControls.tsx`'s "Your hand suggests up to N" sentence). Layout leaves room for an AI-difficulty picker / bid-window hint later, per #54 — no stub UI added since those AI tiers don't exist yet.
- New `GameShell.tsx` owns the start-menu/in-game split and the mid-game overlays; `GameFlow.tsx` itself is unchanged in default behavior (still renders straight into a fresh deal with zero props), so no existing tests needed rewiring.

Closes #54

## Test plan
- [x] `npm test` — 237/237 passing (added `gameSave.test.ts`, `options.test.ts`, `MainMenu.test.tsx`, `OptionsPanel.test.tsx`, `GameShell.test.tsx`, `Seat.test.tsx`, plus a `BiddingControls` case)
- [x] `npx tsc -b` clean, `npx oxlint` clean
- [x] Manual browser verification: started the dev server, played into an auction and a full trick, confirmed the mid-game menu button, toggled both Options live (opponent-card fan and bid hint both react immediately), refreshed mid-round, and confirmed Continue resumed the exact hand/trump/bid/trick-log state and play continued normally afterward
- [x] Caught and fixed a real infinite-render-loop bug during manual testing (inline `onCheckpoint` callback recreated every render, re-triggering the un-guarded per-trick checkpoint effect) — fixed with `useCallback` in `GameFlow.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)