### PR TITLE
Add Expert-tier trick-play strategy + gated deception (issue #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,18 @@ not yet implemented — see the strategy doc below.
   `Game`, meld scoring, bid valuation, passing strategy, trick-play
   strategy. Also holds the Expert-tier forward/return pass logic
   (`choose_forward_pass_cards` / `choose_return_pass_cards`, issue #61,
-  `pinochle_expert_ai_strategy.md` Sections 2-3) as free functions
-  independent of any Player subclass, ready for both a future
-  `ExpertPlayer` (#63) and the rollout sampler's simulated players to
-  call into.
+  `pinochle_expert_ai_strategy.md` Sections 2-3) and Expert-tier
+  trick-play logic (`choose_expert_lead_card` / `choose_expert_follow_card`,
+  issue #62, Sections 4 and 7) as free functions independent of any
+  `Player` subclass, ready for both a future `ExpertPlayer` (#63) and the
+  rollout sampler's simulated players to call into. Trick-play logic
+  covers Ace-first trump leads (shared by the Bidder and partner),
+  endgame loser-first sequencing to protect the 12th-trick bonus,
+  following-suit heuristics (duck/feed, count-card protection,
+  over/under-trump judgment), a static-vs-rollout-compare split for
+  whether defenders ever lead trump, and false-carding/fake-void
+  deception as pluggable candidate moves gated behind an optional
+  `deception_evaluator`.
 - [`pinochle_rollout.py`](pinochle_rollout.py) — Monte Carlo
   determinization sampler + Auto-SET guard (issue #59): deals the
   currently-unseen cards for a decision point (bidding / return-pass /

--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -1214,6 +1214,346 @@ def choose_return_pass_cards(hand, trump, count):
 
 
 # ---------------------------------------------------------------------------
+# Expert-tier trick-play logic (issue #62) — implements
+# pinochle_expert_ai_strategy.md Section 4 (trick-play strategy) and, gated
+# behind an optional deception_evaluator, Section 7 (deception) as shared,
+# callable logic. Same design shape as Section 2/3's
+# choose_forward_pass_cards / choose_return_pass_cards above (issue #61):
+# free functions, independent of any Player subclass and of the Proficient-
+# tier choose_lead_card / choose_follow_card (which stay untouched — that's
+# the tournament control group, see CLAUDE.md/README.md) — reused/extended
+# here rather than duplicated, per this issue's Scope note. A future
+# ExpertPlayer (#63) and the rollout sampler's internal simulated players
+# (pinochle_rollout.py, #59) can both call into the exact same code. This
+# module never imports pinochle_rollout — callers that want rollout-compare
+# mode (defenders' trump-lead question, Section 9 Q5) or deception wire in
+# real evaluator callbacks from the outside, built on top of
+# monte_carlo_rollout/rollout_deal elsewhere, matching #61's precedent of
+# leaving that wiring to the GeneralStrategy issue.
+# ---------------------------------------------------------------------------
+
+TOTAL_TRUMP_COPIES = 12  # 6 ranks x 2 copies each
+
+
+def _trick_has_points(trick_plays):
+    return any(c.rank in POINT_RANKS for _, c in trick_plays)
+
+
+def _trump_fully_accounted(hand, trump, tracker):
+    """
+    Conservative proxy for Section 4's endgame trigger, "no trump remains
+    live among opponents". Real trick play only ever exposes this player's
+    own hand plus PlayTracker's played-so-far counts — never partner's
+    hand — so there is no way to prove trump is specifically dead among
+    *opponents* without also knowing partner's hand. This reuses the same
+    accounted-for pattern as `is_safe`/`is_unsecured_ace` above: sum
+    played-count + this hand's own count for every trump rank, and only
+    fire when that reaches all 12 copies (i.e. no trump card remains
+    unaccounted for ANYWHERE — a strictly stronger, always-safe subset of
+    "dead among opponents", since it also implies dead among partner).
+    Documented as the current default/tunable, same spirit as Section
+    2/3's resolved v1 defaults.
+    """
+    accounted = sum(
+        tracker.played_count(trump, rank) + _hand_count(hand, trump, rank)
+        for rank in RANKS
+    )
+    return accounted >= TOTAL_TRUMP_COPIES
+
+
+def _offense_trump_lead(hand, trump, tracker):
+    """
+    Section 4 "Bidder leading — draw trump", shared by both the Bidder and
+    the Bidder's partner (doc Section 9 Q4, resolved for v1: the partner
+    runs this exact same logic independently if *they* end up on lead —
+    no special-casing that defers to the Bidder's plan). Callers on the
+    bidding team (either seat) call this same function; there is exactly
+    one implementation of "how the offense leads trump", not two that can
+    drift apart.
+
+    1. If a trump Ace is held, it is always the first lead — unconditionally
+       (doc Section 4 point 1: unbeatable by rank, risk-free, and clarifies
+       whether the second Ace is still live).
+    2. Otherwise (doc Section 9 Q3, resolved for v1): this is a mid-hand
+       behavioral shift, not a bid-time refusal — the contract is kept
+       (bid-time EV already priced this risk in), but the aggressive
+       trump-draw plan is abandoned in favor of a conservative lead:
+       protect count cards, don't force trump out. Concretely, this
+       prefers any non-trump lead (via the existing safe-card cascade,
+       `choose_lead_card`) over proactively leading trump; trump is only
+       led here if it's literally all that's left in hand.
+    """
+    trump_aces = [c for c in hand if c.suit == trump and c.rank == "A"]
+    if trump_aces:
+        return trump_aces[0]
+
+    non_trump = [c for c in hand if c.suit != trump]
+    if non_trump:
+        return choose_lead_card(non_trump, trump, tracker)
+    return choose_lead_card(hand, trump, tracker)
+
+
+def _defender_lead(hand, trump, tracker, rollout_evaluator=None):
+    """
+    Section 4 "Defending team" — doc Section 9 Q5, revised resolution: NOT
+    one fixed global rule, the same static-mode-vs-rollout-compare-mode
+    split as #61, tied to skill level (see #63's dial):
+
+      - `rollout_evaluator=None` (static/no-rollout-budget skill levels):
+        avoid leading trump — it helps the Bidder consolidate control —
+        and instead attack the Bidder's weakest suit. Implemented as the
+        existing safe-card cascade (`choose_lead_card`) restricted to
+        non-trump cards (falls back to trump only when the hand is
+        entirely trump, i.e. there is no other legal lead at all).
+      - `rollout_evaluator` supplied (rollout-budget skill levels): no
+        hardcoded avoidance. Generates both the static non-trump-lead
+        candidate AND a trump-lead candidate, and lets
+        `rollout_evaluator` pick whichever scores better in this exact
+        game state — e.g. once the Bidder is nearly out of trump, leading
+        trump may no longer help them and the flat avoidance rule would
+        be wrong. This is exactly the kind of exception higher skill
+        should be able to find that the static rule can't.
+
+    `rollout_evaluator`, if provided, must be a callable:
+
+        rollout_evaluator(hand, trump, tracker, candidate_card) -> float
+
+    returning a higher-is-better simulated EV for leading `candidate_card`
+    in this exact state. This function only needs that numeric comparison
+    — it never imports or calls into pinochle_rollout.py itself, so it
+    stays pure/testable against constructed hands independent of the
+    rollout machinery (a caller wires a real evaluator on top of
+    `monte_carlo_rollout`/`rollout_deal` from pinochle_rollout.py, #59,
+    elsewhere).
+    """
+    non_trump = [c for c in hand if c.suit != trump]
+    trump_cards = [c for c in hand if c.suit == trump]
+
+    static_pick = (
+        choose_lead_card(non_trump, trump, tracker) if non_trump
+        else choose_lead_card(hand, trump, tracker)
+    )
+
+    if rollout_evaluator is None or not trump_cards or not non_trump:
+        return static_pick
+
+    trump_pick = choose_lead_card(trump_cards, trump, tracker)
+    ev_static = rollout_evaluator(hand, trump, tracker, static_pick)
+    ev_trump = rollout_evaluator(hand, trump, tracker, trump_pick)
+    return trump_pick if ev_trump > ev_static else static_pick
+
+
+def choose_expert_lead_card(hand, trump, tracker, is_bidding_team, rollout_evaluator=None):
+    """
+    Section 4 entry point for leading (having table control). Order of
+    decisions:
+
+      1. Endgame sequencing (doc "Endgame sequencing — protect the
+         last-trick bonus"): once no trump remains live among opponents
+         (see `_trump_fully_accounted` for exactly what that means here)
+         and this hand holds a mix of trump and non-trump cards, play
+         losers first and hold trump back — this guarantees a trump card
+         is still in hand to win trick 12's +10 bonus. Implemented by
+         restricting the lead choice to non-trump cards via the existing
+         safe-card cascade.
+      2. Otherwise, dispatch by side: the bidding team (Bidder or
+         partner, doc Section 9 Q4) uses the shared Ace-first trump-draw
+         logic (`_offense_trump_lead`); the defending team (doc Section 9
+         Q5) uses the static/rollout-compare split (`_defender_lead`).
+
+    `rollout_evaluator` is only consulted for a defending-team lead (see
+    `_defender_lead`) — the offense side's Ace-first rule has no
+    static/compare split (doc Section 4 point 1 is unconditional).
+    """
+    non_trump = [c for c in hand if c.suit != trump]
+    trump_cards = [c for c in hand if c.suit == trump]
+
+    if trump_cards and non_trump and _trump_fully_accounted(hand, trump, tracker):
+        return choose_lead_card(non_trump, trump, tracker)
+
+    if is_bidding_team:
+        return _offense_trump_lead(hand, trump, tracker)
+    return _defender_lead(hand, trump, tracker, rollout_evaluator=rollout_evaluator)
+
+
+def generate_false_card_candidates(hand, legal_moves, trick_plays, tracker):
+    """
+    Section 7 false-carding: legal alternative follow-plays that
+    misrepresent this player's holding in the suit being played — e.g.
+    playing a card other than the "honest" cheapest-sufficient/lowest
+    choice so an opponent tracking per-copy history (`PlayTracker`, reused
+    here rather than rebuilt) reads the remaining holding incorrectly.
+
+    Only proposes a rank as a false-card candidate when it's still
+    *believable* — i.e. the other physical copy of that exact (suit,
+    rank) is not yet fully accounted for (played, or still in this hand)
+    — so the deception isn't immediately self-defeating: playing a rank
+    you're provably out of (because both copies are otherwise accounted
+    for) wouldn't fool a card-counting opponent regardless of which one
+    you play.
+
+    Pure candidate generator — every returned card is drawn from
+    `legal_moves`, so it is trivially still a legal move. Never called
+    unless a caller supplies a `deception_evaluator` to
+    `choose_expert_follow_card`; does not decide anything on its own.
+    """
+    if len(legal_moves) < 2:
+        return []
+    candidates = []
+    for c in legal_moves:
+        other_copy_accounted = (
+            tracker.played_count(c.suit, c.rank) + _hand_count(hand, c.suit, c.rank) >= 2
+        )
+        if not other_copy_accounted:
+            candidates.append(c)
+    return candidates
+
+
+def generate_fake_void_candidates(hand, legal_moves, trick_plays, trump, tracker):
+    """
+    Section 7 fake voids: only meaningful during a genuine free sluff —
+    more than one suit represented among `legal_moves` — where discarding
+    from a suit that already has at least one copy of that same card's
+    rank recorded as played (via `PlayTracker`) is more believable as "I'm
+    voiding this suit" than a first-ever discard from it would be.
+
+    Pure candidate generator, same contract as
+    `generate_false_card_candidates` — every returned card is drawn from
+    `legal_moves`, so it is trivially still legal.
+    """
+    suits_present = {c.suit for c in legal_moves}
+    if len(suits_present) < 2:
+        return []  # no real choice of which suit to discard from
+    candidates = []
+    for c in legal_moves:
+        if tracker.played_count(c.suit, c.rank) >= 1:
+            candidates.append(c)
+    return candidates
+
+
+def _expert_follow_card_honest(hand, legal_moves, trick_plays, trump, my_team_players, tracker):
+    """
+    Section 4 "Following suit (general)" — the non-deceptive baseline
+    follow-card choice `choose_expert_follow_card` builds on:
+
+      - Mandatory-beat cases (`Trick.legal_moves` has already restricted
+        `legal_moves` to beaters-only) win as cheaply as possible — this
+        is where "third-hand-high" is mechanically enforced by the rules
+        engine itself, so there's no separate heuristic needed for it.
+      - Duck when partner is already winning: don't spend a big card on a
+        trick that's already secured; feed K/10 across if doing so is
+        free (doesn't cost the trick).
+      - Protect count cards (A/10/K): when following suit but unable to
+        beat, or when free-sluffing, prefer a zero-count card (9/J/Q)
+        over a count card whenever one is legal.
+      - Trump-in judgment when first to trump a trick (void of the lead
+        suit, no trump yet on the table — the one point in this ruleset
+        where trumping in is mandatory but *which* trump is a genuine
+        free choice): over-trump (commit the highest trump held) only
+        when the trick is worth winning — it already carries count
+        points, or the partner isn't already the one showing as the
+        trick's leader — otherwise under-trump (play the lowest trump
+        held) to conserve high trump for later.
+    """
+    lead_suit = trick_plays[0][1].suit if trick_plays else None
+    winner_player, winner_card = _current_winner(trick_plays, trump) if trick_plays else (None, None)
+    partner_winning = winner_player in my_team_players if winner_player else False
+
+    all_lead_suit = lead_suit is not None and all(c.suit == lead_suit for c in legal_moves)
+    all_trump = all(c.suit == trump for c in legal_moves)
+
+    if all_lead_suit and lead_suit != trump:
+        forced_beat = winner_card is not None and all(
+            RANK_VALUE[c.rank] > RANK_VALUE[winner_card.rank] for c in legal_moves
+        )
+        if forced_beat:
+            return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
+        if partner_winning:
+            feed_cards = [c for c in legal_moves if c.rank in ("K", "10")]
+            if feed_cards:
+                return max(feed_cards, key=lambda c: RANK_VALUE[c.rank])
+            return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
+        non_points = [c for c in legal_moves if c.rank not in POINT_RANKS]
+        if non_points:
+            return min(non_points, key=lambda c: RANK_VALUE[c.rank])
+        return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
+
+    if all_trump:
+        trump_on_table = any(c.suit == trump for _, c in trick_plays)
+        if trump_on_table:
+            current_best_trump = max(
+                (c for _, c in trick_plays if c.suit == trump), key=lambda c: RANK_VALUE[c.rank]
+            )
+            forced_beat = all(
+                RANK_VALUE[c.rank] > RANK_VALUE[current_best_trump.rank] for c in legal_moves
+            )
+            if forced_beat:
+                return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
+            non_points = [c for c in legal_moves if c.rank not in POINT_RANKS]
+            if non_points:
+                return min(non_points, key=lambda c: RANK_VALUE[c.rank])
+            return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
+
+        worth_winning = _trick_has_points(trick_plays) or not partner_winning
+        if worth_winning:
+            return max(legal_moves, key=lambda c: RANK_VALUE[c.rank])
+        return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
+
+    # Free sluff - no lead-suit card, no trump forced. Protect count cards
+    # first, then build toward a void in the shortest suit among whatever
+    # is left, same tie-break as the Proficient-tier choose_follow_card.
+    non_points = [c for c in legal_moves if c.rank not in POINT_RANKS]
+    pool = non_points if non_points else legal_moves
+    legal_sorted = sorted(pool, key=lambda c: (_suit_length(hand, c.suit), RANK_VALUE[c.rank]))
+    return legal_sorted[0]
+
+
+def choose_expert_follow_card(hand, legal_moves, trick_plays, trump, my_team_players,
+                               tracker=None, deception_evaluator=None):
+    """
+    Section 4 + Section 7 entry point for following (not leading).
+    `legal_moves` already has the mandatory beat-if-possible / trump-if-
+    void rules applied by `Trick.legal_moves` — this only picks which one
+    to use.
+
+    Computes the honest baseline (`_expert_follow_card_honest`) per the
+    "Following suit (general)" heuristics. If `deception_evaluator` is
+    supplied (Section 7 — gated to the top skill levels by the caller, not
+    unconditionally on), also generates false-card and fake-void
+    candidates (`generate_false_card_candidates` /
+    `generate_fake_void_candidates`, both reusing `PlayTracker`'s per-copy
+    tracking to judge believability) and lets the evaluator pick among the
+    honest baseline plus every deceptive candidate — never a hardcoded
+    "always false-card when X" rule. Every candidate considered is drawn
+    from `legal_moves`, so the result is always a legal move regardless of
+    whether deception is enabled.
+
+    `deception_evaluator`, if provided, must be a callable:
+
+        deception_evaluator(hand, trump, tracker, trick_plays, candidate_card) -> float
+
+    returning a higher-is-better simulated EV for playing `candidate_card`
+    in this exact trick-play state. As with `rollout_evaluator` elsewhere
+    in this module, a caller wires a real evaluator on top of
+    `monte_carlo_rollout`/`rollout_deal` (pinochle_rollout.py, #59)
+    elsewhere — this module never imports pinochle_rollout.
+    """
+    tracker = tracker if tracker is not None else PlayTracker()
+    honest = _expert_follow_card_honest(hand, legal_moves, trick_plays, trump, my_team_players, tracker)
+
+    if deception_evaluator is None or len(legal_moves) < 2:
+        return honest
+
+    candidates = {honest}
+    candidates.update(generate_false_card_candidates(hand, legal_moves, trick_plays, tracker))
+    candidates.update(generate_fake_void_candidates(hand, legal_moves, trick_plays, trump, tracker))
+    return max(
+        candidates,
+        key=lambda c: deception_evaluator(hand, trump, tracker, trick_plays, c),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Player / Team
 # ---------------------------------------------------------------------------
 

--- a/test_trick_play_strategy.py
+++ b/test_trick_play_strategy.py
@@ -1,0 +1,384 @@
+"""
+Tests for issue #62 - Trick-play rollout strategy + gated deception,
+implementing pinochle_expert_ai_strategy.md Section 4 (trick-play strategy)
+and, gated behind an optional deception_evaluator, Section 7 (deception) as
+shared, callable functions (`choose_expert_lead_card` /
+`choose_expert_follow_card` in pinochle_engine.py) independent of any
+Player subclass or the rollout sampler itself. Plain assert-based,
+pytest-discoverable, matching test_expert_pass.py / test_rollout.py's
+convention.
+
+Covers:
+  1. Bidder-leading Ace-first trump lead (doc Section 4 point 1), and that
+     the exact same shared function drives both the Bidder's and the
+     partner's lead (doc Section 9 Q4, resolved).
+  2. The no-trump-Ace mid-hand conservative shift (doc Section 9 Q3,
+     resolved): abandons the aggressive trump-draw plan, never proactively
+     leads trump when a non-trump lead is available.
+  3. Endgame loser-first sequencing: once all trump is accounted for
+     outside a near-empty hand, losers lead first and trump is held back.
+  4. Following-suit heuristics: duck vs. feed when partner is already
+     winning, count-card protection on both a forced non-beat and a free
+     sluff (including the case where a naive shortest-suit tie-break would
+     get it wrong), and over-trump-vs-under-trump judgment when first to
+     trump a trick.
+  5. The defender static/rollout-compare split (doc Section 9 Q5, revised
+     resolution): static mode never leads trump; rollout-compare mode CAN
+     override that default when the injected evaluator prefers it.
+  6. Deception (Section 7): false-card/fake-void candidate generators only
+     propose believable candidates per PlayTracker's per-copy tracking,
+     and `choose_expert_follow_card` with `deception_evaluator` supplied
+     can diverge from the honest baseline while always returning a legal
+     move.
+  7. General legality across randomized hands/trick states for both the
+     lead and follow entry points.
+
+Run directly (`python test_trick_play_strategy.py`) or via pytest.
+"""
+
+from pinochle_engine import (
+    Card,
+    Deck,
+    PlayTracker,
+    Suit,
+    Trick,
+    choose_expert_follow_card,
+    choose_expert_lead_card,
+    generate_fake_void_candidates,
+    generate_false_card_candidates,
+)
+
+
+def C(suit, rank, copy_id=1):
+    return Card(suit, rank, copy_id)
+
+
+def _fresh_hands():
+    deck = Deck()
+    deck.shuffle()
+    cards = deck.cards
+    return [cards[i * 12:(i + 1) * 12] for i in range(4)]
+
+
+# ---------------------------------------------------------------------------
+# 1. Ace-first trump lead, shared by Bidder and partner (doc Section 9 Q4).
+# ---------------------------------------------------------------------------
+
+def test_offense_leads_trump_ace_when_held():
+    trump = Suit.HEARTS
+    tracker = PlayTracker()
+    hand = [C(trump, "A"), C(trump, "K"), C(Suit.CLUBS, "9"), C(Suit.SPADES, "A")]
+    card = choose_expert_lead_card(hand, trump, tracker, is_bidding_team=True)
+    assert card.suit == trump and card.rank == "A", card
+
+
+def test_offense_ace_first_shared_by_bidder_and_partner():
+    """Doc Section 9 Q4, resolved: the partner runs the exact same
+    Ace-first logic independently - not a special-cased deferral to
+    whatever the Bidder's plan was. Proven here by calling the one shared
+    function on two different hands, both with is_bidding_team=True."""
+    trump = Suit.SPADES
+    tracker = PlayTracker()
+    bidder_hand = [C(trump, "A"), C(Suit.HEARTS, "9"), C(Suit.CLUBS, "K")]
+    partner_hand = [C(Suit.DIAMONDS, "9"), C(trump, "A"), C(Suit.CLUBS, "Q")]
+
+    bidder_lead = choose_expert_lead_card(bidder_hand, trump, tracker, is_bidding_team=True)
+    partner_lead = choose_expert_lead_card(partner_hand, trump, tracker, is_bidding_team=True)
+
+    assert bidder_lead.suit == trump and bidder_lead.rank == "A"
+    assert partner_lead.suit == trump and partner_lead.rank == "A"
+
+
+# ---------------------------------------------------------------------------
+# 2. No-trump-Ace mid-hand conservative shift (doc Section 9 Q3, resolved).
+# ---------------------------------------------------------------------------
+
+def test_offense_conservative_lead_without_trump_ace():
+    """Holding trump but no trump Ace: the aggressive trump-draw plan is
+    abandoned - a non-trump lead is preferred whenever one is available,
+    rather than proactively forcing trump out."""
+    trump = Suit.HEARTS
+    tracker = PlayTracker()
+    hand = [C(trump, "K"), C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2)]
+    card = choose_expert_lead_card(hand, trump, tracker, is_bidding_team=True)
+    assert card.suit != trump, "must not proactively lead trump without a trump Ace"
+
+
+def test_offense_leads_trump_only_when_nothing_else_left():
+    trump = Suit.HEARTS
+    tracker = PlayTracker()
+    hand = [C(trump, "K"), C(trump, "Q")]  # trump-only hand, no Ace
+    card = choose_expert_lead_card(hand, trump, tracker, is_bidding_team=True)
+    assert card.suit == trump  # no non-trump option exists at all
+
+
+# ---------------------------------------------------------------------------
+# 3. Endgame sequencing - protect the last-trick bonus.
+# ---------------------------------------------------------------------------
+
+def test_endgame_holds_trump_back_and_leads_losers_first():
+    trump = Suit.HEARTS
+    tracker = PlayTracker()
+    for rank in ("A", "10", "K", "Q", "J"):
+        tracker.record(C(trump, rank, 1))
+        tracker.record(C(trump, rank, 2))
+    tracker.record(C(trump, "9", 2))  # the OTHER copy of the 9 this hand still holds
+    # All 12 trump copies are now accounted for: 10 played + 1 played + 1 in hand.
+
+    hand = [C(trump, "9", 1), C(Suit.CLUBS, "A"), C(Suit.DIAMONDS, "9")]
+
+    offense_lead = choose_expert_lead_card(hand, trump, tracker, is_bidding_team=True)
+    defense_lead = choose_expert_lead_card(hand, trump, tracker, is_bidding_team=False)
+
+    assert offense_lead.suit != trump, "endgame sequencing must hold the last trump back"
+    assert defense_lead.suit != trump, "endgame sequencing applies regardless of which side is leading"
+
+
+def test_endgame_not_triggered_while_trump_still_unaccounted():
+    """Sanity check: with a fresh tracker (nothing played), the endgame
+    guard must not fire, and normal Ace-first offense logic still applies."""
+    trump = Suit.HEARTS
+    tracker = PlayTracker()
+    hand = [C(trump, "A"), C(Suit.CLUBS, "9")]
+    card = choose_expert_lead_card(hand, trump, tracker, is_bidding_team=True)
+    assert card.suit == trump and card.rank == "A"
+
+
+# ---------------------------------------------------------------------------
+# 4. Defender static/rollout-compare split (doc Section 9 Q5, revised).
+# ---------------------------------------------------------------------------
+
+def test_defender_static_avoids_trump_lead():
+    trump = Suit.HEARTS
+    tracker = PlayTracker()
+    hand = [C(trump, "A"), C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2)]
+    card = choose_expert_lead_card(hand, trump, tracker, is_bidding_team=False)
+    assert card.suit != trump, "static-mode defenders must not lead trump, even holding a trump Ace"
+
+
+def test_defender_rollout_compare_can_choose_trump_over_static_default():
+    trump = Suit.HEARTS
+    tracker = PlayTracker()
+    hand = [C(trump, "A"), C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2)]
+
+    static_pick = choose_expert_lead_card(hand, trump, tracker, is_bidding_team=False)
+    assert static_pick.suit != trump  # static default: avoid trump
+
+    def prefer_trump(hand_, trump_, tracker_, candidate):
+        return 20.0 if candidate.suit == trump_ else 10.0
+
+    compare_pick = choose_expert_lead_card(
+        hand, trump, tracker, is_bidding_team=False, rollout_evaluator=prefer_trump,
+    )
+    assert compare_pick.suit == trump, \
+        "rollout-compare mode must be able to override the static avoidance default"
+    assert static_pick.suit != compare_pick.suit, \
+        "the two modes must actually diverge on this hand, not just both exist"
+
+
+def test_defender_rollout_compare_keeps_static_pick_when_evaluator_prefers_it():
+    """Symmetric check: the evaluator - not a hardcoded ranking - decides."""
+    trump = Suit.HEARTS
+    tracker = PlayTracker()
+    hand = [C(trump, "A"), C(Suit.CLUBS, "9"), C(Suit.CLUBS, "9", 2)]
+
+    def prefer_non_trump(hand_, trump_, tracker_, candidate):
+        return 20.0 if candidate.suit != trump_ else 10.0
+
+    static_pick = choose_expert_lead_card(hand, trump, tracker, is_bidding_team=False)
+    compare_pick = choose_expert_lead_card(
+        hand, trump, tracker, is_bidding_team=False, rollout_evaluator=prefer_non_trump,
+    )
+    assert static_pick == compare_pick
+
+
+# ---------------------------------------------------------------------------
+# 5. Following suit - duck/feed, count-card protection, over/under-trump.
+# ---------------------------------------------------------------------------
+
+def test_follow_ducks_when_partner_winning_and_nothing_to_feed():
+    trump = Suit.HEARTS
+    partner = object()
+    trick_plays = [(partner, C(Suit.CLUBS, "K"))]
+    hand = [C(Suit.CLUBS, "9"), C(Suit.CLUBS, "Q")]  # neither beats K, no K/10 to feed
+    card = choose_expert_follow_card(hand, hand, trick_plays, trump, {partner}, PlayTracker())
+    assert card.rank == "9"  # lowest - duck, don't overspend on a secured trick
+
+
+def test_follow_feeds_partner_when_a_count_card_is_free():
+    trump = Suit.HEARTS
+    partner = object()
+    trick_plays = [(partner, C(Suit.CLUBS, "K", 1))]
+    hand = [C(Suit.CLUBS, "9"), C(Suit.CLUBS, "K", 2)]  # 2nd copy of K ties, doesn't beat
+    card = choose_expert_follow_card(hand, hand, trick_plays, trump, {partner}, PlayTracker())
+    assert card.rank == "K", "should feed the count card across to partner's secured trick"
+
+
+def test_follow_protects_count_card_when_unable_to_beat():
+    trump = Suit.HEARTS
+    opponent = object()
+    trick_plays = [(opponent, C(Suit.CLUBS, "A"))]  # unbeatable
+    hand = [C(Suit.CLUBS, "9"), C(Suit.CLUBS, "10")]
+    card = choose_expert_follow_card(hand, hand, trick_plays, trump, set(), PlayTracker())
+    assert card.rank == "9", "must sluff the zero-count 9, not the 10, into a trick that can't be won"
+
+
+def test_follow_sluff_protects_count_cards_over_shorter_suit():
+    """The tricky case: a naive shortest-suit-first tie-break would sluff
+    the count-card 10 (its suit has only 1 card) instead of the zero-count
+    9 sitting in a longer suit. Count-card protection must win."""
+    trump = Suit.HEARTS
+    hand = [C(Suit.CLUBS, "10"), C(Suit.DIAMONDS, "9"), C(Suit.DIAMONDS, "J")]
+    legal_moves = list(hand)  # void of lead suit and trump - free sluff
+    trick_plays = [(object(), C(Suit.SPADES, "K"))]
+    card = choose_expert_follow_card(hand, legal_moves, trick_plays, trump, set(), PlayTracker())
+    assert card.suit == Suit.DIAMONDS and card.rank == "9", card
+
+
+def test_follow_trump_forced_beat_wins_cheaply():
+    trump = Suit.HEARTS
+    trick_plays = [(object(), C(Suit.CLUBS, "9")), (object(), C(trump, "9"))]
+    hand = [C(trump, "Q"), C(trump, "K")]
+    card = choose_expert_follow_card(hand, hand, trick_plays, trump, set(), PlayTracker())
+    assert card.rank == "Q"  # cheapest sufficient beat over the trumped-in 9
+
+
+def test_follow_over_trumps_when_trick_has_points():
+    trump = Suit.HEARTS
+    trick_plays = [(object(), C(Suit.CLUBS, "A"))]  # count-card lead, worth winning
+    hand = [C(trump, "9"), C(trump, "Q")]
+    card = choose_expert_follow_card(hand, hand, trick_plays, trump, set(), PlayTracker())
+    assert card.rank == "Q", "should commit the higher trump when the trick is worth securing"
+
+
+def test_follow_under_trumps_when_not_worth_winning():
+    trump = Suit.HEARTS
+    partner = object()
+    trick_plays = [(partner, C(Suit.CLUBS, "J"))]  # zero-count, partner already shown ahead
+    hand = [C(trump, "9"), C(trump, "Q")]
+    card = choose_expert_follow_card(hand, hand, trick_plays, trump, {partner}, PlayTracker())
+    assert card.rank == "9", "should conserve the higher trump on a point-less forced ruff over partner"
+
+
+# ---------------------------------------------------------------------------
+# 6. Deception (Section 7) - gated behind deception_evaluator.
+# ---------------------------------------------------------------------------
+
+def test_false_card_candidates_require_believability():
+    tracker = PlayTracker()
+    hand = [C(Suit.CLUBS, "9"), C(Suit.CLUBS, "Q")]
+    legal_moves = list(hand)
+
+    candidates = generate_false_card_candidates(hand, legal_moves, [], tracker)
+    assert any(c.rank == "Q" for c in candidates), "unaccounted rank is a believable false-card"
+
+    tracker.record(C(Suit.CLUBS, "9", 2))  # now both copies of clubs-9 are accounted for
+    candidates2 = generate_false_card_candidates(hand, legal_moves, [], tracker)
+    assert not any(c.rank == "9" for c in candidates2), \
+        "a provably-exhausted rank isn't a believable false-card"
+
+
+def test_false_card_candidates_are_always_legal():
+    tracker = PlayTracker()
+    hand = [C(Suit.CLUBS, "9"), C(Suit.CLUBS, "Q"), C(Suit.CLUBS, "K")]
+    legal_moves = hand[:2]  # only a subset is actually legal right now
+    candidates = generate_false_card_candidates(hand, legal_moves, [], tracker)
+    for c in candidates:
+        assert c in legal_moves
+
+
+def test_fake_void_candidates_require_multi_suit_and_prior_discard_history():
+    tracker = PlayTracker()
+    hand = [C(Suit.CLUBS, "9"), C(Suit.DIAMONDS, "9")]
+    legal_moves = list(hand)
+
+    assert generate_fake_void_candidates(hand, legal_moves, [], Suit.HEARTS, tracker) == []
+
+    tracker.record(C(Suit.CLUBS, "9", 2))
+    candidates = generate_fake_void_candidates(hand, legal_moves, [], Suit.HEARTS, tracker)
+    pairs = {(c.suit, c.rank) for c in candidates}
+    assert (Suit.CLUBS, "9") in pairs
+    assert (Suit.DIAMONDS, "9") not in pairs
+
+
+def test_fake_void_candidates_empty_when_single_suit_present():
+    tracker = PlayTracker()
+    tracker.record(C(Suit.CLUBS, "9", 2))
+    hand = [C(Suit.CLUBS, "9"), C(Suit.CLUBS, "Q")]
+    assert generate_fake_void_candidates(hand, hand, [], Suit.HEARTS, tracker) == []
+
+
+def test_deception_disabled_returns_honest_pick_unchanged():
+    trump = Suit.HEARTS
+    hand = [C(Suit.CLUBS, "10"), C(Suit.DIAMONDS, "9"), C(Suit.DIAMONDS, "J")]
+    legal_moves = list(hand)
+    trick_plays = [(object(), C(Suit.SPADES, "K"))]
+    without = choose_expert_follow_card(hand, legal_moves, trick_plays, trump, set(), PlayTracker())
+    with_none = choose_expert_follow_card(
+        hand, legal_moves, trick_plays, trump, set(), PlayTracker(), deception_evaluator=None,
+    )
+    assert without == with_none
+
+
+def test_deception_enabled_can_diverge_but_always_returns_a_legal_move():
+    """Required by issue #62: false-carding/fake-void must produce only
+    legal moves when enabled."""
+    trump = Suit.HEARTS
+    tracker = PlayTracker()
+    hand = [C(Suit.CLUBS, "9"), C(Suit.CLUBS, "Q"), C(Suit.DIAMONDS, "9")]
+    legal_moves = list(hand)  # free sluff scenario
+    trick_plays = [(object(), C(Suit.SPADES, "K"))]
+
+    def evaluator(hand_, trump_, tracker_, trick_plays_, candidate):
+        # Deliberately prefers a card the honest baseline would avoid (a
+        # count-free choice exists, so the honest pick would never be the
+        # Q of clubs) - proves the evaluator decides, not a hardcoded rule.
+        return 100.0 if candidate.rank == "Q" else 0.0
+
+    honest = choose_expert_follow_card(hand, legal_moves, trick_plays, trump, set(), tracker)
+    deceptive = choose_expert_follow_card(
+        hand, legal_moves, trick_plays, trump, set(), tracker, deception_evaluator=evaluator,
+    )
+
+    assert deceptive in legal_moves, "deceptive pick must still be a legal move"
+    assert deceptive.rank == "Q"
+    assert deceptive != honest, "deception must be able to diverge from the honest baseline"
+
+
+# ---------------------------------------------------------------------------
+# 7. General legality across randomized hands/trick states.
+# ---------------------------------------------------------------------------
+
+def test_lead_always_returns_a_card_in_hand():
+    for _ in range(20):
+        for hand in _fresh_hands():
+            for trump in Suit:
+                tracker = PlayTracker()
+                for is_bidding_team in (True, False):
+                    card = choose_expert_lead_card(hand, trump, tracker, is_bidding_team)
+                    assert card in hand
+
+
+def test_follow_always_returns_a_legal_move():
+    trump = Suit.HEARTS
+    for _ in range(30):
+        hands = _fresh_hands()
+        trick = Trick(trump)
+        lead_card = hands[0][0]
+        trick.play("p0", lead_card)
+        tracker = PlayTracker()
+        tracker.record(lead_card)
+
+        follower_hand = hands[1]
+        legal = trick.legal_moves(follower_hand)
+        card = choose_expert_follow_card(follower_hand, legal, trick.plays, trump, {"p0"}, tracker)
+        assert card in legal
+
+
+if __name__ == "__main__":
+    tests = [obj for name, obj in list(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    for t in tests:
+        t()
+        print(f"OK: {t.__name__}")
+    print(f"\n{len(tests)} tests passed.")


### PR DESCRIPTION
## Summary

Implements `pinochle_expert_ai_strategy.md` Section 4 (trick-play strategy) and, gated behind an optional evaluator, Section 7 (deception) as new free functions in `pinochle_engine.py` — following the exact same static-mode/rollout-compare-mode interface pattern issue #61 established for `choose_forward_pass_cards`/`choose_return_pass_cards`.

- **`choose_expert_lead_card`** (leading):
  - Ace-first trump lead, unconditional, shared by both the Bidder and the Bidder's partner (doc Section 9 Q4, resolved) — one function, no special-casing by role.
  - No-trump-Ace mid-hand conservative shift (Q3, resolved): abandons the aggressive trump-draw plan and prefers a non-trump lead instead of forcing trump out.
  - Endgame sequencing: once all trump is accounted for outside the current hand, losers lead first and trump is held back to protect the 12th-trick +10 bonus.
  - Defenders' trump-lead question (Q5, revised — **not** one fixed global rule): `rollout_evaluator=None` gives the static default (avoid leading trump, attack elsewhere); passing a `rollout_evaluator` callback generates both a trump-lead and non-trump-lead candidate and lets the evaluator's simulated EV pick the winner for that specific state.
- **`choose_expert_follow_card`** (following): duck vs. feed when partner is already winning, count-card protection (both on a forced non-beat and on a free sluff, including the case where a naive shortest-suit tie-break would get it wrong), and over-trump-vs-under-trump judgment when first to trump a trick.
- **`generate_false_card_candidates` / `generate_fake_void_candidates`** (Section 7 deception): pluggable candidate moves, never unconditional rules — reuse `PlayTracker`'s existing per-copy tracking to judge whether a false-card/fake-void would even be believable. Wired in via an optional `deception_evaluator` on `choose_expert_follow_card`; every candidate considered is drawn from `legal_moves`, so the result is always a legal move whether or not deception is enabled.

All of this lives as free functions independent of any `Player` subclass, per the doc's Appendix and #61's precedent — Proficient's `choose_lead_card`/`choose_follow_card` are untouched (tournament control group). A future `ExpertPlayer` (#63) and the rollout sampler's simulated players can call directly into this code.

Part of #57, closes #62

## Test plan

- [x] `test_trick_play_strategy.py` (24 new tests): Ace-first lead + shared bidder/partner behavior, no-trump-Ace conservative shift, endgame loser-first sequencing (and that it doesn't false-trigger), duck/feed/count-card-protection/over-under-trump follow-card heuristics, defender static-avoid-trump default, a constructed case proving rollout-compare mode has a defender lead trump when the static default wouldn't (plus the symmetric case where the evaluator keeps the static pick), false-card/fake-void believability filters, deception producing only legal moves when enabled, and legality fuzzing across randomized hands/trick states for both entry points.
- [x] Full suite: `python -m pytest -q` → 78 passed (54 pre-existing + 24 new), no regressions.
- [x] `python pinochle_engine.py` self-checks still pass; `pinochle_rollout.py` still imports cleanly.