### PR TITLE
Add tournament simulator harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,20 @@ not yet implemented — see the strategy doc below.
   process (no pickling needed).
 - [`names.py`](names.py) — 200-name pool for randomizing AI opponent
   names.
+- [`tournament_sim.py`](tournament_sim.py) — dev/tuning tool: batch-runs
+  N full `Game.play()` matches between two team configs (player class +
+  kwargs per seat), alternating which physical seats each team occupies
+  to cancel out positional bias, and reports win rate and average score
+  margin per team. Not yet useful for its intended purpose (comparing
+  AI skill levels) until the Expert/GeneralStrategy tier lands, but
+  runs today against `Player`/`EasyPlayer`.
 
 ## Running
 
 ```
 python pinochle_engine.py   # rules engine self-checks + full-game sanity runs
 python play_local.py        # play a full interactive game in the terminal
+python tournament_sim.py --games 300   # Proficient-vs-Proficient sanity check (~50/50)
 ```
 
 ## Architecture

--- a/test_tournament_sim.py
+++ b/test_tournament_sim.py
@@ -1,0 +1,81 @@
+"""
+Basic tests for issue #64 - tournament_sim.py. Not a full pytest suite
+(same deferred-Phase-2 caveat as test_ai_tiers.py) - just plain
+assert-based, pytest-discoverable checks that a tiny run completes
+without error and produces a well-formed report, using existing
+Player/EasyPlayer matchups (doesn't need GeneralStrategy to exist).
+
+Run directly (`python test_tournament_sim.py`) or via pytest.
+"""
+
+from pinochle_engine import Player, EasyPlayer, GAME_LOSE_SCORE, GAME_WIN_SCORE
+from tournament_sim import PlayerConfig, TournamentReport, team_config, run_tournament
+
+
+def test_tiny_run_produces_well_formed_report():
+    report = run_tournament(
+        team_config(Player), team_config(Player), n_games=4,
+        label_a="A", label_b="B", seed=0,
+    )
+    assert isinstance(report, TournamentReport)
+    assert report.n_games == 4
+    assert report.wins_a + report.wins_b == 4
+    assert len(report.margins_a) == 4
+    assert 0.0 <= report.win_rate_a <= 1.0
+    assert 0.0 <= report.win_rate_b <= 1.0
+    assert abs(report.win_rate_a + report.win_rate_b - 1.0) < 1e-9
+
+    # Each recorded margin should be consistent with a real, completed
+    # game: nobody's score sits strictly between the two loss/win
+    # thresholds forever, so a plausible margin isn't bounded tightly,
+    # but it must be a finite int-like number, not a placeholder.
+    for margin in report.margins_a:
+        assert isinstance(margin, (int, float))
+
+    summary = report.summary()
+    assert "A" in summary and "B" in summary
+    assert "4 games" in summary
+
+
+def test_mixed_tier_teams_run_cleanly():
+    """Sanity that seat configs don't have to be uniform per team - each
+    seat can be its own (player_class, kwargs) pair."""
+    team_a = [PlayerConfig(EasyPlayer), PlayerConfig(Player)]
+    team_b = team_config(Player)
+    report = run_tournament(team_a, team_b, n_games=4, seed=1)
+    assert report.wins_a + report.wins_b == 4
+
+
+def test_seat_alternation_swaps_physical_seats_each_game():
+    """Odd-indexed games in the run put team B in seats 0&2 instead of
+    team A - verified indirectly here by confirming a run with an odd
+    game count still produces exactly one result per game (no crash from
+    the swap bookkeeping) and win totals stay within bounds."""
+    report = run_tournament(team_config(Player), team_config(Player), n_games=5, seed=2)
+    assert report.n_games == 5
+    assert report.wins_a + report.wins_b == 5
+    assert 0 <= report.wins_a <= 5
+    assert 0 <= report.wins_b <= 5
+
+
+def test_team_config_helper_builds_two_matching_seat_configs():
+    cfg = team_config(EasyPlayer)
+    assert len(cfg) == 2
+    assert all(c.player_class is EasyPlayer for c in cfg)
+    p = cfg[0].build("T")
+    assert isinstance(p, EasyPlayer)
+    assert p.name == "T"
+    assert p.team is None  # Game.from_players() wires this later
+
+
+if __name__ == "__main__":
+    tests = [
+        test_tiny_run_produces_well_formed_report,
+        test_mixed_tier_teams_run_cleanly,
+        test_seat_alternation_swaps_physical_seats_each_game,
+        test_team_config_helper_builds_two_matching_seat_configs,
+    ]
+    for t in tests:
+        t()
+        print(f"{t.__name__} passed")
+    print(f"\n{len(tests)}/{len(tests)} test_tournament_sim.py checks passed.")

--- a/tournament_sim.py
+++ b/tournament_sim.py
@@ -1,0 +1,183 @@
+"""
+Tournament simulator — batch Game.play() harness (issue #64, part of
+epic #57's General Strategy AI work).
+
+Runs N full games between two "team configs" (each a pair of
+(player_class, kwargs) specs for that team's two seats) via
+Game.from_players()/Game.play(), and reports win rate and average score
+margin per team.
+
+Why seats are alternated: Game always deals to seat 0 first and starts
+scoring/dealer rotation at dealer_index 0 (see Game._init_from_players /
+Game.play() in pinochle_engine.py). If one team always sat in seats 0&2
+and the other always in 1&3, any small positional edge baked into who
+deals/bids first would show up as a fake skill gap. To cancel that out,
+this harness swaps which team occupies seats 0&2 vs 1&3 every other
+game, so across a full run each team spends half its games in each
+seat pair.
+
+This is a dev/tuning tool, not user-facing — no polish beyond a small
+CLI. Once GeneralStrategy (#57 children) lands, its skill levels plug in
+here the same way EasyPlayer/Player already do: as a
+(player_class, kwargs) pair per seat.
+
+Run directly for the built-in sanity check (Proficient+Proficient vs
+itself, should land close to 50/50):
+
+    python tournament_sim.py
+    python tournament_sim.py --games 300
+"""
+
+import argparse
+import random
+import time
+from dataclasses import dataclass, field
+
+from pinochle_engine import Game, Player
+
+
+# ---------------------------------------------------------------------------
+# Team/player configuration
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PlayerConfig:
+    """One seat's spec: which Player subclass to build and any extra
+    constructor kwargs beyond (name, team) — team is always overwritten by
+    Game.from_players()'s team-wiring, so callers only need to supply
+    kwargs a given tier's __init__ actually takes (e.g. a future
+    GeneralStrategy skill-level kwarg)."""
+    player_class: type = Player
+    kwargs: dict = field(default_factory=dict)
+
+    def build(self, name):
+        return self.player_class(name, None, **self.kwargs)
+
+
+def team_config(player_class=Player, **kwargs):
+    """Convenience: a 2-player team where both seats share one
+    (player_class, kwargs) spec. For mixed-seat teams, build a
+    [PlayerConfig(...), PlayerConfig(...)] list directly instead."""
+    return [PlayerConfig(player_class, kwargs), PlayerConfig(player_class, kwargs)]
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TournamentReport:
+    n_games: int
+    label_a: str
+    label_b: str
+    wins_a: int
+    wins_b: int
+    margins_a: list  # per-game (team_a_score - team_b_score), signed toward A
+    elapsed_seconds: float
+
+    @property
+    def win_rate_a(self):
+        return self.wins_a / self.n_games
+
+    @property
+    def win_rate_b(self):
+        return self.wins_b / self.n_games
+
+    @property
+    def avg_margin_a(self):
+        return sum(self.margins_a) / self.n_games
+
+    def summary(self):
+        ms_per_game = self.elapsed_seconds / self.n_games * 1000
+        return (
+            f"Tournament: {self.label_a} vs {self.label_b} - {self.n_games} games "
+            f"({self.elapsed_seconds:.1f}s, {ms_per_game:.0f} ms/game)\n"
+            f"  {self.label_a}: {self.wins_a} wins ({self.win_rate_a:.1%})  "
+            f"avg margin {self.avg_margin_a:+.0f}\n"
+            f"  {self.label_b}: {self.wins_b} wins ({self.win_rate_b:.1%})  "
+            f"avg margin {-self.avg_margin_a:+.0f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def run_tournament(team_a, team_b, n_games, label_a="Team A", label_b="Team B", seed=None):
+    """
+    team_a / team_b: each a list of 2 PlayerConfig (see team_config() for
+    the common same-tier-both-seats case).
+
+    Every other game swaps which team occupies seats 0&2 vs 1&3 (see
+    module docstring for why), so a fresh set of Player objects is built
+    per game either way — AI tiers here are stateless across games, so
+    this is just bookkeeping, not a fairness workaround for shared state.
+    """
+    assert len(team_a) == 2, "team_a must have exactly 2 seat configs"
+    assert len(team_b) == 2, "team_b must have exactly 2 seat configs"
+    assert n_games > 0
+
+    if seed is not None:
+        random.seed(seed)
+
+    wins_a = wins_b = 0
+    margins_a = []
+    start = time.perf_counter()
+
+    for i in range(n_games):
+        swap = (i % 2 == 1)
+        if not swap:
+            seat_configs = [team_a[0], team_b[0], team_a[1], team_b[1]]
+            a_is_teams_index_0 = True
+        else:
+            seat_configs = [team_b[0], team_a[0], team_b[1], team_a[1]]
+            a_is_teams_index_0 = False
+
+        players = [cfg.build(f"P{seat}") for seat, cfg in enumerate(seat_configs)]
+        game = Game.from_players(players)
+        winner = game.play()
+
+        # Game._init_from_players always wires teams[0] = seats (0,2) and
+        # teams[1] = seats (1,3), regardless of which logical team we put
+        # there this game — so which side is "A" flips with `swap`.
+        team_a_obj = game.teams[0] if a_is_teams_index_0 else game.teams[1]
+        team_b_obj = game.teams[1] if a_is_teams_index_0 else game.teams[0]
+
+        margins_a.append(team_a_obj.score - team_b_obj.score)
+        if winner is team_a_obj:
+            wins_a += 1
+        else:
+            wins_b += 1
+
+    elapsed = time.perf_counter() - start
+    return TournamentReport(n_games, label_a, label_b, wins_a, wins_b, margins_a, elapsed)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _sanity_check(n_games):
+    """Proficient+Proficient vs Proficient+Proficient — should land close
+    to 50/50 over enough games; this is the harness's own self-test that
+    seat-alternation isn't introducing bias, not just a demo."""
+    team_a = team_config(Player)
+    team_b = team_config(Player)
+    report = run_tournament(team_a, team_b, n_games, label_a="Proficient A", label_b="Proficient B")
+    print(report.summary())
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--games", type=int, default=200, help="number of games to simulate (default: 200)")
+    parser.add_argument("--seed", type=int, default=None, help="random seed for reproducibility")
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+    _sanity_check(args.games)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of #57, closes #64

## Summary
- Adds `tournament_sim.py`: batch-runs N full `Game.play()` matches between two team configs (`player_class` + kwargs per seat), via `Game.from_players()`. Alternates which physical seats (0&2 vs 1&3) each team occupies every other game so any positional bias from `Game`'s fixed dealer-starts-at-seat-0 behavior cancels out across a run rather than favoring one side. Reports win rate and average score margin per team.
- Simple CLI (`python tournament_sim.py --games N --seed S`), dev tool only, no polish beyond that - matches the issue's scope.
- Fast: ~15-20ms/game, so a few hundred games run in single-digit seconds.
- Works today against existing `Player`/`EasyPlayer` tiers; not yet useful for its ultimate purpose (comparing AI skill levels) until `GeneralStrategy` (#57's child issues) exists, per the issue.
- Adds `test_tournament_sim.py`: tiny N=4/5 runs, mixed-seat-config teams, and well-formed-report checks (matches the existing `test_ai_tiers.py` plain-assert, pytest-discoverable convention - no test framework wired up yet per `CODING_STANDARDS.md`).
- Documents the new module in `README.md`'s Contents/Running sections.

## Sanity check
Proficient+Proficient vs itself, run several ways to confirm it's not a fixed artifact of the seat-alternation logic:

| Games | Seed | Team A | Team B |
|---|---|---|---|
| 300 | 42 | 150 (50.0%) | 150 (50.0%) |
| 300 | 7 | 141 (47.0%) | 159 (53.0%) |
| 301 | 99 | 142 (47.2%) | 159 (52.8%) |
| 400 | 2026 | 179 (44.8%) | 221 (55.2%) |

All within normal sampling variance around 50/50 for these game counts - no systematic bias toward either seat/team.

## Test plan
- [x] `python pinochle_engine.py` - existing engine self-checks pass
- [x] `python test_ai_tiers.py` - existing AI-tier suite passes (9/9), unaffected
- [x] `python test_tournament_sim.py` - new tests pass (4/4)
- [x] `python tournament_sim.py --games 400` - sanity check lands close to 50/50 across multiple seeds (see table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)