### PR TITLE
Add Monte Carlo determinization sampler + Auto-SET guard

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -559,6 +559,75 @@ def choose_follow_card(hand, legal_moves, trick_plays, trump, my_team_players, t
 
 
 # ---------------------------------------------------------------------------
+# Shared pass/trick-play phase runners — used by Round for a real game, and
+# reused as-is by the Monte Carlo rollout sampler (pinochle_rollout.py, issue
+# #59) so there is exactly one implementation of "how passing/trick-play
+# actually happens," not two that can drift apart. Free functions (not Round
+# methods) so the rollout module can call them without a live Round/Deck.
+# ---------------------------------------------------------------------------
+
+def run_forward_pass(bid_winner, partner, trump_suit):
+    """Partner -> bidder, PASS_COUNT cards, via the real
+    Player.choose_pass_cards. Mutates both players' hands in place."""
+    to_bidder = partner.choose_pass_cards(PASS_COUNT, trump_suit, is_bid_winner=False)
+    for c in to_bidder:
+        partner.hand.remove(c)
+    bid_winner.hand.extend(to_bidder)
+
+
+def run_return_pass(bid_winner, partner, trump_suit):
+    """Bidder -> partner, PASS_COUNT cards, via the real
+    Player.choose_pass_cards. Mutates both players' hands in place."""
+    back_to_partner = bid_winner.choose_pass_cards(PASS_COUNT, trump_suit, is_bid_winner=True)
+    for c in back_to_partner:
+        bid_winner.hand.remove(c)
+    partner.hand.extend(back_to_partner)
+
+
+def play_tricks(players, trump, leader_index, tracker, num_tricks=12, trick_num_offset=0):
+    """
+    Plays `num_tricks` tricks starting with players[leader_index] on lead,
+    via each player's real choose_card (-> choose_lead_card/
+    choose_follow_card). Mutates player hands and `tracker` in place.
+
+    `trick_num_offset` is the overall trick number (0-11) of the first
+    trick played here - only overall trick 11 gets the +10 last-trick
+    bonus, so a caller resuming mid-round (rollout sampler picking up
+    partway through a round) must pass the right offset to still award
+    it in the correct trick.
+
+    Returns {team: trick_points} for just the tricks played here.
+    """
+    trick_points = {}
+    for p in players:
+        trick_points.setdefault(p.team, 0)
+
+    for i in range(num_tricks):
+        trick = Trick(trump)
+        idx = leader_index
+        for _ in range(4):
+            player = players[idx]
+            legal = trick.legal_moves(player.hand)
+            card = player.choose_card(
+                legal, trick=trick, trump=trump,
+                tracker=tracker, my_team_players=set(player.team.players),
+            )
+            player.hand.remove(card)
+            trick.play(player, card)
+            tracker.record(card)
+            idx = (idx + 1) % 4
+
+        winner = trick.winner()
+        points = trick.points()
+        if trick_num_offset + i == 11:
+            points += 10  # last trick bonus
+        trick_points[winner.team] += points
+        leader_index = players.index(winner)
+
+    return trick_points
+
+
+# ---------------------------------------------------------------------------
 # Trick — owns lead suit, trump, legal-move filtering, and winner resolution.
 # ---------------------------------------------------------------------------
 
@@ -1209,16 +1278,8 @@ class Round:
 
     def _passing_phase(self):
         partner = next(p for p in self.bid_winner.team.players if p is not self.bid_winner)
-
-        to_bidder = partner.choose_pass_cards(PASS_COUNT, self.trump_suit, is_bid_winner=False)
-        for c in to_bidder:
-            partner.hand.remove(c)
-        self.bid_winner.hand.extend(to_bidder)
-
-        back_to_partner = self.bid_winner.choose_pass_cards(PASS_COUNT, self.trump_suit, is_bid_winner=True)
-        for c in back_to_partner:
-            self.bid_winner.hand.remove(c)
-        partner.hand.extend(back_to_partner)
+        run_forward_pass(self.bid_winner, partner, self.trump_suit)
+        run_return_pass(self.bid_winner, partner, self.trump_suit)
 
     def _meld_phase(self):
         for team in self.teams:
@@ -1229,30 +1290,8 @@ class Round:
 
     def _trick_taking_loop(self):
         """Runs 12 tricks, returns {team: trick_points}."""
-        trick_points = {team: 0 for team in self.teams}
         leader_index = self.players.index(self.bid_winner)
-
-        for trick_num in range(12):
-            trick = Trick(self.trump_suit)
-            idx = leader_index
-            for _ in range(4):
-                player = self.players[idx]
-                legal = trick.legal_moves(player.hand)
-                card = player.choose_card(
-                    legal, trick=trick, trump=self.trump_suit,
-                    tracker=self.tracker, my_team_players=set(player.team.players),
-                )
-                player.hand.remove(card)
-                trick.play(player, card)
-                self.tracker.record(card)
-                idx = (idx + 1) % 4
-
-            winner = trick.winner()
-            points = trick.points()
-            if trick_num == 11:
-                points += 10  # last trick bonus
-            trick_points[winner.team] += points
-            leader_index = self.players.index(winner)
+        trick_points = play_tricks(self.players, self.trump_suit, leader_index, self.tracker)
 
         for team in self.teams:
             team.trick_points = trick_points[team]

--- a/pinochle_rollout.py
+++ b/pinochle_rollout.py
@@ -1,0 +1,450 @@
+"""
+Monte Carlo determinization sampler + Auto-SET guard (issue #59).
+
+Foundation piece for the Expert AI epic (#57) - implements
+`pinochle_expert_ai_strategy.md` Section 0 (the shared determinization +
+rollout machinery that underlies bid-time EV, pass selection, and the
+"realistic ceiling" problem) and Section 5 (the Auto-SET hard prune).
+
+This module is infrastructure only. It is deliberately NOT wired into any
+Player subclass's decision-making yet - that's issue #63 (GeneralStrategy).
+What lives here is the shared machinery later issues will call:
+
+  - Determinization: randomly deal the *currently unseen* cards into the
+    unseen hands appropriate to a decision point (bidding / return-pass /
+    trick-play - see Section 0's table), never touching cards that are
+    actually known.
+  - Rollout: given a fully-determinized sample, run the REAL pass logic
+    (`Player.choose_pass_cards`) and REAL trick-play logic
+    (`Player.choose_card` -> `choose_lead_card`/`choose_follow_card`) to
+    completion and score the result - not simplified stand-ins, per
+    Section 0's fidelity requirement. Reuses `PlayTracker` for per-copy
+    card tracking rather than building a second mechanism (already
+    consumed by `choose_lead_card`/`choose_follow_card`).
+  - Auto-SET guard (Section 5): a hard mathematical prune checked before
+    any 12-trick rollout, so a sample that's already a guaranteed set
+    skips the expensive trick-play simulation entirely.
+
+Sample counts are always a caller-supplied parameter (never hardcoded) -
+the doc suggests ~100-150 for bid-time and ~300+ for the one-time
+post-pass evaluation, but that's just a starting point for later issues
+to tune.
+"""
+
+import random
+
+from pinochle_engine import (
+    Card,
+    PlayTracker,
+    Player,
+    RANKS,
+    Suit,
+    Team,
+    play_tricks,
+    run_forward_pass,
+    run_return_pass,
+    score_melds,
+)
+
+
+# ---------------------------------------------------------------------------
+# Determinization: deal the currently-unseen cards into the unseen hands.
+# ---------------------------------------------------------------------------
+
+def unseen_cards_for(known_cards, known_counts=None):
+    """
+    The full 48-card deck minus what's known, split into two kinds of
+    "known" because they're tracked differently:
+
+      `known_cards` - exact Card objects known by identity (e.g. my own
+      hand) - removed by (suit, rank, copy_id) match.
+
+      `known_counts` - optional dict of (suit, rank) -> count for cards
+      that are known to be gone but whose exact copy_id isn't tracked
+      (e.g. cards already played this round, from PlayTracker.
+      played_count - both copies of a suit/rank are interchangeable for
+      gameplay purposes, so only the count matters). Whichever remaining
+      copy_id(s) happen to still be in the pool are removed.
+
+      Deliberately NOT done by reconstructing guessed Card objects for
+      the count-only side and unioning them with `known_cards`: two
+      "known" sources that don't track exact copy_id the same way can
+      easily guess the *same* copy_id for two actually-different physical
+      cards, which would silently make one of them vanish from the
+      unseen pool while leaving a real card unaccounted for. Decrementing
+      counts directly from what's left avoids that collision entirely.
+
+    Raises ValueError if `known_cards` itself contains a duplicate, or if
+    `known_counts` asks to remove more of a suit/rank than remain - both
+    are caller bugs (e.g. a card double-counted as known), not runtime
+    conditions to silently paper over.
+    """
+    known_list = list(known_cards)
+    known_set = set(known_list)
+    if len(known_set) != len(known_list):
+        raise ValueError("known_cards contains a duplicate card")
+
+    full_deck = [
+        Card(suit, rank, copy_id)
+        for suit in Suit
+        for rank in RANKS
+        for copy_id in (1, 2)
+    ]
+    remaining = [c for c in full_deck if c not in known_set]
+
+    if known_counts:
+        for (suit, rank), count in known_counts.items():
+            if count <= 0:
+                continue
+            removed = 0
+            kept = []
+            for c in remaining:
+                if removed < count and c.suit == suit and c.rank == rank:
+                    removed += 1
+                    continue
+                kept.append(c)
+            if removed != count:
+                raise ValueError(
+                    f"known_counts asks for {count} known {rank}{suit.value} "
+                    f"but only {removed} remained unaccounted for"
+                )
+            remaining = kept
+
+    return remaining
+
+
+def deal_unseen_cards(unseen_cards, hand_sizes, rng=None):
+    """
+    Randomly partition `unseen_cards` into groups of the given sizes.
+
+    `hand_sizes` is an ordered sequence of (key, count) pairs (a list
+    rather than a dict, so callers control iteration/assignment order
+    explicitly instead of relying on dict ordering as an implementation
+    detail). Returns a dict of key -> list[Card].
+
+    Raises ValueError if the sizes don't sum to len(unseen_cards) - a
+    mismatched unseen pool is a caller bug, not something to deal
+    partially and hope nobody notices.
+    """
+    hand_sizes = list(hand_sizes)
+    total = sum(count for _, count in hand_sizes)
+    if total != len(unseen_cards):
+        raise ValueError(
+            f"hand_sizes sum to {total} but there are {len(unseen_cards)} unseen cards"
+        )
+
+    rng = rng if rng is not None else random
+    pool = list(unseen_cards)
+    rng.shuffle(pool)
+
+    result = {}
+    i = 0
+    for key, count in hand_sizes:
+        result[key] = pool[i:i + count]
+        i += count
+    return result
+
+
+def played_counts_from_tracker(tracker):
+    """
+    Reads everything a PlayTracker has recorded as played so far this
+    round into a {(suit, rank): count} dict - the shape `unseen_cards_for`
+    wants for its `known_counts` argument, since exact copy_id was never
+    tracked (and doesn't matter - both copies of a suit/rank are
+    functionally interchangeable) and reconstructing guessed Card objects
+    for them risks colliding with a real card known by exact identity
+    elsewhere (e.g. the deciding player's own hand).
+    """
+    counts = {}
+    for suit in Suit:
+        for rank in RANKS:
+            count = tracker.played_count(suit, rank)
+            if count:
+                counts[(suit, rank)] = count
+    return counts
+
+
+def sample_bid_time_deal(my_hand, rng=None):
+    """
+    Bidding decision point (Section 0 table, row 1): only my own 12 cards
+    are known. Deals the other 36 cards uniformly at random into
+    partner/opp_left/opp_right, 12 each.
+    """
+    unseen = unseen_cards_for(my_hand)
+    return deal_unseen_cards(
+        unseen, [("partner", 12), ("opp_left", 12), ("opp_right", 12)], rng=rng,
+    )
+
+
+def sample_return_pass_deal(my_hand, partner_known_count=9, rng=None):
+    """
+    Return-pass decision point (Section 0 table, row 2): the bidder knows
+    their own 15 cards (12 dealt + 3 already received for real from the
+    partner's forward pass). Deals the remaining 33 cards into partner's
+    other `partner_known_count` (9 by default: partner's 12 minus the 3
+    already sent) / opp_left 12 / opp_right 12.
+    """
+    unseen = unseen_cards_for(my_hand)
+    return deal_unseen_cards(
+        unseen,
+        [("partner", partner_known_count), ("opp_left", 12), ("opp_right", 12)],
+        rng=rng,
+    )
+
+
+def sample_trick_play_deal(my_hand, tracker, remaining_hand_sizes, rng=None):
+    """
+    Trick-play decision point (Section 0 table, row 3): everything played
+    so far (via PlayTracker - reused, not re-tracked) plus my own current
+    hand is known. `remaining_hand_sizes` is an ordered (key, count)
+    sequence giving the other three seats' current hand sizes. Deals the
+    unseen remainder into those seats.
+    """
+    unseen = unseen_cards_for(my_hand, known_counts=played_counts_from_tracker(tracker))
+    return deal_unseen_cards(unseen, remaining_hand_sizes, rng=rng)
+
+
+# ---------------------------------------------------------------------------
+# Auto-SET guard (Section 5) - a hard mathematical prune, not a heuristic.
+# ---------------------------------------------------------------------------
+
+MAX_TRICK_POINTS = 250  # max possible trick points in any round (pinochle_rules.md)
+
+
+def is_auto_set(bidding_team_meld, bid):
+    """
+    True if the bidding team cannot possibly reach `bid` even if they took
+    every single trick point available (all 250) - the literal inequality
+    from Section 5, run before any 12-trick rollout so a guaranteed-set
+    sample can skip the expensive trick-play simulation entirely.
+    """
+    return bidding_team_meld + MAX_TRICK_POINTS < bid
+
+
+# ---------------------------------------------------------------------------
+# Rollout: run one fully-determinized sample to completion via the REAL
+# pass/trick-play logic, and score it.
+# ---------------------------------------------------------------------------
+
+def rollout_deal(players, trump, bid, bid_winner, tracker=None,
+                  leader_index=None, tricks_already_played=0, passing="none",
+                  bidding_meld=None, defending_meld=None):
+    """
+    Roll out one Monte Carlo sample to completion and score it.
+
+    `players` is the 4 Player objects in table (turn) order, each already
+    carrying a determinized `.hand` (known cards + this sample's dealt
+    unseen cards) and wired to its `.team`. `bid_winner` must be one of
+    `players`.
+
+    `passing` controls which real pass-logic steps run before melding,
+    mirroring Section 0's per-decision-point table:
+      "both"        - forward pass (partner -> bidder) then return pass
+                       (bidder -> partner). Use for bid-time rollouts,
+                       where neither pass has happened yet.
+      "return_only" - just the return pass. Use for return-pass rollouts,
+                       where the forward pass already happened for real
+                       (baked into the hands passed in).
+      "none"        - no passing. Use for trick-play rollouts, where
+                       passing is long since resolved.
+
+    `tracker` continues an in-progress PlayTracker for a trick-play
+    rollout; a fresh one is created when None (correct for bid-time /
+    return-pass rollouts, where no card has been played yet this round).
+
+    `leader_index` / `tricks_already_played` let a rollout resume
+    mid-round for the trick-play decision point. `leader_index` defaults
+    to bid_winner's seat (correct for bid-time/return-pass, where the
+    auction winner always leads the first trick).
+
+    `bidding_meld` / `defending_meld`: when `tricks_already_played == 0`,
+    these are computed from the (still-full) hands after passing - meld
+    is fixed at the real meld phase and can't be recomputed once cards
+    have already been played out of a hand, so callers resuming mid-round
+    (tricks_already_played > 0) MUST supply both explicitly.
+
+    Returns a dict: auto_set, made (bidding team reached `bid`),
+    bidding_meld, defending_meld, bidding_trick_points,
+    defending_trick_points, bidding_total, defending_total.
+    """
+    partner = next(p for p in bid_winner.team.players if p is not bid_winner)
+    bidding_team = bid_winner.team
+    all_teams = {p.team for p in players}
+    defending_team = next(t for t in all_teams if t is not bidding_team)
+
+    if passing == "both":
+        run_forward_pass(bid_winner, partner, trump)
+        run_return_pass(bid_winner, partner, trump)
+    elif passing == "return_only":
+        run_return_pass(bid_winner, partner, trump)
+    elif passing != "none":
+        raise ValueError(f"unknown passing mode: {passing!r}")
+
+    if tricks_already_played == 0:
+        if bidding_meld is None:
+            bidding_meld = sum(score_melds(p.hand, trump)[0] for p in bidding_team.players)
+        if defending_meld is None:
+            defending_meld = sum(score_melds(p.hand, trump)[0] for p in defending_team.players)
+    elif bidding_meld is None or defending_meld is None:
+        raise ValueError(
+            "bidding_meld/defending_meld must be supplied explicitly when "
+            "tricks_already_played > 0 - meld is fixed at the real meld "
+            "phase and can't be recomputed from a hand that already has "
+            "cards played out of it"
+        )
+
+    if is_auto_set(bidding_meld, bid):
+        # Hard prune (Section 5): skip the 12-trick rollout entirely.
+        return {
+            "auto_set": True,
+            "made": False,
+            "bidding_meld": bidding_meld,
+            "defending_meld": defending_meld,
+            "bidding_trick_points": 0,
+            "defending_trick_points": 0,
+            "bidding_total": bidding_meld,
+            "defending_total": defending_meld,
+        }
+
+    tracker = tracker if tracker is not None else PlayTracker()
+    if leader_index is None:
+        leader_index = players.index(bid_winner)
+    num_tricks = 12 - tricks_already_played
+
+    trick_points = play_tricks(
+        players, trump, leader_index, tracker,
+        num_tricks=num_tricks, trick_num_offset=tricks_already_played,
+    )
+
+    bidding_trick_points = trick_points[bidding_team]
+    defending_trick_points = trick_points[defending_team]
+    bidding_total = bidding_meld + bidding_trick_points
+    defending_total = defending_meld + defending_trick_points
+
+    return {
+        "auto_set": False,
+        "made": bidding_total >= bid,
+        "bidding_meld": bidding_meld,
+        "defending_meld": defending_meld,
+        "bidding_trick_points": bidding_trick_points,
+        "defending_trick_points": defending_trick_points,
+        "bidding_total": bidding_total,
+        "defending_total": defending_total,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Monte Carlo orchestration - run N samples, average the outcome.
+# ---------------------------------------------------------------------------
+
+def monte_carlo_rollout(sample_fn, build_players_fn, trump, bid, num_samples,
+                         rollout_kwargs=None, rng=None):
+    """
+    Runs `num_samples` independent determinize-then-rollout samples and
+    aggregates them into P(make)/E[points] (Section 0's closing step:
+    "average across samples"). `num_samples` is always caller-supplied,
+    never hardcoded.
+
+    `sample_fn(rng) -> dealt` produces one determinized deal (e.g.
+    `sample_bid_time_deal`). `build_players_fn(dealt) -> (players,
+    bid_winner)` turns that sample into fully-wired Player objects ready
+    for `rollout_deal`. `rollout_kwargs` is passed through to
+    `rollout_deal` unchanged (passing mode, tracker, tricks_already_played,
+    etc).
+    """
+    rng = rng if rng is not None else random
+    rollout_kwargs = rollout_kwargs or {}
+
+    results = []
+    for _ in range(num_samples):
+        dealt = sample_fn(rng)
+        players, bid_winner = build_players_fn(dealt)
+        results.append(rollout_deal(players, trump, bid, bid_winner, **rollout_kwargs))
+
+    made_count = sum(1 for r in results if r["made"])
+    return {
+        "samples": results,
+        "p_make": made_count / num_samples,
+        "expected_bidding_points": sum(r["bidding_total"] for r in results) / num_samples,
+        "expected_defending_points": sum(r["defending_total"] for r in results) / num_samples,
+        "auto_set_rate": sum(1 for r in results if r["auto_set"]) / num_samples,
+    }
+
+
+def _build_rollout_players(seat_names, hands):
+    """
+    Wires 4 fresh, disposable Player objects (Proficient tier - the REAL
+    pass/trick-play logic per Section 0, regardless of which AI tier is
+    asking) into 2 Teams, seats 0&2 vs 1&3 (matching
+    Game._init_from_players' convention), with the given hands.
+
+    Always builds new Player/Team objects rather than reusing the
+    caller's own long-lived ones, and copies each hand list - a rollout
+    sample must never be able to mutate real game state.
+    """
+    players = [Player(name, None) for name in seat_names]
+    team_a = Team("Rollout Team A", [players[0], players[2]])
+    team_b = Team("Rollout Team B", [players[1], players[3]])
+    players[0].team = players[2].team = team_a
+    players[1].team = players[3].team = team_b
+    for player, hand in zip(players, hands):
+        player.hand = list(hand)
+    return players
+
+
+def estimate_bid_time(hand, trump, bid, num_samples=150, rng=None):
+    """
+    Bid-time Monte Carlo estimate (Section 0/1). `hand` (12 known cards)
+    is seated as the bid winner; partner and both opponents get randomly
+    determinized 12-card hands each sample. Runs the real forward pass,
+    real return pass, and real trick play for every sample, applying the
+    Auto-SET guard before any 12-trick rollout.
+
+    Returns the aggregate dict from `monte_carlo_rollout` (p_make,
+    expected_bidding_points, expected_defending_points, auto_set_rate,
+    plus the raw per-sample results).
+    """
+    rng = rng if rng is not None else random
+
+    def sample_fn(active_rng):
+        return sample_bid_time_deal(hand, rng=active_rng)
+
+    def build_fn(dealt):
+        players = _build_rollout_players(
+            ["me", "opp_left", "partner", "opp_right"],
+            [hand, dealt["opp_left"], dealt["partner"], dealt["opp_right"]],
+        )
+        return players, players[0]
+
+    return monte_carlo_rollout(
+        sample_fn, build_fn, trump, bid, num_samples,
+        rollout_kwargs={"passing": "both"}, rng=rng,
+    )
+
+
+def estimate_return_pass(hand, trump, bid, num_samples=300, rng=None):
+    """
+    Return-pass Monte Carlo estimate (Section 0/3). `hand` is the
+    bidder's known 15 cards (12 dealt + 3 already received for real from
+    partner's forward pass). Partner's other 9 cards and both opponents'
+    12 each are determinized per sample; only the real return pass is
+    simulated (the forward pass already happened for real).
+
+    Returns the aggregate dict from `monte_carlo_rollout`.
+    """
+    rng = rng if rng is not None else random
+
+    def sample_fn(active_rng):
+        return sample_return_pass_deal(hand, rng=active_rng)
+
+    def build_fn(dealt):
+        players = _build_rollout_players(
+            ["me", "opp_left", "partner", "opp_right"],
+            [hand, dealt["opp_left"], dealt["partner"], dealt["opp_right"]],
+        )
+        return players, players[0]
+
+    return monte_carlo_rollout(
+        sample_fn, build_fn, trump, bid, num_samples,
+        rollout_kwargs={"passing": "return_only"}, rng=rng,
+    )

--- a/test_rollout.py
+++ b/test_rollout.py
@@ -1,0 +1,391 @@
+"""
+Tests for issue #59 - Monte Carlo determinization sampler + Auto-SET guard
+(pinochle_rollout.py). Plain assert-based, pytest-discoverable, matching
+test_ai_tiers.py's convention. Covers:
+
+  1. Determinization produces only legal deals: correct card counts, no
+     duplicates, no leaks of known cards into the "unseen" pool - for all
+     three decision points (bid-time, return-pass, trick-play).
+  2. The Auto-SET guard correctly skips rollout on constructed
+     guaranteed-set hands, and correctly does NOT skip on close/makeable
+     hands (including the exact boundary).
+  3. rollout_deal end-to-end: Auto-SET short-circuits before any trick is
+     played; the full pass + trick-play rollout runs to completion using
+     the REAL Player logic; resuming mid-round (trick-play decision
+     point) is scored correctly, including the last-trick bonus landing
+     on the true final trick, not a locally-relative one.
+  4. The two convenience aggregate estimators (estimate_bid_time /
+     estimate_return_pass) run for a caller-supplied sample count and
+     produce a sane aggregate (p_make in [0, 1], right sample count).
+
+Run directly (`python test_rollout.py`) or via pytest.
+"""
+
+import random
+from collections import Counter
+
+from pinochle_engine import (
+    Card, Deck, PlayTracker, Player, RANKS, Suit, Team, Trick, score_melds,
+)
+from pinochle_rollout import (
+    deal_unseen_cards,
+    estimate_bid_time,
+    estimate_return_pass,
+    is_auto_set,
+    played_counts_from_tracker,
+    rollout_deal,
+    sample_bid_time_deal,
+    sample_return_pass_deal,
+    sample_trick_play_deal,
+    unseen_cards_for,
+    _build_rollout_players,
+)
+
+
+def _fresh_hands():
+    deck = Deck()
+    deck.shuffle()
+    cards = deck.cards
+    return [cards[i * 12:(i + 1) * 12] for i in range(4)]
+
+
+def _full_deck_set():
+    return {Card(suit, rank, copy_id)
+            for suit in Suit for rank in RANKS for copy_id in (1, 2)}
+
+
+# ---------------------------------------------------------------------------
+# 1. Determinization primitives - legal deals only.
+# ---------------------------------------------------------------------------
+
+def test_unseen_cards_for_excludes_known_and_covers_rest():
+    for hand in _fresh_hands():
+        unseen = unseen_cards_for(hand)
+        assert len(unseen) == 36
+        assert len(set(unseen)) == 36  # no duplicates within unseen
+        assert not (set(unseen) & set(hand)), "known card leaked into unseen pool"
+        assert set(unseen) | set(hand) == _full_deck_set()
+
+
+def test_unseen_cards_for_rejects_duplicate_known():
+    hand = _fresh_hands()[0]
+    dup_hand = hand + [hand[0]]
+    try:
+        unseen_cards_for(dup_hand)
+        assert False, "expected ValueError for duplicate known card"
+    except ValueError:
+        pass
+
+
+def test_deal_unseen_cards_correct_counts_no_duplicates():
+    for _ in range(10):
+        hand = _fresh_hands()[0]
+        unseen = unseen_cards_for(hand)
+        dealt = deal_unseen_cards(
+            unseen, [("partner", 12), ("opp_left", 12), ("opp_right", 12)],
+        )
+        assert set(dealt.keys()) == {"partner", "opp_left", "opp_right"}
+        for key, cards in dealt.items():
+            assert len(cards) == 12, (key, len(cards))
+
+        all_dealt = dealt["partner"] + dealt["opp_left"] + dealt["opp_right"]
+        assert len(all_dealt) == 36
+        assert len(set(all_dealt)) == 36, "duplicate card dealt across groups"
+        assert set(all_dealt) == set(unseen), "dealt cards don't match the unseen pool exactly"
+        assert not (set(all_dealt) & set(hand)), "known card leaked into a dealt group"
+
+
+def test_deal_unseen_cards_size_mismatch_raises():
+    hand = _fresh_hands()[0]
+    unseen = unseen_cards_for(hand)
+    try:
+        deal_unseen_cards(unseen, [("partner", 12), ("opp_left", 12), ("opp_right", 11)])
+        assert False, "expected ValueError for size mismatch"
+    except ValueError:
+        pass
+
+
+def test_sample_bid_time_deal_legal():
+    for hand in _fresh_hands() * 3:
+        dealt = sample_bid_time_deal(hand)
+        assert len(dealt["partner"]) == 12
+        assert len(dealt["opp_left"]) == 12
+        assert len(dealt["opp_right"]) == 12
+        everyone = list(hand) + dealt["partner"] + dealt["opp_left"] + dealt["opp_right"]
+        assert len(everyone) == 48
+        assert set(everyone) == _full_deck_set(), "sampled deal isn't a legal full deck"
+        # no known card leaked into any sampled hand
+        for key in ("partner", "opp_left", "opp_right"):
+            assert not (set(dealt[key]) & set(hand))
+
+
+def test_sample_return_pass_deal_legal():
+    """Bidder's known 15 cards (12 dealt + 3 already received) -> partner's
+    remaining 9 + both opponents' 12 each, all sampled legally."""
+    deck = Deck()
+    deck.shuffle()
+    cards = deck.cards
+    bidder_hand = cards[0:12] + cards[12:15]  # 12 + 3 "received" = 15 known
+    rest = cards[15:]
+    assert len(rest) == 33
+
+    dealt = sample_return_pass_deal(bidder_hand)
+    assert len(dealt["partner"]) == 9
+    assert len(dealt["opp_left"]) == 12
+    assert len(dealt["opp_right"]) == 12
+
+    everyone = list(bidder_hand) + dealt["partner"] + dealt["opp_left"] + dealt["opp_right"]
+    assert len(everyone) == 48
+    assert set(everyone) == _full_deck_set()
+    for key in ("partner", "opp_left", "opp_right"):
+        assert not (set(dealt[key]) & set(bidder_hand))
+
+
+def test_sample_trick_play_deal_legal_and_uses_tracker():
+    """Reuses PlayTracker (not a second mechanism) to know what's already
+    played, then deals only the genuinely-unseen remainder - no leaks of
+    my own hand or already-played cards into any sampled hand."""
+    deck = Deck()
+    deck.shuffle()
+    hands = [deck.cards[i * 12:(i + 1) * 12] for i in range(4)]
+
+    tracker = PlayTracker()
+    # Simulate 2 tricks (8 cards) already played, one from each hand per trick.
+    played_cards = []
+    for trick_i in range(2):
+        for seat in range(4):
+            card = hands[seat].pop()
+            tracker.record(card)
+            played_cards.append(card)
+
+    my_hand = hands[0]  # deciding player's real remaining 10-card hand
+    other_sizes = [("partner", len(hands[2])), ("opp_left", len(hands[1])), ("opp_right", len(hands[3]))]
+
+    dealt = sample_trick_play_deal(my_hand, tracker, other_sizes)
+
+    assert len(dealt["partner"]) == len(hands[2]) == 10
+    assert len(dealt["opp_left"]) == len(hands[1]) == 10
+    assert len(dealt["opp_right"]) == len(hands[3]) == 10
+
+    all_dealt = dealt["partner"] + dealt["opp_left"] + dealt["opp_right"]
+    assert len(all_dealt) == len(set(all_dealt)), "duplicate card object in trick-play sample"
+
+    # My own hand is known by exact copy_id, so no sampled card should
+    # exactly equal one of those. Already-played cards are only tracked by
+    # (suit, rank) count (PlayTracker doesn't track copy_id, and copy_id is
+    # gameplay-meaningless - both copies of a card are interchangeable), so
+    # the right "no leak" check there is per-(suit, rank) count, not exact
+    # object identity: no suit/rank may ever be accounted for more than
+    # twice across my hand + already-played + this sample.
+    assert not (set(all_dealt) & set(my_hand)), "my own known card leaked into trick-play sample"
+
+    counts = Counter((c.suit, c.rank) for c in my_hand)
+    counts.update((c.suit, c.rank) for c in played_cards)
+    counts.update((c.suit, c.rank) for c in all_dealt)
+    assert all(n == 2 for n in counts.values()), counts
+    assert len(my_hand) + len(played_cards) + len(all_dealt) == 48
+
+
+def test_played_counts_from_tracker_matches_recorded_plays():
+    tracker = PlayTracker()
+    tracker.record(Card(Suit.SPADES, "A", 1))
+    tracker.record(Card(Suit.SPADES, "A", 2))
+    tracker.record(Card(Suit.HEARTS, "9", 1))
+    counts = played_counts_from_tracker(tracker)
+    assert counts == {(Suit.SPADES, "A"): 2, (Suit.HEARTS, "9"): 1}
+
+
+# ---------------------------------------------------------------------------
+# 2. Auto-SET guard.
+# ---------------------------------------------------------------------------
+
+def test_is_auto_set_skips_guaranteed_set():
+    # 0 meld, bid of 300 -> even 250/250 trick points can't reach it.
+    assert is_auto_set(bidding_team_meld=0, bid=300) is True
+    assert is_auto_set(bidding_team_meld=40, bid=350) is True  # 40 + 250 = 290 < 350
+
+
+def test_is_auto_set_does_not_skip_makeable_hand():
+    # 100 meld, bid of 300 -> 100 + 250 = 350 >= 300, theoretically makeable.
+    assert is_auto_set(bidding_team_meld=100, bid=300) is False
+    assert is_auto_set(bidding_team_meld=300, bid=300) is False  # meld alone already covers it
+
+
+def test_is_auto_set_boundary_is_strict():
+    # meld + 250 == bid exactly -> NOT auto-set (still theoretically makeable
+    # with a perfect trick-point run) - only strictly-less triggers the prune.
+    assert is_auto_set(bidding_team_meld=50, bid=300) is False  # 50 + 250 == 300
+    assert is_auto_set(bidding_team_meld=49, bid=300) is True   # 49 + 250 == 299 < 300
+
+
+# ---------------------------------------------------------------------------
+# 3. rollout_deal - real pass/trick-play logic, Auto-SET short-circuit,
+#    and mid-round resumption.
+# ---------------------------------------------------------------------------
+
+def test_rollout_deal_auto_set_skips_trick_play_entirely():
+    hands = _fresh_hands()
+    players = _build_rollout_players(["me", "opp_left", "partner", "opp_right"], hands)
+    bid_winner = players[0]
+    trump = Suit.SPADES
+
+    bidding_meld = sum(score_melds(p.hand, trump)[0] for p in bid_winner.team.players)
+    bid = bidding_meld + 251  # guarantees bidding_meld + 250 < bid
+
+    hand_lengths_before = [len(p.hand) for p in players]
+    result = rollout_deal(players, trump, bid, bid_winner, passing="none")
+
+    assert result["auto_set"] is True
+    assert result["made"] is False
+    assert result["bidding_total"] == result["bidding_meld"] == bidding_meld
+    assert result["bidding_trick_points"] == 0
+    # No trick was actually played - hands must be untouched.
+    assert [len(p.hand) for p in players] == hand_lengths_before
+
+
+def test_rollout_deal_no_passing_plays_out_all_tricks():
+    hands = _fresh_hands()
+    players = _build_rollout_players(["me", "opp_left", "partner", "opp_right"], hands)
+    bid_winner = players[0]
+    trump = Suit.SPADES
+
+    bidding_meld = sum(score_melds(p.hand, trump)[0] for p in bid_winner.team.players)
+    bid = 50  # low enough it won't trigger Auto-SET for any reasonable meld
+
+    result = rollout_deal(players, trump, bid, bid_winner, passing="none")
+
+    assert result["auto_set"] is False
+    assert isinstance(result["made"], bool)
+    assert all(len(p.hand) == 0 for p in players), "12-trick rollout should exhaust every hand"
+    total_trick_points = result["bidding_trick_points"] + result["defending_trick_points"]
+    # 48 cards dealt at 12/player; count cards (A/10/K) score 10 each, +10 last-trick bonus.
+    point_card_count = sum(1 for p_hand in hands for c in p_hand if c.rank in ("A", "10", "K"))
+    assert total_trick_points == point_card_count * 10 + 10
+
+
+def test_rollout_deal_with_both_passing_runs_real_pass_logic():
+    """Smoke test that passing="both" actually invokes the real forward +
+    return pass (Player.choose_pass_cards) without error, end to end."""
+    hand = _fresh_hands()[0]
+    dealt = sample_bid_time_deal(hand, rng=random.Random(42))
+    players = _build_rollout_players(
+        ["me", "opp_left", "partner", "opp_right"],
+        [hand, dealt["opp_left"], dealt["partner"], dealt["opp_right"]],
+    )
+    bid_winner = players[0]
+    trump = Suit.SPADES
+    result = rollout_deal(players, trump, bid=50, bid_winner=bid_winner, passing="both")
+    assert isinstance(result["made"], bool)
+    assert all(len(p.hand) == 0 for p in players)
+
+
+def test_rollout_deal_mid_round_requires_explicit_meld():
+    hands = _fresh_hands()
+    players = _build_rollout_players(["me", "opp_left", "partner", "opp_right"], hands)
+    bid_winner = players[0]
+    tracker = PlayTracker()
+    try:
+        rollout_deal(players, Suit.SPADES, bid=300, bid_winner=bid_winner,
+                      tracker=tracker, tricks_already_played=2, passing="none")
+        assert False, "expected ValueError when resuming mid-round without explicit meld"
+    except ValueError:
+        pass
+
+
+def test_rollout_deal_resumes_mid_round_with_correct_last_trick_bonus():
+    hands = _fresh_hands()
+    players = _build_rollout_players(["me", "opp_left", "partner", "opp_right"], hands)
+    bid_winner = players[0]
+    trump = Suit.SPADES
+
+    bidding_meld = sum(score_melds(p.hand, trump)[0] for p in bid_winner.team.players)
+    defending_team = next(p.team for p in players if p.team is not bid_winner.team)
+    defending_meld = sum(score_melds(p.hand, trump)[0] for p in defending_team.players)
+
+    # Play the first 2 tricks "for real" using the same primitive rollout_deal
+    # itself relies on, tracking the true leader for the resume point.
+    tracker = PlayTracker()
+    leader_index = 0
+    for _ in range(2):
+        trick = Trick(trump)
+        idx = leader_index
+        for _ in range(4):
+            player = players[idx]
+            legal = trick.legal_moves(player.hand)
+            card = player.choose_card(legal, trick=trick, trump=trump, tracker=tracker,
+                                       my_team_players=set(player.team.players))
+            player.hand.remove(card)
+            trick.play(player, card)
+            tracker.record(card)
+            idx = (idx + 1) % 4
+        leader_index = players.index(trick.winner())
+
+    remaining_point_cards = sum(1 for p in players for c in p.hand if c.rank in ("A", "10", "K"))
+    expected_total_trick_points = remaining_point_cards * 10 + 10  # last-trick bonus still owed
+
+    result = rollout_deal(
+        players, trump, bid=50, bid_winner=bid_winner, tracker=tracker,
+        leader_index=leader_index, tricks_already_played=2, passing="none",
+        bidding_meld=bidding_meld, defending_meld=defending_meld,
+    )
+
+    assert result["auto_set"] is False
+    assert result["bidding_meld"] == bidding_meld
+    assert result["defending_meld"] == defending_meld
+    assert all(len(p.hand) == 0 for p in players)
+    total = result["bidding_trick_points"] + result["defending_trick_points"]
+    assert total == expected_total_trick_points, (total, expected_total_trick_points)
+
+
+# ---------------------------------------------------------------------------
+# 4. Convenience aggregate estimators - caller-supplied sample counts.
+# ---------------------------------------------------------------------------
+
+def test_estimate_bid_time_produces_valid_aggregate():
+    hand = _fresh_hands()[0]
+    trump = Suit.SPADES
+    num_samples = 20
+    result = estimate_bid_time(hand, trump, bid=250, num_samples=num_samples, rng=random.Random(7))
+    assert len(result["samples"]) == num_samples
+    assert 0.0 <= result["p_make"] <= 1.0
+    assert 0.0 <= result["auto_set_rate"] <= 1.0
+    assert result["expected_bidding_points"] >= 0
+    assert result["expected_defending_points"] >= 0
+
+
+def test_estimate_return_pass_produces_valid_aggregate():
+    deck = Deck()
+    deck.shuffle()
+    bidder_hand = deck.cards[0:15]
+    trump = Suit.SPADES
+    num_samples = 15
+    result = estimate_return_pass(bidder_hand, trump, bid=250, num_samples=num_samples, rng=random.Random(3))
+    assert len(result["samples"]) == num_samples
+    assert 0.0 <= result["p_make"] <= 1.0
+
+
+if __name__ == "__main__":
+    tests = [
+        test_unseen_cards_for_excludes_known_and_covers_rest,
+        test_unseen_cards_for_rejects_duplicate_known,
+        test_deal_unseen_cards_correct_counts_no_duplicates,
+        test_deal_unseen_cards_size_mismatch_raises,
+        test_sample_bid_time_deal_legal,
+        test_sample_return_pass_deal_legal,
+        test_sample_trick_play_deal_legal_and_uses_tracker,
+        test_played_counts_from_tracker_matches_recorded_plays,
+        test_is_auto_set_skips_guaranteed_set,
+        test_is_auto_set_does_not_skip_makeable_hand,
+        test_is_auto_set_boundary_is_strict,
+        test_rollout_deal_auto_set_skips_trick_play_entirely,
+        test_rollout_deal_no_passing_plays_out_all_tricks,
+        test_rollout_deal_with_both_passing_runs_real_pass_logic,
+        test_rollout_deal_mid_round_requires_explicit_meld,
+        test_rollout_deal_resumes_mid_round_with_correct_last_trick_bonus,
+        test_estimate_bid_time_produces_valid_aggregate,
+        test_estimate_return_pass_produces_valid_aggregate,
+    ]
+    for t in tests:
+        t()
+        print(f"{t.__name__} passed")
+    print(f"\n{len(tests)}/{len(tests)} test_rollout.py checks passed.")


### PR DESCRIPTION
## Summary

Part of #57, closes #59.

Foundation piece for the Expert AI epic: the shared Monte Carlo determinization + rollout machinery from `pinochle_expert_ai_strategy.md` Section 0, plus the Auto-SET guard from Section 5. Not wired into any Player strategy yet (that's #63) — this is infrastructure other issues (bid EV, pass logic, trick-play) will build on.

- **`pinochle_rollout.py`** (new module):
  - `unseen_cards_for` / `deal_unseen_cards` — generic determinization primitives (deal only the currently-unseen cards, never touch known ones).
  - `sample_bid_time_deal` / `sample_return_pass_deal` / `sample_trick_play_deal` — decision-point-specific wrappers matching Section 0's known/sampled table. The trick-play sampler reuses `PlayTracker.played_count` (not a second tracking mechanism, per the issue) via `played_counts_from_tracker`.
  - `is_auto_set` — the literal `meld + 250 < bid` inequality from Section 5.
  - `rollout_deal` — runs the **real** pass logic (`Player.choose_pass_cards`) and **real** trick-play logic (`choose_lead_card`/`choose_follow_card`) to completion on a fully-determinized sample, checking the Auto-SET guard before any 12-trick simulation and short-circuiting when it fires. Supports resuming mid-round for the trick-play decision point.
  - `monte_carlo_rollout` + `estimate_bid_time` / `estimate_return_pass` — aggregate P(make)/E[points] across N samples, with sample count always a caller-supplied parameter (never hardcoded).
- **`pinochle_engine.py`**: extracted `run_forward_pass` / `run_return_pass` / `play_tricks` as free functions so `Round` and the rollout sampler share exactly one implementation of "how passing/trick-play actually happens" — not two that can drift apart. `Round`'s external behavior is unchanged (verified against the existing test suite).
- **`test_rollout.py`** (new): sampler legality (correct counts, no duplicates, no leaks of known/already-played cards, across all three decision points), Auto-SET skip/no-skip/boundary cases, `rollout_deal`'s Auto-SET short-circuit and mid-round resume (correct last-trick-bonus placement), end-to-end aggregate estimator sanity checks.

Along the way, caught and fixed a real bug during test-writing: naively reconstructing "already-played" `Card` objects from `PlayTracker`'s counts (guessing `copy_id`) could collide with a real card known by exact identity elsewhere (e.g. the deciding player's own hand), silently dropping a card from the unseen pool. Fixed by decrementing counts directly from the remaining pool instead of reconstructing guessed `Card` objects.

## Test plan

- [x] `python test_rollout.py` — 18/18 new tests pass (ran 5x to check for flakiness from randomness).
- [x] `python test_ai_tiers.py` — 9/9 existing tests still pass after the `Round` refactor.
- [x] `python pinochle_engine.py` — existing `__main__` sanity checks (meld scoring, full games, mixed AI tiers) still pass.
- [x] Verified `human_play.py` still imports cleanly (its `InteractiveRound` overrides `_passing_phase`/`_trick_taking_loop` independently per the documented "known duplication," so it's unaffected by the `Round` refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)