### PR TITLE
Add shared forward/return pass logic (Sections 2-3, issue #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,17 @@ not yet implemented — see the strategy doc below.
 - [`pinochle_engine.py`](pinochle_engine.py) — the rules engine and
   Proficient AI: `Card`, `Deck`, `Player`, `Team`, `Trick`, `Round`,
   `Game`, meld scoring, bid valuation, passing strategy, trick-play
-  strategy.
+  strategy. Also holds the Expert-tier forward/return pass logic
+  (`choose_forward_pass_cards` / `choose_return_pass_cards`, issue #61,
+  `pinochle_expert_ai_strategy.md` Sections 2-3) as free functions
+  independent of any Player subclass, ready for both a future
+  `ExpertPlayer` (#63) and the rollout sampler's simulated players to
+  call into.
+- [`pinochle_rollout.py`](pinochle_rollout.py) — Monte Carlo
+  determinization sampler + Auto-SET guard (issue #59): deals the
+  currently-unseen cards for a decision point (bidding / return-pass /
+  trick-play), rolls a sample out to completion via the real pass/
+  trick-play logic, and aggregates P(make)/E[points] across samples.
 - [`human_play.py`](human_play.py) — resumable interactive play layer
   (`HumanPlayer`, `InteractiveRound`) built for chat-session play, where
   a script can't block on `input()` between messages: decisions raise

--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -871,6 +871,349 @@ def _bidder_pass_selection(hand, trump, category, count):
 
 
 # ---------------------------------------------------------------------------
+# Expert-tier pass logic (issue #61) — implements
+# pinochle_expert_ai_strategy.md Sections 2 (forward pass) and 3 (return
+# pass) as shared, callable logic, per the doc's Appendix: "there should be
+# exactly one implementation of 'how a partner passes', not two that can
+# drift apart." `choose_forward_pass_cards`/`choose_return_pass_cards` are
+# deliberately free functions, independent of the Proficient-tier
+# `_partner_pass_selection`/`_bidder_pass_selection` above (which stay
+# untouched — Proficient is the tournament control group, see
+# CLAUDE.md/README.md) and of any Player subclass, so both a future
+# ExpertPlayer (#63) and the rollout sampler's internal simulated players
+# (pinochle_rollout.py, #59) can call into the exact same code. Pure
+# functions over a hand + trump + count, independent of the rollout
+# machinery itself (per issue #61's Scope note) — callers that want
+# rollout-compare mode (Section 2) wire in a `rollout_evaluator` callback
+# from the outside; this module never imports pinochle_rollout.
+# ---------------------------------------------------------------------------
+
+def _pad_pass_selection(hand, chosen, count):
+    """Safety net matching Player.choose_pass_cards' own fallback: the
+    tiered logic above should always fill `count`, but pad deterministically
+    with whatever's left rather than ever returning short."""
+    if len(chosen) < count:
+        remaining = [c for c in hand if c not in chosen]
+        chosen = chosen + remaining[:count - len(chosen)]
+    return chosen[:count]
+
+
+def _tier0_forward_pass_candidates(hand, trump):
+    """
+    Section 2 Tier 0 — "always chase if missing": cards the partner should
+    unconditionally offer toward the bidder's meld, in priority order:
+
+      1. QS / JD (Pinochle) — trump-independent, always a candidate since
+         the physical cards are QS/JD specifically.
+      2. Trump A/10/K/Q/J (Run/Marriage) — trump-suit only, in RUN_RANKS
+         order (A, 10, K, Q, J).
+      3. Any Ace, any suit (Aces Around only).
+
+    Hard exclusion (doc-confirmed, not implemented here by omission, not
+    by a negative check): Kings/Queens/Jacks Around are NEVER chased, from
+    zero or from partial progress — no "3 Kings implies partner might hold
+    a Queen" heuristic. That kind of inference is meant to emerge from the
+    rollout itself (Section 0), not be hardcoded. A trump K/Q/J still shows
+    up here, but only via the Run/Marriage tier above, not because of
+    Kings/Queens/Jacks Around.
+    """
+    pool = list(hand)
+    chosen = []
+    limit = len(hand)
+
+    _take(pool, chosen, limit,
+          lambda c: (c.suit == Suit.SPADES and c.rank == "Q")
+          or (c.suit == Suit.DIAMONDS and c.rank == "J"))
+
+    _take(pool, chosen, limit,
+          lambda c: c.suit == trump and c.rank in RUN_RANKS,
+          sort_key=lambda c: RUN_RANKS.index(c.rank))
+
+    _take(pool, chosen, limit, lambda c: c.rank == "A")
+
+    return chosen
+
+
+def _tier1_forward_pass_candidates(hand, trump, exclude):
+    """
+    Section 2 Tier 1 — fallback shedding, used only when Tier 0 doesn't
+    fill all slots (static mode) or as the competing alternative to a
+    marginal Tier 0 pick (rollout-compare mode). Priority order:
+
+      1. Non-trump 10s not already chosen — zero meld value outside a
+         trump-only Run/Double Run, pure liability (same reasoning as the
+         return-pass rule in Section 3).
+      2. Other unprotected non-trump count-cards (A/K) that wouldn't break
+         partner's own kept marriage/around.
+      3. Void-building filler: a whole non-trump suit that fits the
+         remaining slots and contains nothing protected.
+      4. Any other non-trump card that doesn't break a kept meld.
+      5. True last resort: anything left (surplus trump, or a card that
+         would break a kept meld).
+
+    Concrete doc example: partner holds 10-K-Q of a non-trump suit and
+    nothing Tier-0 eligible — keeps K+Q (preserves the 20-pt Common
+    Marriage), ships the 10 (tier 1). Never proposes a card that would
+    break the partner's own kept meld ahead of one that wouldn't.
+    """
+    pool = [c for c in hand if c not in exclude]
+    chosen = []
+    limit = len(pool)
+
+    keeps_meld = lambda c: _breaks_marriage(hand, c) or _breaks_around(hand, c)
+
+    _take(pool, chosen, limit,
+          lambda c: c.suit != trump and c.rank == "10",
+          sort_key=lambda c: _suit_length(hand, c.suit))
+
+    _take(pool, chosen, limit,
+          lambda c: c.suit != trump and c.rank in POINT_RANKS and not keeps_meld(c),
+          sort_key=lambda c: _suit_length(hand, c.suit))
+
+    if len(chosen) < limit:
+        void_cards = _find_void_opportunity(pool, trump, keeps_meld, limit - len(chosen))
+        if void_cards:
+            for c in void_cards:
+                if c in pool and len(chosen) < limit:
+                    chosen.append(c)
+                    pool.remove(c)
+
+    _take(pool, chosen, limit, lambda c: c.suit != trump and not keeps_meld(c))
+    _take(pool, chosen, limit, lambda c: True)
+
+    return chosen
+
+
+def choose_forward_pass_cards(hand, trump, count, rollout_evaluator=None):
+    """
+    Section 2 entry point: partner -> bidder pass selection. Combines Tier
+    0 ("always chase if missing", `_tier0_forward_pass_candidates`) and
+    Tier 1 fallback shedding (`_tier1_forward_pass_candidates`).
+
+    **Resolved v1 design (doc Section 9 Q1 / issue #61's revised open
+    question)**: whether Tier 1 can outrank a marginal Tier 0 pick is NOT
+    one fixed global rule — it's a static-mode-vs-rollout-compare-mode
+    split tied to skill level (see #63's GeneralStrategy dial):
+
+      - `rollout_evaluator=None` (static/no-rollout-budget skill levels):
+        Tier 1 is a strict last resort — it only fills slots Tier 0 left
+        empty, and never outranks a Tier 0 pick. Intentionally not the
+        smartest possible play; that gap is part of what makes low skill
+        actually play worse.
+      - `rollout_evaluator` supplied (rollout-budget skill levels): no
+        hardcoded ranking. When Tier 0 alone has enough candidates to fill
+        every slot, this generates two candidate pass sets — the static
+        all-Tier-0 pick, and one that swaps the single lowest-priority
+        ("marginal") Tier 0 card for the best competing Tier 1 card — and
+        lets `rollout_evaluator` pick the winner by simulated EV. This is
+        what lets higher skill levels discover the cases where shedding
+        differently is actually correct, instead of following a fixed
+        rule.
+
+    `rollout_evaluator`, if provided, must be a callable:
+
+        rollout_evaluator(hand, trump, candidate_cards) -> float
+
+    returning a higher-is-better simulated EV for passing exactly
+    `candidate_cards` (a list of `count` Card objects drawn from `hand`).
+    This function only needs that numeric comparison — it never imports or
+    calls into pinochle_rollout.py itself, so it stays pure/testable
+    against constructed hands independent of the rollout machinery (a
+    caller wires a real evaluator on top of `monte_carlo_rollout`/
+    `rollout_deal` from pinochle_rollout.py, #59, elsewhere).
+    """
+    tier0 = _tier0_forward_pass_candidates(hand, trump)
+
+    if len(tier0) < count:
+        # Tier 0 has nothing left to offer for the remaining slots — both
+        # modes agree here, there's no marginal pick to compare against.
+        chosen = list(tier0)
+        tier1 = _tier1_forward_pass_candidates(hand, trump, exclude=chosen)
+        chosen += tier1[:count - len(chosen)]
+        return _pad_pass_selection(hand, chosen, count)
+
+    static_chosen = tier0[:count]
+    if rollout_evaluator is None:
+        return static_chosen
+
+    tier1 = _tier1_forward_pass_candidates(hand, trump, exclude=static_chosen)
+    if not tier1:
+        return static_chosen  # nothing to compare against — static and compare modes agree
+
+    marginal_kept = static_chosen[:-1]
+    competing_tier1_pick = tier1[0]
+    candidate_static = static_chosen
+    candidate_compare = marginal_kept + [competing_tier1_pick]
+
+    ev_static = rollout_evaluator(hand, trump, candidate_static)
+    ev_compare = rollout_evaluator(hand, trump, candidate_compare)
+    return candidate_compare if ev_compare > ev_static else candidate_static
+
+
+def _first_n_of(hand, suit, rank, n):
+    return [c for c in hand if c.suit == suit and c.rank == rank][:n]
+
+
+def _return_pass_meld_groups(hand, trump):
+    """
+    Section 3 knapsack input: every meld currently present in `hand` (same
+    categories as `score_melds`), as (value, name, required_cards) triples.
+    `required_cards` are the exact physical Card objects that meld needs —
+    deliberately allowed to overlap across groups (e.g. a trump King is
+    part of both Run and Royal Marriage using the very same card), since
+    `_knapsack_lock_return_pass_melds` below dedupes by tracking what's
+    already locked rather than by partitioning cards into disjoint pools.
+    """
+    groups = []
+
+    def n(suit, rank):
+        return _n_of(hand, suit, rank)
+
+    run_count = min(n(trump, r) for r in RUN_RANKS)
+    if run_count == 2:
+        cards = [c for r in RUN_RANKS for c in _first_n_of(hand, trump, r, 2)]
+        groups.append((DOUBLE_RUN_VALUE, "Double Run", cards))
+    elif run_count == 1:
+        cards = [c for r in RUN_RANKS for c in _first_n_of(hand, trump, r, 1)]
+        groups.append((RUN_VALUE, "Run", cards))
+
+    royal_count = min(n(trump, "K"), n(trump, "Q"))
+    if royal_count:
+        cards = _first_n_of(hand, trump, "K", royal_count) + _first_n_of(hand, trump, "Q", royal_count)
+        groups.append((royal_count * ROYAL_MARRIAGE_VALUE, "Royal Marriage", cards))
+
+    for suit in Suit:
+        if suit == trump:
+            continue
+        cm = min(n(suit, "K"), n(suit, "Q"))
+        if cm:
+            cards = _first_n_of(hand, suit, "K", cm) + _first_n_of(hand, suit, "Q", cm)
+            groups.append((cm * COMMON_MARRIAGE_VALUE, f"Common Marriage ({suit.value})", cards))
+
+    dix_count = n(trump, "9")
+    if dix_count:
+        groups.append((dix_count * DIX_VALUE, "Dix", _first_n_of(hand, trump, "9", dix_count)))
+
+    qs_count = n(Suit.SPADES, "Q")
+    jd_count = n(Suit.DIAMONDS, "J")
+    pin_count = min(qs_count, jd_count)
+    if pin_count == 2:
+        cards = _first_n_of(hand, Suit.SPADES, "Q", 2) + _first_n_of(hand, Suit.DIAMONDS, "J", 2)
+        groups.append((PINOCHLE_DOUBLE_VALUE, "Double Pinochle", cards))
+    elif pin_count == 1:
+        cards = _first_n_of(hand, Suit.SPADES, "Q", 1) + _first_n_of(hand, Suit.DIAMONDS, "J", 1)
+        groups.append((PINOCHLE_SINGLE_VALUE, "Pinochle", cards))
+
+    for rank, base in AROUND_VALUES.items():
+        around_count = min(n(s, rank) for s in Suit)
+        if around_count == 2:
+            cards = [c for s in Suit for c in _first_n_of(hand, s, rank, 2)]
+            groups.append((base * AROUND_DOUBLE_MULTIPLIER, f"{rank}s Around (double)", cards))
+        elif around_count == 1:
+            cards = [c for s in Suit for c in _first_n_of(hand, s, rank, 1)]
+            groups.append((base, f"{rank}s Around", cards))
+
+    return groups
+
+
+def _knapsack_lock_return_pass_melds(hand, trump, cap):
+    """
+    Section 3 knapsack triage: sort candidate meld groups by point value
+    descending, greedily lock the cards each one needs — skipping cards a
+    higher-value group already locked — as long as the running total stays
+    within `cap` slots. A group that would push the total over `cap` is
+    skipped ENTIRELY, never partially locked: doc example — a hand that
+    could complete Kings Around (80) *and* Run (150) + Double Pinochle
+    (300) + Aces Around (100) but lacks slots for all of it breaks Kings
+    Around whole and keeps the higher group whole.
+
+    **Resolved v1 default (doc Section 9 Q2)**: this has no "reopen a
+    locked meld to chase its Double" step — a complete single meld that
+    gets locked here stays locked for good, it is never broken later to
+    protect progress toward a Double of the same meld. Documented here as
+    the current default/tunable, same as Section 2's mode split.
+    """
+    groups = sorted(_return_pass_meld_groups(hand, trump), key=lambda g: -g[0])
+    locked = []
+    for _value, _name, cards in groups:
+        additional = [c for c in cards if c not in locked]
+        if len(locked) + len(additional) <= cap:
+            locked.extend(additional)
+    return locked
+
+
+def _return_pass_pool_priority(pool, hand, trump):
+    """
+    Section 3 shedding priority within the return-pass pool (cards NOT
+    locked by the knapsack triage — see `_knapsack_lock_return_pass_melds`).
+    Objective: reduce the Bidder's count-card liability, pass loser-points
+    to partner. Priority order:
+
+      1. Non-trump 10s — zero meld value outside a trump-only Run/Double
+         Run, so any non-trump 10 not needed for a Run is a top ship
+         candidate (doc-mandated, tier-agnostic).
+      2. Other unprotected non-trump count-cards (A/K) — reduces liability
+         the Bidder would otherwise have to protect through 12 tricks.
+      3. Void-building filler: a whole non-trump suit that fits the
+         remaining slots.
+      4. Any other non-trump card.
+      5. True last resort: trump (or anything left).
+    """
+    remaining = list(pool)
+    chosen = []
+    limit = len(remaining)
+
+    # Everything reaching this pool is already NOT part of a locked meld
+    # (that's what makes it pool, not locked), so there's no kept-meld to
+    # break here — `_find_void_opportunity` still wants an is_protected
+    # callback, so pass a permissive no-op.
+    not_protected = lambda c: False
+
+    _take(remaining, chosen, limit,
+          lambda c: c.suit != trump and c.rank == "10",
+          sort_key=lambda c: _suit_length(hand, c.suit))
+
+    _take(remaining, chosen, limit,
+          lambda c: c.suit != trump and c.rank in POINT_RANKS,
+          sort_key=lambda c: _suit_length(hand, c.suit))
+
+    if len(chosen) < limit:
+        void_cards = _find_void_opportunity(remaining, trump, not_protected, limit - len(chosen))
+        if void_cards:
+            for c in void_cards:
+                if c in remaining and len(chosen) < limit:
+                    chosen.append(c)
+                    remaining.remove(c)
+
+    _take(remaining, chosen, limit, lambda c: c.suit != trump)
+    _take(remaining, chosen, limit, lambda c: True)
+
+    return chosen
+
+
+def choose_return_pass_cards(hand, trump, count):
+    """
+    Section 3 entry point: bidder -> partner pass selection. `hand` is the
+    bidder's full 15-card hand (12 dealt + 3 already received from the
+    forward pass) — no restriction on which cards can be returned,
+    including ones just received (pinochle_rules.md).
+
+    Knapsack-locks up to `len(hand) - count` cards to the hand's
+    highest-value melds (`_knapsack_lock_return_pass_melds`), then ranks
+    everything NOT locked by shedding priority
+    (`_return_pass_pool_priority`) and ships the top `count`. Locking never
+    exceeds `len(hand) - count` cards, so the pool is always guaranteed at
+    least `count` cards — the fallback pad below is just a defensive net,
+    not expected to ever trigger in practice.
+    """
+    cap = len(hand) - count
+    locked = _knapsack_lock_return_pass_melds(hand, trump, cap)
+    pool = [c for c in hand if c not in locked]
+    chosen = _return_pass_pool_priority(pool, hand, trump)[:count]
+    return _pad_pass_selection(hand, chosen, count)
+
+
+# ---------------------------------------------------------------------------
 # Player / Team
 # ---------------------------------------------------------------------------
 

--- a/pinochle_expert_ai_strategy.md
+++ b/pinochle_expert_ai_strategy.md
@@ -152,9 +152,26 @@ Tier-0 eligible. Correct play: **keep K+Q** (preserves the partner's own
 of Run/Double Run, which are trump-only — a non-trump 10 is pure
 liability; shipping it also starts a void).
 
-**OPEN QUESTION:** Is Tier 1 strictly a last resort (only used to fill
-slots when Tier 0 is exhausted), or can it actively outrank a marginal
-Tier 0 pick? Needs a decision before implementing the priority sort.
+**Resolved for v1 (issue #61, revised)**: this is not one fixed global
+rule — it's a static-mode-vs-rollout-compare-mode split tied to skill
+level (see #63's dial), implemented as an optional `rollout_evaluator`
+callback on the shared `choose_forward_pass_cards` function
+(`pinochle_engine.py`):
+
+- **Static/no-rollout-budget skill levels** (no evaluator passed): Tier 1
+  is a strict last resort — it only fills slots Tier 0 left empty, and
+  never outranks a Tier 0 pick. This is intentionally not the smartest
+  possible play; that gap is part of what makes low skill actually play
+  worse.
+- **Rollout-budget skill levels** (evaluator passed): no hardcoded
+  ranking. Generate both the marginal Tier 0 candidate and the competing
+  Tier 1 candidate, and let the determinization sampler (#59) score each
+  via a mini pass-and-rollout EV comparison — whichever wins, wins. This
+  lets higher skill levels discover the cases where shedding differently
+  is actually correct, instead of following a fixed rule.
+
+Documented as the current default/tunable, same as the knapsack-doubles
+question in Section 3.
 
 ---
 
@@ -190,11 +207,14 @@ return-pass pool. Example: a hand that could complete Kings Around (80)
 slots for all of it should break the Kings Around and keep the higher
 group.
 
-**OPEN QUESTION:** Does this triage extend to doubles — e.g., is it ever
-correct to break a *complete* single Aces Around (100) to protect
-progress toward a Double Aces Around (1000)? Needs a decision; the
-greedy-by-value approach as described handles single-vs-single cleanly
-but hasn't been validated against double-vs-single tradeoffs.
+**Resolved for v1 (issue #61)**: no — the greedy-by-value knapsack does
+NOT break a complete single meld (e.g. a finished Aces Around) to chase a
+Double of the same meld. `choose_return_pass_cards`
+(`pinochle_engine.py`) locks melds highest-value-first and never reopens
+a lock once made — a complete single meld that gets locked stays locked
+for good. Documented as the current default/tunable; validating
+double-vs-single tradeoffs empirically is left to future tournament-sim
+tuning, not hand-coded here.
 
 ### Advanced: duplicate-card elimination plays (last resort, situational)
 
@@ -369,10 +389,14 @@ batch-simulate variants and let win rate pick the winner.
 
 ## 9. Open Design Questions — resolve before implementing the affected section
 
-1. **(Section 2)** Is Tier-1 forward-pass shedding strictly a last resort,
-   or can it outrank a marginal Tier-0 pick?
-2. **(Section 3)** Does return-pass knapsack triage extend to
-   doubles (e.g., break a complete single Around to chase its Double)?
+1. ~~**(Section 2)** Is Tier-1 forward-pass shedding strictly a last
+   resort, or can it outrank a marginal Tier-0 pick?~~ **Resolved for
+   v1** (issue #61): both, split by skill level via an optional
+   `rollout_evaluator` callback — see Section 2.
+2. ~~**(Section 3)** Does return-pass knapsack triage extend to
+   doubles (e.g., break a complete single Around to chase its
+   Double)?~~ **Resolved for v1** (issue #61): no, completed melds
+   stay locked once knapsacked — see Section 3.
 3. **(Section 4)** What does "fold" mean for a Bidder with no trump Ace —
    a bid-time signal (don't take the contract on such a hand) or a
    mid-hand behavioral shift (keep the contract, abandon the aggressive
@@ -411,4 +435,8 @@ batch-simulate variants and let win rate pick the winner.
   (Section 3) as shared, callable logic — used both by the real
   `choose_pass_cards` and by the sampler's internal simulated players,
   so there's exactly one implementation of "how a partner passes," not
-  two that can drift apart.
+  two that can drift apart. **Implemented (issue #61)** as
+  `choose_forward_pass_cards` / `choose_return_pass_cards` in
+  `pinochle_engine.py`, independent of any Player subclass — a future
+  `ExpertPlayer` (#63) and the rollout sampler's internal simulated
+  players both call into the same functions.

--- a/test_expert_pass.py
+++ b/test_expert_pass.py
@@ -1,0 +1,412 @@
+"""
+Tests for issue #61 - Forward/return pass rollout logic (shared pass
+strategy), implementing pinochle_expert_ai_strategy.md Sections 2 (forward
+pass) and 3 (return pass) as shared, callable functions
+(`choose_forward_pass_cards` / `choose_return_pass_cards` in
+pinochle_engine.py) independent of any Player subclass or the rollout
+sampler itself. Plain assert-based, pytest-discoverable, matching
+test_rollout.py / test_ai_tiers.py's convention.
+
+Covers:
+  1. Section 2 Tier 0 "always chase if missing" - each category (trump
+     Run/Marriage completion, QS/JD Pinochle trump-independence, missing
+     Ace toward Aces Around).
+  2. The hard exclusion: Kings/Queens/Jacks Around are never chased, from
+     zero or from partial progress - no soft "3 Kings implies a Queen"
+     heuristic.
+  3. Tier 1 fallback shedding, static mode: strictly a last resort, matches
+     the doc's concrete 10-K-Q example (keep the marriage, ship the 10).
+  4. The resolved v1 mode split (doc Section 9 Q1): static mode never lets
+     Tier 1 outrank a marginal Tier 0 pick; rollout-compare mode (an
+     injected `rollout_evaluator` callback) can and does pick differently
+     on the same hand - proving the two modes actually diverge, not just
+     that both exist.
+  5. Section 3: non-trump 10s are automatic top ship candidates.
+  6. Section 3 knapsack triage: a hand with more meld-in-progress than
+     fits in the post-pass hand breaks the lowest-value meld whole and
+     keeps the higher-value groups whole (doc's Kings-Around-vs-Run
+     example).
+  7. The resolved v1 default (doc Section 9 Q2): a complete single meld
+     that gets knapsack-locked is never reopened/broken later to chase a
+     Double of the same meld.
+  8. General legality: both functions always return exactly `count`
+     distinct cards actually present in the input hand, across many
+     randomized hands.
+
+Run directly (`python test_expert_pass.py`) or via pytest.
+"""
+
+import random
+
+from pinochle_engine import (
+    Card,
+    Deck,
+    Suit,
+    choose_forward_pass_cards,
+    choose_return_pass_cards,
+    score_melds,
+    _knapsack_lock_return_pass_melds,
+    _tier0_forward_pass_candidates,
+    _tier1_forward_pass_candidates,
+)
+
+
+def C(suit, rank, copy_id=1):
+    return Card(suit, rank, copy_id)
+
+
+def _names(cards):
+    return sorted(f"{c.rank}{c.suit.value}" for c in cards)
+
+
+def _fresh_hands():
+    deck = Deck()
+    deck.shuffle()
+    cards = deck.cards
+    return [cards[i * 12:(i + 1) * 12] for i in range(4)]
+
+
+# ---------------------------------------------------------------------------
+# 1. Section 2 Tier 0 - "always chase if missing", per category.
+# ---------------------------------------------------------------------------
+
+def test_tier0_chases_each_trump_run_rank():
+    trump = Suit.HEARTS
+    for rank in ("A", "10", "K", "Q", "J"):
+        hand = [C(trump, rank)] + [C(Suit.CLUBS, "9", i) for i in (1, 2)] * 5
+        hand = hand[:12]
+        tier0 = _tier0_forward_pass_candidates(hand, trump)
+        assert any(c.suit == trump and c.rank == rank for c in tier0), (rank, tier0)
+
+
+def test_tier0_chases_pinochle_trump_independent():
+    """QS/JD are Tier 0 regardless of the declared trump suit."""
+    for trump in Suit:
+        hand = [C(Suit.SPADES, "Q"), C(Suit.DIAMONDS, "J")] + \
+            [C(Suit.CLUBS, "9", i) for i in (1, 2)] * 5
+        hand = hand[:12]
+        tier0 = _tier0_forward_pass_candidates(hand, trump)
+        names = _names(tier0)
+        assert "QS" in names and "JD" in names, (trump, names)
+
+
+def test_tier0_chases_missing_ace_toward_aces_around():
+    trump = Suit.HEARTS
+    for suit in Suit:
+        hand = [C(suit, "A")] + [C(Suit.CLUBS, "9", i) for i in (1, 2)] * 5
+        hand = hand[:12]
+        tier0 = _tier0_forward_pass_candidates(hand, trump)
+        assert any(c.suit == suit and c.rank == "A" for c in tier0), (suit, tier0)
+
+
+# ---------------------------------------------------------------------------
+# 2. Hard exclusion - Kings/Queens/Jacks Around never chased, even from
+#    partial progress. No soft "3 Kings implies a Queen" heuristic.
+# ---------------------------------------------------------------------------
+
+def test_tier0_never_chases_kings_around_even_with_partial_progress():
+    trump = Suit.HEARTS
+    # 3 Kings already held (partial progress toward Kings Around) - the
+    # doc explicitly forbids treating this as chase-worthy.
+    hand = [C(Suit.SPADES, "K"), C(Suit.DIAMONDS, "K"), C(Suit.CLUBS, "K")] + \
+        [C(Suit.CLUBS, "9", 1), C(Suit.CLUBS, "9", 2)] * 4 + [C(Suit.DIAMONDS, "9")]
+    hand = hand[:12]
+    tier0 = _tier0_forward_pass_candidates(hand, trump)
+    names = _names(tier0)
+    # None of the non-trump Kings should appear (KH would be fine - that's
+    # the trump King, chased via Run/Marriage, not via Kings Around).
+    assert "KS" not in names and "KD" not in names and "KC" not in names, names
+
+
+def test_tier0_never_chases_queens_or_jacks_around_from_zero():
+    trump = Suit.HEARTS
+    hand = [C(Suit.CLUBS, "Q"), C(Suit.SPADES, "J")] + \
+        [C(Suit.DIAMONDS, "9", i) for i in (1, 2)] * 5
+    hand = hand[:12]
+    tier0 = _tier0_forward_pass_candidates(hand, trump)
+    names = _names(tier0)
+    assert "QC" not in names  # not trump, not QS -> no Pinochle/Run reason either
+    assert "JS" not in names  # not trump, not JD -> no Pinochle/Run reason either
+
+
+def test_tier0_trump_kqj_still_chased_via_run_not_around():
+    """The stated exception: a trump K/Q/J IS Tier 0, but only via
+    Run/Marriage/Pinochle reasoning, never via Kings/Queens/Jacks Around."""
+    trump = Suit.SPADES
+    hand = [C(Suit.SPADES, "K"), C(Suit.SPADES, "Q"), C(Suit.SPADES, "J")] + \
+        [C(Suit.CLUBS, "9", i) for i in (1, 2)] * 4 + [C(Suit.DIAMONDS, "9")]
+    hand = hand[:12]
+    tier0 = _tier0_forward_pass_candidates(hand, trump)
+    names = _names(tier0)
+    assert {"KS", "QS", "JS"} <= set(names)
+
+
+# ---------------------------------------------------------------------------
+# 3. Section 2 Tier 1 - static mode is a strict last resort. Doc's
+#    concrete example: 10-K-Q of a non-trump suit, nothing Tier-0 eligible
+#    -> keep K+Q (preserves the Common Marriage), ship the 10.
+# ---------------------------------------------------------------------------
+
+def _no_tier0_hand(trump):
+    """12-card hand with zero Tier 0 candidates: no QS/JD, no trump
+    A/10/K/Q/J, no Aces anywhere - isolates Tier 1 behavior."""
+    assert trump == Suit.HEARTS, "helper assumes HEARTS trump for the fixed card list below"
+    return [
+        C(Suit.CLUBS, "10"), C(Suit.CLUBS, "K"), C(Suit.CLUBS, "Q"),
+        C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2),
+        C(Suit.DIAMONDS, "9"), C(Suit.DIAMONDS, "9", 2),
+        C(Suit.SPADES, "9"), C(Suit.SPADES, "9", 2),
+        C(Suit.HEARTS, "9"), C(Suit.HEARTS, "9", 2),
+        C(Suit.CLUBS, "J"),
+    ]
+
+
+def test_tier1_static_mode_keeps_marriage_ships_the_ten():
+    trump = Suit.HEARTS
+    hand = _no_tier0_hand(trump)
+    assert len(hand) == 12
+    assert _tier0_forward_pass_candidates(hand, trump) == []
+
+    chosen = choose_forward_pass_cards(hand, trump, 3)
+    names = _names(chosen)
+    assert "10C" in names, names
+    assert "KC" not in names and "QC" not in names, "must not break the kept Common Marriage"
+
+
+def test_tier1_is_strict_last_resort_in_static_mode():
+    """When Tier 0 has enough candidates to fill every slot, static mode
+    (no rollout_evaluator) never reaches into Tier 1 at all."""
+    trump = Suit.HEARTS
+    hand = [
+        C(Suit.SPADES, "Q"), C(Suit.DIAMONDS, "J"), C(Suit.HEARTS, "A"),
+        C(Suit.CLUBS, "10"),  # prime Tier 1 candidate (non-trump 10) - must NOT be picked
+        C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2),
+        C(Suit.DIAMONDS, "9"), C(Suit.DIAMONDS, "9", 2),
+        C(Suit.SPADES, "9"), C(Suit.SPADES, "9", 2),
+        C(Suit.CLUBS, "K"), C(Suit.CLUBS, "J"),
+    ]
+    assert len(hand) == 12
+    chosen = choose_forward_pass_cards(hand, trump, 3)
+    names = _names(chosen)
+    assert "10C" not in names, names
+    assert set(names) == {"QS", "JD", "AH"}
+
+
+# ---------------------------------------------------------------------------
+# 4. Resolved v1 mode split (doc Section 9 Q1): rollout-compare mode CAN
+#    pick a Tier 1 card over a marginal Tier 0 pick; static mode never
+#    does. Proves the two modes actually diverge on the same hand.
+# ---------------------------------------------------------------------------
+
+def _marginal_vs_competing_hand():
+    trump = Suit.HEARTS
+    hand = [
+        C(Suit.SPADES, "Q"), C(Suit.DIAMONDS, "J"), C(Suit.HEARTS, "A"),
+        C(Suit.CLUBS, "10"),  # the Tier 1 challenger
+        C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2),
+        C(Suit.DIAMONDS, "9"), C(Suit.DIAMONDS, "9", 2),
+        C(Suit.SPADES, "9"), C(Suit.SPADES, "9", 2),
+        C(Suit.CLUBS, "K"), C(Suit.CLUBS, "J"),
+    ]
+    assert len(hand) == 12
+    return trump, hand
+
+
+def test_rollout_compare_mode_can_outrank_marginal_tier0_pick():
+    trump, hand = _marginal_vs_competing_hand()
+
+    static_chosen = choose_forward_pass_cards(hand, trump, 3)
+    assert _names(static_chosen) == ["AH", "JD", "QS"]
+
+    def prefer_the_ten(hand, trump, candidates):
+        return 20.0 if any(c.rank == "10" and c.suit == Suit.CLUBS for c in candidates) else 10.0
+
+    compare_chosen = choose_forward_pass_cards(hand, trump, 3, rollout_evaluator=prefer_the_ten)
+    assert _names(compare_chosen) == ["10C", "JD", "QS"]
+
+    assert _names(static_chosen) != _names(compare_chosen), \
+        "rollout-compare mode must be able to pick differently than static mode"
+
+
+def test_rollout_compare_mode_keeps_static_pick_when_evaluator_prefers_it():
+    """Symmetric check: the evaluator - not a hardcoded ranking - decides.
+    When it scores the static (Tier 0) candidate higher, compare mode
+    agrees with static mode."""
+    trump, hand = _marginal_vs_competing_hand()
+
+    def prefer_the_ace(hand, trump, candidates):
+        return 20.0 if any(c.rank == "A" and c.suit == Suit.HEARTS for c in candidates) else 10.0
+
+    static_chosen = choose_forward_pass_cards(hand, trump, 3)
+    compare_chosen = choose_forward_pass_cards(hand, trump, 3, rollout_evaluator=prefer_the_ace)
+    assert _names(static_chosen) == _names(compare_chosen)
+
+
+# ---------------------------------------------------------------------------
+# 5. Section 3 - non-trump 10s are automatic top ship candidates.
+# ---------------------------------------------------------------------------
+
+def test_non_trump_tens_are_auto_ship_candidates():
+    trump = Suit.HEARTS
+    hand = [
+        C(Suit.CLUBS, "10"), C(Suit.DIAMONDS, "10"),
+        C(Suit.HEARTS, "A"), C(Suit.HEARTS, "K"),
+        C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2),
+        C(Suit.DIAMONDS, "9"), C(Suit.DIAMONDS, "9", 2),
+        C(Suit.SPADES, "9"), C(Suit.SPADES, "9", 2),
+        C(Suit.CLUBS, "K"), C(Suit.CLUBS, "Q"),
+        C(Suit.SPADES, "K"), C(Suit.SPADES, "Q"),
+        C(Suit.CLUBS, "J"),
+    ]
+    assert len(hand) == 15
+    chosen = choose_return_pass_cards(hand, trump, 3)
+    names = _names(chosen)
+    assert "10C" in names and "10D" in names, names
+
+
+def test_trump_ten_not_treated_as_auto_ship():
+    """A trump 10 is part of a potential Run, not a "zero meld value"
+    liability - only NON-trump 10s get the automatic-ship treatment."""
+    trump = Suit.HEARTS
+    hand = [
+        C(Suit.HEARTS, "10"),  # trump 10 - part of the Run below, must be kept
+        C(Suit.HEARTS, "A"), C(Suit.HEARTS, "K"), C(Suit.HEARTS, "Q"), C(Suit.HEARTS, "J"),
+        C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2),
+        C(Suit.DIAMONDS, "9"), C(Suit.DIAMONDS, "9", 2),
+        C(Suit.SPADES, "9"), C(Suit.SPADES, "9", 2),
+        C(Suit.CLUBS, "J"), C(Suit.SPADES, "J"),
+        C(Suit.CLUBS, "K"), C(Suit.SPADES, "K"),
+    ]
+    assert len(hand) == 15
+    chosen = choose_return_pass_cards(hand, trump, 3)
+    names = _names(chosen)
+    assert "10H" not in names, "trump 10 (Run piece) must not be shipped"
+
+
+# ---------------------------------------------------------------------------
+# 6. Section 3 knapsack triage: more meld-in-progress than fits - break
+#    the lowest-value group whole, keep the higher-value groups whole.
+# ---------------------------------------------------------------------------
+
+def test_knapsack_breaks_lowest_value_meld_when_overflowing():
+    trump = Suit.HEARTS
+    hand = [
+        # Run (150): trump A,10,K,Q,J
+        C(Suit.HEARTS, "A"), C(Suit.HEARTS, "10"), C(Suit.HEARTS, "K"),
+        C(Suit.HEARTS, "Q"), C(Suit.HEARTS, "J"),
+        # Double Pinochle (300): QS x2, JD x2
+        C(Suit.SPADES, "Q", 1), C(Suit.SPADES, "Q", 2),
+        C(Suit.DIAMONDS, "J", 1), C(Suit.DIAMONDS, "J", 2),
+        # Aces Around (100): A of S, D, C (H ace already in the Run above)
+        C(Suit.SPADES, "A"), C(Suit.DIAMONDS, "A"), C(Suit.CLUBS, "A"),
+        # Kings Around (80): K of S, D, C (H king already in the Run above)
+        C(Suit.SPADES, "K"), C(Suit.DIAMONDS, "K"), C(Suit.CLUBS, "K"),
+    ]
+    assert len(hand) == 15
+    total, breakdown = score_melds(hand, trump)
+    assert breakdown.get("Ks Around") == 80  # sanity: Kings Around really is present
+
+    chosen = choose_return_pass_cards(hand, trump, 3)
+    names = set(_names(chosen))
+    assert names == {"KS", "KD", "KC"}, names
+
+    # And the higher-value groups genuinely stayed intact (weren't touched).
+    remaining = [c for c in hand if c not in chosen]
+    remaining_total, remaining_breakdown = score_melds(remaining, trump)
+    assert "Run" in remaining_breakdown
+    assert "Double Pinochle" in remaining_breakdown
+    assert "As Around" in remaining_breakdown
+    assert "Ks Around" not in remaining_breakdown
+
+
+def test_knapsack_lock_never_exceeds_cap():
+    """A meld group that doesn't fit is skipped whole, never partially
+    locked - the locked set can never exceed the cap."""
+    trump = Suit.HEARTS
+    hand = [
+        C(Suit.HEARTS, "A"), C(Suit.HEARTS, "10"), C(Suit.HEARTS, "K"),
+        C(Suit.HEARTS, "Q"), C(Suit.HEARTS, "J"),
+        C(Suit.SPADES, "Q", 1), C(Suit.SPADES, "Q", 2),
+        C(Suit.DIAMONDS, "J", 1), C(Suit.DIAMONDS, "J", 2),
+        C(Suit.SPADES, "A"), C(Suit.DIAMONDS, "A"), C(Suit.CLUBS, "A"),
+        C(Suit.SPADES, "K"), C(Suit.DIAMONDS, "K"), C(Suit.CLUBS, "K"),
+    ]
+    for cap in range(0, 16):
+        locked = _knapsack_lock_return_pass_melds(hand, trump, cap)
+        assert len(locked) <= cap, (cap, len(locked))
+
+
+# ---------------------------------------------------------------------------
+# 7. Resolved v1 default (doc Section 9 Q2): a complete single meld that's
+#    locked stays locked - never reopened/broken to chase its Double.
+# ---------------------------------------------------------------------------
+
+def test_complete_single_meld_not_reopened_to_chase_its_double():
+    """Bidder holds a complete Aces Around (100, locked) plus 3 more Aces
+    of the same suits already used (an impossible extra copy in real play,
+    but the point here is purely mechanical: the knapsack must never try
+    to "break" the locked Aces Around to protect duplicate progress toward
+    a Double). Ships from the lower-value clutter instead, and the locked
+    Aces Around cards are never candidates."""
+    trump = Suit.HEARTS
+    hand = [
+        C(Suit.HEARTS, "A"), C(Suit.HEARTS, "10"), C(Suit.HEARTS, "K"),
+        C(Suit.HEARTS, "Q"), C(Suit.HEARTS, "J"),  # Run (150) - highest value, locked first
+        C(Suit.SPADES, "A"), C(Suit.DIAMONDS, "A"), C(Suit.CLUBS, "A"),  # Aces Around (100)
+        C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2),
+        C(Suit.DIAMONDS, "9"), C(Suit.DIAMONDS, "9", 2),
+        C(Suit.SPADES, "9"), C(Suit.SPADES, "9", 2),
+        C(Suit.CLUBS, "10"),
+    ]
+    assert len(hand) == 15
+    _, breakdown = score_melds(hand, trump)
+    assert breakdown.get("As Around") == 100
+
+    locked = _knapsack_lock_return_pass_melds(hand, trump, cap=12)
+    locked_names = set(_names(locked))
+    assert {"AS", "AD", "AC"} <= locked_names, "the complete Aces Around must be locked"
+
+    chosen = choose_return_pass_cards(hand, trump, 3)
+    chosen_names = set(_names(chosen))
+    assert not (chosen_names & {"AS", "AD", "AC"}), \
+        "a locked complete meld must never be broken to chase its Double"
+    assert "10C" in chosen_names  # the actual non-trump-10 liability, correctly shipped instead
+
+
+# ---------------------------------------------------------------------------
+# 8. General legality across randomized hands.
+# ---------------------------------------------------------------------------
+
+def test_forward_pass_always_legal_and_exact_count():
+    for _ in range(15):
+        for hand in _fresh_hands():
+            for trump in Suit:
+                chosen = choose_forward_pass_cards(hand, trump, 3)
+                assert len(chosen) == 3
+                assert len(set(id(c) for c in chosen)) == 3
+                for c in chosen:
+                    assert c in hand
+
+
+def test_return_pass_always_legal_and_exact_count():
+    deck = Deck()
+    deck.shuffle()
+    cards = deck.cards
+    for _ in range(15):
+        random.shuffle(cards)
+        hand15 = cards[:15]
+        for trump in Suit:
+            chosen = choose_return_pass_cards(hand15, trump, 3)
+            assert len(chosen) == 3
+            assert len(set(id(c) for c in chosen)) == 3
+            for c in chosen:
+                assert c in hand15
+
+
+if __name__ == "__main__":
+    tests = [obj for name, obj in list(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    for t in tests:
+        t()
+        print(f"OK: {t.__name__}")
+    print(f"\n{len(tests)} tests passed.")


### PR DESCRIPTION
## Summary

Implements `pinochle_expert_ai_strategy.md` Sections 2 (forward pass) and 3 (return pass) as pure, shared functions — `choose_forward_pass_cards` / `choose_return_pass_cards` in `pinochle_engine.py` — independent of any `Player` subclass, per the doc's Appendix: "exactly one implementation of 'how a partner passes'." Ready for a future `ExpertPlayer` (#63) and for the rollout sampler's simulated players to call into.

- **Forward pass (Section 2)**: Tier 0 "always chase if missing" — trump A/10/K/Q/J (Run/Marriage), QS/JD (Pinochle, trump-independent), missing Ace toward Aces Around — with the hard Kings/Queens/Jacks-Around exclusion (never chased, even from partial progress, no soft "3 Kings implies a Queen" heuristic). Tier 1 fallback shedding never breaks partner's own kept marriage/around.
- **Resolves doc Section 9 Q1 (revised)**: Tier 1 vs Tier 0 priority is *not* one global rule. `choose_forward_pass_cards` takes an optional `rollout_evaluator(hand, trump, candidates) -> float` callback:
  - `None` → static mode: Tier 1 is a strict last resort, never outranks a Tier 0 pick (low/no-rollout-budget skill levels).
  - callback supplied → compare-via-rollout mode: generates the marginal Tier 0 candidate and the competing Tier 1 candidate, lets the callback's simulated EV pick the winner (high/rollout-budget skill levels, #63's dial).
  - The pass-logic module never imports `pinochle_rollout.py` — stays pure/testable against constructed hands independent of the sampler, per the issue's Scope note. A caller wires the callback on top of `monte_carlo_rollout`/`rollout_deal` (#59).
- **Return pass (Section 3)**: non-trump 10s are automatic top ship candidates (zero meld value outside a trump-only Run). Real knapsack triage: sort candidate meld groups by value descending, greedily lock cards to the highest-value groups first — a group that doesn't fit is skipped whole, never partially locked.
- **Resolves doc Section 9 Q2**: the knapsack never reopens a locked complete meld to chase a Double of the same meld — completed simple melds stay locked.
- `pinochle_expert_ai_strategy.md`'s two open questions are marked resolved for v1, pointing at the implementation.

## Test plan

- [x] `test_expert_pass.py` (17 new tests): each Tier 0 category, the hard Kings/Queens/Jacks-Around exclusion (including partial-progress), Tier 1's static-mode strict-last-resort behavior (doc's 10-K-Q concrete example), a constructed case proving rollout-compare mode picks a Tier 1 card over a marginal Tier 0 pick + a symmetric case where it still agrees with static mode, the non-trump-10 auto-ship rule (and that a *trump* 10 is NOT auto-shipped), a knapsack-overflow case (Kings Around correctly broken to keep Run + Double Pinochle + Aces Around intact), the locked-meld-never-reopened-for-doubles default, and general legal-move/exact-count checks across randomized hands.
- [x] Full suite: `python -m pytest -q` → 48 passed (31 pre-existing + 17 new), nothing else broken.
- [x] `python pinochle_engine.py` self-checks (meld scoring, full-game sanity runs) still pass.

Part of #57, closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)