### PR TITLE
Bid-time simulated EV via rollout sampler

### DIFF
--- a/pinochle_rollout.py
+++ b/pinochle_rollout.py
@@ -1,10 +1,12 @@
 """
-Monte Carlo determinization sampler + Auto-SET guard (issue #59).
+Monte Carlo determinization sampler + Auto-SET guard (issue #59), plus
+bid-time simulated EV built on top of it (issue #60).
 
 Foundation piece for the Expert AI epic (#57) - implements
 `pinochle_expert_ai_strategy.md` Section 0 (the shared determinization +
 rollout machinery that underlies bid-time EV, pass selection, and the
-"realistic ceiling" problem) and Section 5 (the Auto-SET hard prune).
+"realistic ceiling" problem), Section 1 (bid-time expected value), and
+Section 5 (the Auto-SET hard prune).
 
 This module is infrastructure only. It is deliberately NOT wired into any
 Player subclass's decision-making yet - that's issue #63 (GeneralStrategy).
@@ -24,6 +26,12 @@ What lives here is the shared machinery later issues will call:
   - Auto-SET guard (Section 5): a hard mathematical prune checked before
     any 12-trick rollout, so a sample that's already a guaranteed set
     skips the expensive trick-play simulation entirely.
+  - Bid-time EV (Section 1): `bid_ev` folds an `estimate_bid_time`
+    aggregate into a single EV(bid) number using the doc's formula, and
+    `choose_bid_by_ev` picks the candidate bid level that maximizes it -
+    the Expert-tier replacement for the static Base-Bid formula, at the
+    top of the skill range only. `Player`/`EasyPlayer.choose_bid` are
+    untouched; a higher-skill strategy calls this instead (issue #63).
 
 Sample counts are always a caller-supplied parameter (never hardcoded) -
 the doc suggests ~100-150 for bid-time and ~300+ for the one-time
@@ -448,3 +456,96 @@ def estimate_return_pass(hand, trump, bid, num_samples=300, rng=None):
         sample_fn, build_fn, trump, bid, num_samples,
         rollout_kwargs={"passing": "return_only"}, rng=rng,
     )
+
+
+# ---------------------------------------------------------------------------
+# Bid-time expected value (issue #60 / strategy doc Section 1) - EV-maximizing
+# bid selection, built on estimate_bid_time above rather than duplicating any
+# sampling/rollout logic. This is new, additive Expert-tier machinery: it
+# does not touch Player.choose_bid or EasyPlayer.choose_bid, which keep
+# using the static Base-Bid + Competitive-Adjustment formula (still correct
+# as the fast-path prior for those tiers, per the doc).
+# ---------------------------------------------------------------------------
+
+def bid_ev(hand, trump, bid, num_samples=150, rng=None):
+    """
+    Section 1's formula:
+
+        EV(bid) = P(make bid) x E[meld + trick points | made] -
+                  P(fail) x bid
+
+    Runs `estimate_bid_time` - the real determinization + rollout
+    machinery (real forward pass, real return pass, full real trick play,
+    Auto-SET guard included) - and folds the per-sample results into a
+    single expected-value number for this (hand, trump, bid) combination.
+
+    The "meld + trick points" term is deliberately conditioned on made ==
+    True samples only, not `estimate_bid_time`'s unconditional
+    `expected_bidding_points` (which averages in the *lower* totals from
+    samples that got set too, double-counting the failure penalty the
+    -P(fail) x bid term already covers). This mirrors the actual scoring
+    rule the formula models (see `Round._score_round` in
+    pinochle_engine.py): make the bid and your team scores whatever
+    meld+trick total it actually took; fail it and your team scores
+    exactly -bid instead, regardless of how close the total came. There
+    is no partial credit for a failed bid, so a failed sample's actual
+    total has no business feeding the "if made" average.
+
+    Returns (ev, diagnostics) - diagnostics is the aggregate dict from
+    `estimate_bid_time` (p_make, expected_bidding_points, auto_set_rate,
+    samples, ...) with one extra key, `expected_points_if_made` (0.0 if
+    no sample made the bid), so callers/tests can inspect the Monte Carlo
+    detail behind the number rather than just the final float.
+    """
+    diagnostics = estimate_bid_time(hand, trump, bid, num_samples=num_samples, rng=rng)
+    p_make = diagnostics["p_make"]
+    p_fail = 1.0 - p_make
+
+    made_samples = [r for r in diagnostics["samples"] if r["made"]]
+    if made_samples:
+        expected_points_if_made = sum(r["bidding_total"] for r in made_samples) / len(made_samples)
+    else:
+        expected_points_if_made = 0.0
+
+    diagnostics["expected_points_if_made"] = expected_points_if_made
+    ev = p_make * expected_points_if_made - p_fail * bid
+    return ev, diagnostics
+
+
+def choose_bid_by_ev(hand, trump, candidate_bids, num_samples=150, rng=None):
+    """
+    Section 1: "Choose the bid that maximizes EV ... rather than reading
+    off a fixed table." Evaluates `bid_ev` for every level in
+    `candidate_bids` under a single fixed candidate trump suit (the doc's
+    step 2 assumes trump - this function doesn't search trump suits, a
+    caller does that by calling it once per candidate trump) and returns
+    whichever bid has the highest EV.
+
+    `candidate_bids` may include `None` to represent "don't bid at all" -
+    modeled as a fixed EV of 0.0 (no points won, nothing risked) rather
+    than run a rollout for it, so passing is directly comparable to every
+    real bid level on the same EV scale instead of being a special case
+    the caller has to reason about separately.
+
+    Competitive/blocking bids are not a separate mechanic here, per the
+    doc: a caller just includes bid levels above the naive "optimal" one
+    in `candidate_bids`, and this same evaluation loop picks them up
+    automatically if their EV (accounting for the higher fail risk) still
+    beats every alternative - no hand-coded "should I block" branch.
+
+    Returns (best_bid, best_ev, all_evs) where `all_evs` maps every
+    candidate (including `None`, if supplied) to its EV, so callers/tests
+    can inspect the full comparison, not just the winner.
+    """
+    if not candidate_bids:
+        raise ValueError("candidate_bids must be non-empty")
+
+    all_evs = {}
+    for bid in candidate_bids:
+        if bid is None:
+            all_evs[None] = 0.0
+        else:
+            all_evs[bid], _ = bid_ev(hand, trump, bid, num_samples=num_samples, rng=rng)
+
+    best_bid = max(all_evs, key=all_evs.get)
+    return best_bid, all_evs[best_bid], all_evs

--- a/test_bid_ev.py
+++ b/test_bid_ev.py
@@ -1,0 +1,184 @@
+"""
+Tests for issue #60 - bid-time simulated EV via the rollout sampler
+(the `bid_ev` / `choose_bid_by_ev` additions to pinochle_rollout.py).
+Plain assert-based, pytest-discoverable, matching test_rollout.py's
+convention. Covers:
+
+  1. `bid_ev` returns a float EV plus an `estimate_bid_time`-shaped
+     diagnostics dict (with the extra `expected_points_if_made` key).
+  2. EV is directionally sane: a hand with a strong trump run + double
+     Pinochle (huge meld, strong trick-taking) has a much higher EV at a
+     fixed bid level than a scattered, meld-free, trump-less hand - the
+     doc's own acceptance criterion for this issue.
+  3. The -P(fail) x bid tail of the formula: a bid set absurdly high
+     (guaranteed Auto-SET on every sample, regardless of the random
+     deal) has p_make == 0 and EV == exactly -bid, since no sample ever
+     contributes to the "if made" average.
+  4. `choose_bid_by_ev` picks the higher-EV candidate in constructed A/B
+     comparisons, correctly folds in a `None` ("pass") candidate at EV
+     0.0, and raises on an empty candidate list.
+
+Real pass logic (`Player.choose_pass_cards` with trump_suit/is_bid_winner
+supplied) and real trick-play logic (`choose_lead_card`/
+`choose_follow_card`) are both deterministic given the dealt hands - the
+only randomness in a rollout is the determinized deal itself, which is
+drawn from the caller-supplied `rng`. So passing a seeded `random.Random`
+makes these tests reproducible without needing large sample counts.
+"""
+
+import random
+
+from pinochle_engine import Card, Suit
+from pinochle_rollout import bid_ev, choose_bid_by_ev
+
+
+# ---------------------------------------------------------------------------
+# Constructed hands.
+# ---------------------------------------------------------------------------
+
+def _strong_hand():
+    """
+    Trump run (A/10/K/Q/J of Clubs) + Double Pinochle (2x QS, 2x JD) +
+    an Ace of every other suit (bonus Aces Around, on top of already
+    strong trick-taking power from the trump top cards). 12 cards, huge
+    guaranteed meld (Run 150 + Double Pinochle 300 + Aces Around 100 =
+    550) and excellent trick-taking (holds the top of the trump suit
+    outright).
+    """
+    trump = Suit.CLUBS
+    return [
+        Card(trump, "A", 1), Card(trump, "10", 1), Card(trump, "K", 1),
+        Card(trump, "Q", 1), Card(trump, "J", 1),
+        Card(Suit.SPADES, "Q", 1), Card(Suit.SPADES, "Q", 2),
+        Card(Suit.DIAMONDS, "J", 1), Card(Suit.DIAMONDS, "J", 2),
+        Card(Suit.SPADES, "A", 1), Card(Suit.DIAMONDS, "A", 1), Card(Suit.HEARTS, "A", 1),
+    ], trump
+
+
+def _weak_hand(trump):
+    """
+    12 cards, zero trump (can never ruff), no marriages, no Pinochle, no
+    Arounds - constructed to score exactly 0 meld under `trump` (Clubs)
+    and hold little trick-taking power (only 2 Aces, everything else
+    low/mid, nothing that can beat a trump lead).
+    """
+    assert trump == Suit.CLUBS
+    return [
+        Card(Suit.SPADES, "9", 1), Card(Suit.DIAMONDS, "9", 1), Card(Suit.HEARTS, "9", 1),
+        Card(Suit.SPADES, "J", 1), Card(Suit.HEARTS, "J", 1),
+        Card(Suit.HEARTS, "Q", 1),
+        Card(Suit.SPADES, "K", 1), Card(Suit.DIAMONDS, "K", 1),
+        Card(Suit.HEARTS, "A", 1), Card(Suit.SPADES, "A", 1),
+        Card(Suit.DIAMONDS, "10", 1), Card(Suit.HEARTS, "10", 1),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. bid_ev basic shape.
+# ---------------------------------------------------------------------------
+
+def test_bid_ev_returns_float_and_diagnostics():
+    hand, trump = _strong_hand()
+    ev, diagnostics = bid_ev(hand, trump, bid=300, num_samples=10, rng=random.Random(1))
+    assert isinstance(ev, float)
+    assert len(diagnostics["samples"]) == 10
+    assert 0.0 <= diagnostics["p_make"] <= 1.0
+    assert "expected_points_if_made" in diagnostics
+    assert diagnostics["expected_points_if_made"] >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# 2. Directional sanity: strong meld/trick hand beats scattered weak hand.
+# ---------------------------------------------------------------------------
+
+def test_bid_ev_strong_hand_beats_weak_hand_at_same_bid():
+    strong_hand, trump = _strong_hand()
+    weak_hand = _weak_hand(trump)
+    bid = 300
+
+    strong_ev, strong_diag = bid_ev(strong_hand, trump, bid, num_samples=30, rng=random.Random(11))
+    weak_ev, weak_diag = bid_ev(weak_hand, trump, bid, num_samples=30, rng=random.Random(12))
+
+    assert strong_ev > weak_ev, (strong_ev, weak_ev)
+    # The strong hand's guaranteed meld alone (550) already clears the
+    # bid, so it should make it essentially every sample; the weak,
+    # trump-less, meld-free hand should struggle to reach 300 on trick
+    # points alone.
+    assert strong_diag["p_make"] > weak_diag["p_make"]
+
+
+# ---------------------------------------------------------------------------
+# 3. -P(fail) x bid tail: guaranteed Auto-SET on every sample.
+# ---------------------------------------------------------------------------
+
+def test_bid_ev_guaranteed_set_equals_negative_bid():
+    # A weak hand can't conceivably reach a bid this absurdly high no
+    # matter what partner/opponents are dealt (max any single hand can
+    # meld is nowhere near 5000 - 250), so every sample is auto-set,
+    # p_make is exactly 0, and EV collapses to exactly -bid (no sample
+    # ever contributes to the "if made" average).
+    trump = Suit.CLUBS
+    weak_hand = _weak_hand(trump)
+    bid = 5000
+
+    ev, diagnostics = bid_ev(weak_hand, trump, bid, num_samples=15, rng=random.Random(21))
+
+    assert diagnostics["p_make"] == 0.0
+    assert diagnostics["auto_set_rate"] == 1.0
+    assert diagnostics["expected_points_if_made"] == 0.0
+    assert ev == -float(bid)
+
+
+# ---------------------------------------------------------------------------
+# 4. choose_bid_by_ev - picks the higher-EV candidate.
+# ---------------------------------------------------------------------------
+
+def test_choose_bid_by_ev_picks_higher_ev_candidate():
+    strong_hand, trump = _strong_hand()
+    # 300 is trivially covered by guaranteed meld alone; 5000 is a
+    # guaranteed Auto-SET (see test above) regardless of hand strength.
+    best_bid, best_ev, all_evs = choose_bid_by_ev(
+        strong_hand, trump, candidate_bids=[300, 5000], num_samples=20, rng=random.Random(31),
+    )
+    assert best_bid == 300
+    assert set(all_evs.keys()) == {300, 5000}
+    assert all_evs[300] > all_evs[5000]
+    assert best_ev == all_evs[300]
+
+
+def test_choose_bid_by_ev_none_candidate_is_zero_ev_pass_option():
+    trump = Suit.CLUBS
+    weak_hand = _weak_hand(trump)
+    # A weak, meld-free, trump-less hand bidding an absurdly high amount
+    # is a guaranteed set (EV == -bid, deeply negative) - passing (EV
+    # 0.0) should win over it.
+    best_bid, best_ev, all_evs = choose_bid_by_ev(
+        weak_hand, trump, candidate_bids=[5000, None], num_samples=10, rng=random.Random(41),
+    )
+    assert best_bid is None
+    assert all_evs[None] == 0.0
+    assert best_ev == 0.0
+
+
+def test_choose_bid_by_ev_rejects_empty_candidates():
+    strong_hand, trump = _strong_hand()
+    try:
+        choose_bid_by_ev(strong_hand, trump, candidate_bids=[], num_samples=5)
+        assert False, "expected ValueError for empty candidate_bids"
+    except ValueError:
+        pass
+
+
+if __name__ == "__main__":
+    tests = [
+        test_bid_ev_returns_float_and_diagnostics,
+        test_bid_ev_strong_hand_beats_weak_hand_at_same_bid,
+        test_bid_ev_guaranteed_set_equals_negative_bid,
+        test_choose_bid_by_ev_picks_higher_ev_candidate,
+        test_choose_bid_by_ev_none_candidate_is_zero_ev_pass_option,
+        test_choose_bid_by_ev_rejects_empty_candidates,
+    ]
+    for t in tests:
+        t()
+        print(f"{t.__name__} passed")
+    print(f"\n{len(tests)}/{len(tests)} test_bid_ev.py checks passed.")


### PR DESCRIPTION
Part of #57, closes #60

## Summary

- Adds `bid_ev(hand, trump, bid, num_samples=150, rng=None)` to `pinochle_rollout.py`: implements strategy doc Section 1's `EV(bid) = P(make bid) x E[meld + trick points | made] - P(fail) x bid`, built on `estimate_bid_time` (issue #59) rather than duplicating any sampling/rollout logic. The "if made" term is deliberately conditioned on `made == True` samples only, matching `Round._score_round`'s real scoring rule: a made bid scores the actual total, a failed bid scores exactly `-bid` with no partial credit - so a failed sample's total has no business feeding that average.
- Adds `choose_bid_by_ev(hand, trump, candidate_bids, num_samples=150, rng=None)`: evaluates `bid_ev` for every candidate under one fixed candidate trump suit and returns the highest-EV bid. `None` is a valid candidate representing "pass," modeled as a fixed EV of 0.0. Competitive/blocking bids aren't a separate mechanic - a caller just includes bid levels above the naive optimum and the same evaluation loop picks them up if their EV wins.
- `Player.choose_bid` / `EasyPlayer.choose_bid` are untouched - this is new, additive Expert-tier logic that a higher-skill strategy will call later (issue #63/GeneralStrategy).
- Opponent-bid-reading and score-aware risk (Section 1's v2/optional refinements) are explicitly out of scope per the issue.

## Test plan

- [x] New `test_bid_ev.py`: EV's return shape (float + diagnostics dict), directional sanity (a hand with a trump run + Double Pinochle + Aces Around, 590 guaranteed meld, beats a scattered 0-meld trump-less hand at the same bid), the `-P(fail) x bid` tail via a guaranteed-Auto-SET absurdly-high bid (`EV == exactly -bid`), and `choose_bid_by_ev` picking the higher-EV candidate including the `None`/pass option and rejecting an empty candidate list.
- [x] `python test_bid_ev.py` - 6/6 passed
- [x] `python test_rollout.py` - 18/18 passed (unchanged, confirms #59's machinery still works under this new caller)
- [x] `python test_ai_tiers.py` - 9/9 passed (confirms `Player`/`EasyPlayer.choose_bid` untouched)
- [x] `python pinochle_engine.py` - engine self-checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)