### PR TITLE
Fix New Game confirm popup, missing trump on pass screen, uneven hand cards

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "pinochle-web",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "cwd": "web",
+      "port": 5173
+    }
+  ]
+}

--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -157,7 +157,8 @@ export function AuctionFlow({
 
     if (
       (state.phase === 'passing-partner-to-bidder' || state.phase === 'passing-bidder-to-partner') &&
-      state.bidWinner !== null
+      state.bidWinner !== null &&
+      state.trumpSuit !== null
     ) {
       const partner = partnerOf(state.bidWinner)
       const isPartnerStep = state.phase === 'passing-partner-to-bidder'
@@ -168,6 +169,7 @@ export function AuctionFlow({
           <PassSelector
             hand={state.hands[humanPlayer]}
             count={PASS_COUNT}
+            trumpSuit={state.trumpSuit}
             onConfirm={(cards) => dispatch({ type: 'PASS_CARDS', from: sender, to: receiver, cards })}
           />
         )

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,37 @@
+export interface ConfirmDialogProps {
+  message: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/**
+ * In-app confirmation modal, styled to match MainMenu/OptionsPanel rather
+ * than a native `window.confirm()` — the native dialog blocks the whole
+ * page (and looks like a bare browser alert, not part of the app) rather
+ * than rendering as one of this app's own modals.
+ */
+export function ConfirmDialog({ message, onConfirm, onCancel }: ConfirmDialogProps) {
+  return (
+    <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/70 p-4">
+      <div className="w-full max-w-xs rounded-lg bg-white p-6 text-center text-neutral-900 shadow-xl">
+        <p className="text-sm">{message}</p>
+        <div className="mt-6 flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="w-full rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900"
+          >
+            Start new game
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="w-full rounded bg-neutral-200 px-4 py-2 font-semibold text-neutral-900 hover:bg-neutral-300"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/GameShell.test.tsx
+++ b/web/src/components/GameShell.test.tsx
@@ -70,11 +70,27 @@ describe('GameShell', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
 
     fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
     fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
-    expect(confirmSpy).toHaveBeenCalledOnce()
+    // In-app confirm dialog (not a native window.confirm — that blocks the
+    // whole page and doesn't match the rest of the app's styled modals).
+    expect(screen.getByText('Start a new game? Your current saved game will be lost.')).not.toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     // Declined — the menu is still up, nothing was reset.
     expect(screen.getByText('Pinochle')).not.toBeNull()
+    expect(screen.queryByText('Start a new game? Your current saved game will be lost.')).toBeNull()
+  })
+
+  it('New Game confirmation actually discards the save when accepted', async () => {
+    mockDeal()
+    render(<GameShell />)
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Start new game' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+    expect(Deck.prototype.deal).toHaveBeenCalledTimes(2)
   })
 
   it('toggling "Hide opponent cards" in Options affects the next game rendered', async () => {

--- a/web/src/components/GameShell.tsx
+++ b/web/src/components/GameShell.tsx
@@ -15,6 +15,7 @@
 import { useState } from 'react'
 import { clearSave, hasSavedGame, loadGame } from '../persistence/gameSave'
 import { loadOptions, saveOptions, type GameOptions } from '../persistence/options'
+import { ConfirmDialog } from './ConfirmDialog'
 import { GameFlow } from './GameFlow'
 import type { GameFlowState } from './gameFlowReducer'
 import { MainMenu } from './MainMenu'
@@ -30,17 +31,24 @@ export function GameShell() {
   const [resumeState, setResumeState] = useState<GameFlowState | null>(null)
   const [menuOpen, setMenuOpen] = useState(false)
   const [optionsOpen, setOptionsOpen] = useState(false)
+  const [confirmNewGameOpen, setConfirmNewGameOpen] = useState(false)
   const [options, setOptions] = useState<GameOptions>(() => loadOptions())
 
   function startNewGame(): void {
-    if (hasSavedGame() && !window.confirm('Start a new game? Your current saved game will be lost.')) {
+    if (hasSavedGame()) {
+      setConfirmNewGameOpen(true)
       return
     }
+    doStartNewGame()
+  }
+
+  function doStartNewGame(): void {
     clearSave()
     setResumeState(null)
     setMountKey((k) => k + 1)
     setScreen('game')
     setMenuOpen(false)
+    setConfirmNewGameOpen(false)
   }
 
   function continueGame(): void {
@@ -74,6 +82,13 @@ export function GameShell() {
         {optionsOpen && (
           <OptionsPanel options={options} onChange={updateOptions} onClose={() => setOptionsOpen(false)} />
         )}
+        {confirmNewGameOpen && (
+          <ConfirmDialog
+            message="Start a new game? Your current saved game will be lost."
+            onConfirm={doStartNewGame}
+            onCancel={() => setConfirmNewGameOpen(false)}
+          />
+        )}
       </>
     )
   }
@@ -97,6 +112,13 @@ export function GameShell() {
       )}
       {optionsOpen && (
         <OptionsPanel options={options} onChange={updateOptions} onClose={() => setOptionsOpen(false)} />
+      )}
+      {confirmNewGameOpen && (
+        <ConfirmDialog
+          message="Start a new game? Your current saved game will be lost."
+          onConfirm={doStartNewGame}
+          onCancel={() => setConfirmNewGameOpen(false)}
+        />
       )}
     </>
   )

--- a/web/src/components/PassSelector.test.tsx
+++ b/web/src/components/PassSelector.test.tsx
@@ -15,12 +15,18 @@ const hand = [
 
 describe('PassSelector', () => {
   it('shows the running selection count', () => {
-    render(<PassSelector hand={hand} count={3} onConfirm={() => {}} />)
+    render(<PassSelector hand={hand} count={3} trumpSuit={Suit.Hearts} onConfirm={() => {}} />)
     expect(screen.getByText(/Choose 3 cards to pass \(0\/3 selected\)/)).not.toBeNull()
   })
 
+  it('shows the trump suit so the player can see it without hunting for the header', () => {
+    render(<PassSelector hand={hand} count={3} trumpSuit={Suit.Hearts} onConfirm={() => {}} />)
+    const heading = screen.getByRole('heading', { name: /Choose 3 cards to pass/ })
+    expect(heading.textContent).toContain('Trump: ♥')
+  })
+
   it('keeps Confirm disabled until exactly `count` cards are selected', () => {
-    render(<PassSelector hand={hand} count={3} onConfirm={() => {}} />)
+    render(<PassSelector hand={hand} count={3} trumpSuit={Suit.Hearts} onConfirm={() => {}} />)
     const confirm = screen.getByRole('button', { name: 'Confirm pass' })
     expect(confirm.hasAttribute('disabled')).toBe(true)
 
@@ -33,24 +39,24 @@ describe('PassSelector', () => {
   })
 
   it('does not allow selecting more than `count` cards', () => {
-    render(<PassSelector hand={hand} count={2} onConfirm={() => {}} />)
+    render(<PassSelector hand={hand} count={2} trumpSuit={Suit.Hearts} onConfirm={() => {}} />)
     fireEvent.click(screen.getByRole('img', { name: 'A of S' }))
     fireEvent.click(screen.getByRole('img', { name: 'K of H' }))
     fireEvent.click(screen.getByRole('img', { name: 'Q of D' }))
-    expect(screen.getByText('Choose 2 cards to pass (2/2 selected)')).not.toBeNull()
+    expect(screen.getByText(/Choose 2 cards to pass \(2\/2 selected\)/)).not.toBeNull()
   })
 
   it('toggles a card back off when clicked again', () => {
-    render(<PassSelector hand={hand} count={3} onConfirm={() => {}} />)
+    render(<PassSelector hand={hand} count={3} trumpSuit={Suit.Hearts} onConfirm={() => {}} />)
     const ace = screen.getByRole('img', { name: 'A of S' })
     fireEvent.click(ace)
     fireEvent.click(ace)
-    expect(screen.getByText('Choose 3 cards to pass (0/3 selected)')).not.toBeNull()
+    expect(screen.getByText(/Choose 3 cards to pass \(0\/3 selected\)/)).not.toBeNull()
   })
 
   it('calls onConfirm with exactly the selected cards', () => {
     const onConfirm = vi.fn()
-    render(<PassSelector hand={hand} count={2} onConfirm={onConfirm} />)
+    render(<PassSelector hand={hand} count={2} trumpSuit={Suit.Hearts} onConfirm={onConfirm} />)
     fireEvent.click(screen.getByRole('img', { name: 'A of S' }))
     fireEvent.click(screen.getByRole('img', { name: 'K of H' }))
     fireEvent.click(screen.getByRole('button', { name: 'Confirm pass' }))

--- a/web/src/components/PassSelector.tsx
+++ b/web/src/components/PassSelector.tsx
@@ -1,12 +1,17 @@
 import { useState } from 'react'
-import type { Card } from '../engine/card'
+import type { Card, Suit } from '../engine/card'
 import { sortHandForDisplay } from '../engine/card'
 import { PlayingCard } from './PlayingCard'
+import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
 
 export interface PassSelectorProps {
   hand: readonly Card[]
   /** How many cards must be selected before Confirm is enabled — passing.ts's `PASS_COUNT`. */
   count: number
+  /** Trump is already settled by the time passing happens — shown here so
+   * the player doesn't have to hunt for it in the (dimmed, overlay-covered)
+   * header while deciding what to pass. */
+  trumpSuit: Suit
   onConfirm: (cards: Card[]) => void
 }
 
@@ -17,8 +22,9 @@ export interface PassSelectorProps {
  * which hand/role this renders for; this component just enforces "exactly
  * `count` selected" before letting the player confirm.
  */
-export function PassSelector({ hand, count, onConfirm }: PassSelectorProps) {
+export function PassSelector({ hand, count, trumpSuit, onConfirm }: PassSelectorProps) {
   const [selected, setSelected] = useState<Card[]>([])
+  const trumpColor = RED_SUITS.includes(trumpSuit) ? 'text-red-600' : 'text-neutral-900'
 
   const toggle = (card: Card) => {
     setSelected((prev) => {
@@ -31,7 +37,8 @@ export function PassSelector({ hand, count, onConfirm }: PassSelectorProps) {
   return (
     <div className="w-full max-w-2xl rounded-lg bg-white p-4 text-neutral-900 shadow-xl">
       <h3 className="text-sm font-semibold">
-        Choose {count} cards to pass ({selected.length}/{count} selected)
+        Choose {count} cards to pass ({selected.length}/{count} selected) — Trump:{' '}
+        <span className={`text-base font-bold ${trumpColor}`}>{SUIT_GLYPH[trumpSuit]}</span>
       </h3>
       <div className="mt-3 flex flex-wrap justify-center gap-1">
         {sortHandForDisplay(hand).map((card) => {

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -54,7 +54,13 @@ export function Seat({ seat, position, isHuman, isBidWinner, playable, hideOppon
         )}
       </div>
       {isHuman ? (
-        <div className="flex flex-wrap justify-center gap-1 overflow-x-auto">
+        // A single row, not `flex-wrap`: the fanned-overlap look below relies
+        // on `first:ml-0` to zero out the leading card's negative margin, which
+        // only identifies the true first card in the DOM — with wrapping on, a
+        // second row's leading card still carried the big negative margin and
+        // rendered shifted/misaligned relative to the row above it. One row
+        // that scrolls horizontally instead keeps every row's cards flush.
+        <div className="flex justify-center gap-1 overflow-x-auto">
           {sortHandForDisplay(seat.hand).map((card) => {
             const cardFace = <PlayingCard suit={card.suit} rank={card.rank} />
             if (!playable) {


### PR DESCRIPTION
## Summary
Three UI bugs reported after testing the app in-browser:

1. **Native confirm() popup on New Game** — `GameShell.tsx` called `window.confirm(...)` when New Game would discard an existing save. That's a native browser dialog, jarring and inconsistent with the rest of the app's styled modals (and blocks the page entirely). Replaced with a new `ConfirmDialog.tsx` component matching `MainMenu`/`OptionsPanel` styling.
2. **Trump not shown while passing cards** — trump is already settled by the pass phase, but `PassSelector.tsx` never displayed it; the only place it showed was the header's small `Trump: X` indicator, dimmed behind the pass overlay's backdrop. Added it directly to the pass screen's heading.
3. **Uneven/misaligned hand cards** — `Seat.tsx`'s human hand row combined `flex-wrap` with a negative-margin card-overlap ("fan") technique that relies on `first:ml-0` to zero out the leading card's margin. `first:ml-0` only identifies the true first DOM child, so when the row wrapped, the second row's leading card kept the large negative margin and rendered visibly shifted out of line with the row above. Removed `flex-wrap` — the hand is now a single row that scrolls horizontally instead.

Also adds `.claude/launch.json` so `preview_start` can launch the web dev server for browser verification going forward.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx oxlint` clean
- [x] `npx vitest run` — 239/239 passing
- [x] Manually verified in-browser (user confirmed all three fixes look correct)