### PR TITLE
Randomize opponent and team names per new game

### DIFF
--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -11,6 +11,7 @@ import type { AuctionResult } from './auctionTypes'
 import { partnerOf } from './auctionTypes'
 import { BiddingControls } from './BiddingControls'
 import { PassSelector } from './PassSelector'
+import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
 import type { TableState } from './tableTypes'
 import { TrumpSelector } from './TrumpSelector'
@@ -26,6 +27,11 @@ export interface AuctionFlowProps {
   humanPlayer: PlayerIndex
   dealer: PlayerIndex
   scoresByTeam: Record<TeamId, number>
+  /** Randomized per-game team display names (#73), threaded straight into
+   * the TableState this component builds for Table/Scoreboard. Defaults to
+   * scoreTypes.ts's DEFAULT_TEAM_NAMES ("Team A"/"Team B") when omitted —
+   * GameFlow.tsx always supplies real per-game names in practice. */
+  teamNames?: Record<TeamId, string>
   /** Opens the persistent mid-game menu (#54: New Game / Continue /
    * Options) — rendered by Table.tsx as a small corner button. Omit to
    * render without one (e.g. existing tests that don't exercise it). */
@@ -53,6 +59,7 @@ export function AuctionFlow({
   humanPlayer,
   dealer,
   scoresByTeam,
+  teamNames = DEFAULT_TEAM_NAMES,
   onOpenMenu,
   options = DEFAULT_OPTIONS,
   onComplete,
@@ -123,8 +130,9 @@ export function AuctionFlow({
       currentBid: state.bid || state.bidding.currentBid,
       bidWinner: state.bidWinner,
       scoresByTeam: state.scoresByTeam,
+      teamNames,
     }
-  }, [state, seatNames, humanPlayer])
+  }, [state, seatNames, humanPlayer, teamNames])
 
   const overlay = useMemo(() => {
     if (state.phase === 'bidding' && state.bidding.turn === humanPlayer) {

--- a/web/src/components/GameFlow.tsx
+++ b/web/src/components/GameFlow.tsx
@@ -12,7 +12,6 @@ import {
   HUMAN_PLAYER,
   initGameFlowState,
   INITIAL_DEALER,
-  SEAT_NAMES,
   type GameFlowState,
 } from './gameFlowReducer'
 import { GameOverScreen } from './GameOverScreen'
@@ -133,10 +132,11 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
     return (
       <AuctionFlow
         initialHands={state.hands}
-        seatNames={SEAT_NAMES}
+        seatNames={state.seatNames}
         humanPlayer={HUMAN_PLAYER}
         dealer={state.dealer}
         scoresByTeam={state.scoresByTeam}
+        teamNames={state.teamNames}
         onOpenMenu={onOpenMenu}
         options={options}
         onComplete={handleAuctionComplete}
@@ -152,9 +152,10 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
         trumpSuit={trumpSuit}
         bidWinner={bidWinner}
         bid={bid}
-        seatNames={SEAT_NAMES}
+        seatNames={state.seatNames}
         humanPlayer={HUMAN_PLAYER}
         scoresByTeam={state.scoresByTeam}
+        teamNames={state.teamNames}
         // Local autosave (#54): resume mid-round from the last checkpoint
         // when there is one (only set right after LOAD_SAVE resumed a save
         // straight into this phase — a normal auction handoff clears it),
@@ -194,7 +195,7 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
   // paint in practice) and 'misdeal-check' both render the table
   // underneath, the same shell AuctionFlow uses — misdeal-check adds the
   // human's reshuffle prompt once the check reaches their seat.
-  const seatFor = (p: PlayerIndex) => ({ player: p, name: SEAT_NAMES[p], hand: state.hands[p] })
+  const seatFor = (p: PlayerIndex) => ({ player: p, name: state.seatNames[p], hand: state.hands[p] })
   const tableState: TableState = {
     seats: [seatFor(0), seatFor(1), seatFor(2), seatFor(3)],
     humanPlayer: HUMAN_PLAYER,
@@ -203,6 +204,7 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
     currentBid: 0,
     bidWinner: null,
     scoresByTeam: state.scoresByTeam,
+    teamNames: state.teamNames,
   }
 
   const humanMisdealEligible =

--- a/web/src/components/GameOverScreen.test.tsx
+++ b/web/src/components/GameOverScreen.test.tsx
@@ -11,6 +11,7 @@ afterEach(cleanup)
 const data: GameOverData = {
   winningTeam: 0,
   finalScoresByTeam: { 0: 1040, 1: 760 },
+  teamNames: { 0: 'Team A', 1: 'Team B' },
 }
 
 describe('GameOverScreen', () => {

--- a/web/src/components/GameOverScreen.tsx
+++ b/web/src/components/GameOverScreen.tsx
@@ -1,5 +1,5 @@
 import type { TeamId } from '../engine/round'
-import { TEAM_NAMES, type GameOverData } from './scoreTypes'
+import type { GameOverData } from './scoreTypes'
 
 export interface GameOverScreenProps {
   data: GameOverData
@@ -16,17 +16,17 @@ const TEAM_IDS: readonly TeamId[] = [0, 1]
  * game state when `onNewGame` fires.
  */
 export function GameOverScreen({ data, onNewGame }: GameOverScreenProps) {
-  const { winningTeam, finalScoresByTeam } = data
+  const { winningTeam, finalScoresByTeam, teamNames } = data
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/70 p-4">
       <div className="w-full max-w-sm rounded-lg bg-white p-6 text-center text-neutral-900 shadow-xl">
-        <h2 className="text-2xl font-bold">{TEAM_NAMES[winningTeam]} wins!</h2>
+        <h2 className="text-2xl font-bold">{teamNames[winningTeam]} wins!</h2>
 
         <dl className="mt-4 flex justify-center gap-8 text-sm">
           {TEAM_IDS.map((team) => (
             <div key={team}>
-              <dt className="text-neutral-500">{TEAM_NAMES[team]}</dt>
+              <dt className="text-neutral-500">{teamNames[team]}</dt>
               <dd className={`text-lg font-semibold ${team === winningTeam ? 'text-green-700' : ''}`}>
                 {finalScoresByTeam[team]}
               </dd>

--- a/web/src/components/GameShell.test.tsx
+++ b/web/src/components/GameShell.test.tsx
@@ -51,6 +51,34 @@ describe('GameShell', () => {
     expect(Deck.prototype.deal).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps the same randomized opponent and team names across a save/Continue cycle (#73)', async () => {
+    mockDeal()
+    const { unmount } = render(<GameShell />)
+    fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+
+    // West/Partner/East seat names, read off the seat labels (Seat.tsx
+    // renders `seat.name` as plain text) — captured before unmount so we
+    // can assert the resumed game shows the exact same draw, not a fresh
+    // one.
+    const seatNamesBefore = screen.getAllByText(/cards$/).map((el) => el.parentElement?.textContent ?? '')
+    // Team names, read off the Scoreboard strip ("<name>: <score>").
+    const scoreboardTextBefore = document.querySelector('.bg-green-950')?.textContent ?? ''
+
+    unmount()
+
+    render(<GameShell />)
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
+
+    const seatNamesAfter = screen.getAllByText(/cards$/).map((el) => el.parentElement?.textContent ?? '')
+    const scoreboardTextAfter = document.querySelector('.bg-green-950')?.textContent ?? ''
+
+    expect(seatNamesAfter).toEqual(seatNamesBefore)
+    expect(seatNamesBefore.length).toBeGreaterThan(0) // sanity: actually found opponent seats
+    expect(scoreboardTextAfter).toBe(scoreboardTextBefore)
+  })
+
   it('opens the mid-game menu via the persistent menu button, and Continue there just resumes', async () => {
     mockDeal()
     render(<GameShell />)

--- a/web/src/components/RoundSummary.test.tsx
+++ b/web/src/components/RoundSummary.test.tsx
@@ -15,6 +15,7 @@ const madeContractData: RoundSummaryData = {
   bidWinnerTeam: 0,
   bid: 180,
   cumulativeScoresByTeam: { 0: 610, 1: 524 },
+  teamNames: { 0: 'Team A', 1: 'Team B' },
 }
 
 const wentSetData: RoundSummaryData = {
@@ -24,6 +25,7 @@ const wentSetData: RoundSummaryData = {
   bidWinnerTeam: 0,
   bid: 340,
   cumulativeScoresByTeam: { 0: 80, 1: 554 },
+  teamNames: { 0: 'Team A', 1: 'Team B' },
 }
 
 describe('RoundSummary', () => {

--- a/web/src/components/RoundSummary.tsx
+++ b/web/src/components/RoundSummary.tsx
@@ -1,5 +1,5 @@
 import type { TeamId } from '../engine/round'
-import { TEAM_NAMES, type RoundSummaryData } from './scoreTypes'
+import type { RoundSummaryData } from './scoreTypes'
 
 export interface RoundSummaryProps {
   data: RoundSummaryData
@@ -21,7 +21,8 @@ const TEAM_IDS: readonly TeamId[] = [0, 1]
  * `onContinue` does.
  */
 export function RoundSummary({ data, onContinue }: RoundSummaryProps) {
-  const { meldPointsByTeam, trickPointsByTeam, roundScoreByTeam, bidWinnerTeam, bid, cumulativeScoresByTeam } = data
+  const { meldPointsByTeam, trickPointsByTeam, roundScoreByTeam, bidWinnerTeam, bid, cumulativeScoresByTeam, teamNames } =
+    data
   // scoreRound() only ever produces a negative net score for the bidding
   // team, and only when they fell short of their bid ("going set").
   const wentSet = roundScoreByTeam[bidWinnerTeam] < 0
@@ -31,7 +32,7 @@ export function RoundSummary({ data, onContinue }: RoundSummaryProps) {
       <div className="w-full max-w-sm rounded-lg bg-white p-6 text-neutral-900 shadow-xl">
         <h2 className="text-lg font-semibold">Round summary</h2>
         <p className="mt-1 text-sm text-neutral-600">
-          {TEAM_NAMES[bidWinnerTeam]} bid {bid} and{' '}
+          {teamNames[bidWinnerTeam]} bid {bid} and{' '}
           {wentSet ? 'went set' : 'made their contract'}.
         </p>
 
@@ -41,7 +42,7 @@ export function RoundSummary({ data, onContinue }: RoundSummaryProps) {
               <th className="font-normal" />
               {TEAM_IDS.map((team) => (
                 <th key={team} className="pl-4 font-medium text-neutral-900">
-                  {TEAM_NAMES[team]}
+                  {teamNames[team]}
                 </th>
               ))}
             </tr>

--- a/web/src/components/Scoreboard.tsx
+++ b/web/src/components/Scoreboard.tsx
@@ -4,6 +4,9 @@ import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
 
 export interface ScoreboardProps {
   scoresByTeam: Record<TeamId, number>
+  /** Randomized per-game team display names (#73), replacing the old
+   * static "Team A"/"Team B" labels. */
+  teamNames: Record<TeamId, string>
   currentBid: number
   /** undefined while the auction (#34) hasn't produced a bid winner yet. */
   bidWinnerName?: string
@@ -14,7 +17,7 @@ export interface ScoreboardProps {
 /** Top strip: cumulative team scores, the standing bid, and trump. Stays
  * mounted throughout bidding/passing/trick-play so those flows (separate
  * issues) can render alongside it without needing their own scoreboard. */
-export function Scoreboard({ scoresByTeam, currentBid, bidWinnerName, trumpSuit }: ScoreboardProps) {
+export function Scoreboard({ scoresByTeam, teamNames, currentBid, bidWinnerName, trumpSuit }: ScoreboardProps) {
   const trumpColor = trumpSuit && RED_SUITS.includes(trumpSuit) ? 'text-red-400' : 'text-white'
 
   return (
@@ -26,10 +29,10 @@ export function Scoreboard({ scoresByTeam, currentBid, bidWinnerName, trumpSuit 
         </span>
       </span>
       <span>
-        Team A: <span className="font-semibold">{scoresByTeam[0]}</span>
+        {teamNames[0]}: <span className="font-semibold">{scoresByTeam[0]}</span>
       </span>
       <span>
-        Team B: <span className="font-semibold">{scoresByTeam[1]}</span>
+        {teamNames[1]}: <span className="font-semibold">{scoresByTeam[1]}</span>
       </span>
       <span>
         Bid: <span className="font-semibold">{currentBid || '—'}</span>

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -39,8 +39,18 @@ const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
  * most likely inside/near the human seat and the TrickArea respectively.
  */
 export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards }: TableProps) {
-  const { seats, humanPlayer, trick, trumpSuit, currentBid, bidWinner, scoresByTeam, humanPlayable, trickWinner } =
-    state
+  const {
+    seats,
+    humanPlayer,
+    trick,
+    trumpSuit,
+    currentBid,
+    bidWinner,
+    scoresByTeam,
+    teamNames,
+    humanPlayable,
+    trickWinner,
+  } = state
   const bidWinnerSeat = bidWinner === null ? undefined : seats.find((seat) => seat.player === bidWinner)
 
   return (
@@ -57,6 +67,7 @@ export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards 
       )}
       <Scoreboard
         scoresByTeam={scoresByTeam}
+        teamNames={teamNames}
         currentBid={currentBid}
         bidWinnerName={bidWinnerSeat?.name}
         trumpSuit={trumpSuit}

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -4,6 +4,7 @@ import type { Hands, TeamId } from '../engine/round'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from '../engine/tracker'
 import type { PlayerIndex } from '../engine/trick'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
+import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
 import type { TableState } from './tableTypes'
 import { TrickLog } from './TrickLog'
@@ -26,6 +27,11 @@ export interface TrickPlayFlowProps {
   seatNames: Record<PlayerIndex, string>
   humanPlayer: PlayerIndex
   scoresByTeam: Record<TeamId, number>
+  /** Randomized per-game team display names (#73), threaded straight into
+   * the TableState this component builds for Table/Scoreboard. Defaults to
+   * scoreTypes.ts's DEFAULT_TEAM_NAMES ("Team A"/"Team B") when omitted —
+   * GameFlow.tsx always supplies real per-game names in practice. */
+  teamNames?: Record<TeamId, string>
   /** Local autosave (#54): resume from a saved trick-play checkpoint
    * (GameFlowState.trickPlayCheckpoint) instead of dealing out `hands`
    * fresh via initTrickPlayState. Only ever set by GameFlow.tsx's "Continue"
@@ -80,6 +86,7 @@ export function TrickPlayFlow({
   seatNames,
   humanPlayer,
   scoresByTeam,
+  teamNames = DEFAULT_TEAM_NAMES,
   initialState,
   onCheckpoint,
   onOpenMenu,
@@ -170,10 +177,11 @@ export function TrickPlayFlow({
       currentBid: bid,
       bidWinner: state.bidWinner,
       scoresByTeam,
+      teamNames,
       humanPlayable,
       trickWinner: state.phase === 'trick-complete' ? (state.trickWinners.at(-1) ?? null) : null,
     }
-  }, [state, seatNames, humanPlayer, bid, scoresByTeam, legalMovesForHuman])
+  }, [state, seatNames, humanPlayer, bid, scoresByTeam, teamNames, legalMovesForHuman])
 
   return (
     <Table

--- a/web/src/components/gameFlowReducer.test.ts
+++ b/web/src/components/gameFlowReducer.test.ts
@@ -19,6 +19,21 @@ describe('initGameFlowState', () => {
     expect(state.hands).toEqual(emptyHands())
     expect(state.misdealCheckIndex).toBe(0)
   })
+
+  it('seats the human as "You" and draws 3 unique opponent names (#73)', () => {
+    const state = initGameFlowState(3)
+    expect(state.seatNames[0]).toBe('You')
+    const opponents = [state.seatNames[1], state.seatNames[2], state.seatNames[3]]
+    expect(new Set(opponents).size).toBe(3)
+    for (const name of opponents) expect(name).not.toBe('You')
+  })
+
+  it('draws 2 unique team names (#73)', () => {
+    const state = initGameFlowState(3)
+    expect(state.teamNames[0]).not.toBe(state.teamNames[1])
+    expect(state.teamNames[0]).toBeTruthy()
+    expect(state.teamNames[1]).toBeTruthy()
+  })
 })
 
 describe('gameFlowReducer', () => {
@@ -155,6 +170,7 @@ describe('gameFlowReducer', () => {
           bidWinnerTeam,
           bid: 300,
           cumulativeScoresByTeam: scoresByTeam,
+          teamNames: { 0: 'Team A', 1: 'Team B' },
         },
       }
     }
@@ -172,7 +188,11 @@ describe('gameFlowReducer', () => {
       const state = stateAfterRoundSummary({ 0: GAME_WIN_SCORE, 1: 400 }, 0)
       const next = gameFlowReducer(state, { type: 'CONTINUE_ROUND' })
       expect(next.phase).toBe('game-over')
-      expect(next.gameOverData).toEqual({ winningTeam: 0, finalScoresByTeam: { 0: GAME_WIN_SCORE, 1: 400 } })
+      expect(next.gameOverData).toEqual({
+        winningTeam: 0,
+        finalScoresByTeam: { 0: GAME_WIN_SCORE, 1: 400 },
+        teamNames: state.teamNames,
+      })
     })
 
     it('ends the game in the other team\'s favor once a team busts to the loss threshold', () => {
@@ -194,13 +214,26 @@ describe('gameFlowReducer', () => {
         ...initGameFlowState(1),
         phase: 'game-over',
         scoresByTeam: { 0: 1000, 1: -400 },
-        gameOverData: { winningTeam: 0, finalScoresByTeam: { 0: 1000, 1: -400 } },
+        gameOverData: {
+          winningTeam: 0,
+          finalScoresByTeam: { 0: 1000, 1: -400 },
+          teamNames: { 0: 'Team A', 1: 'Team B' },
+        },
       }
       const next = gameFlowReducer(state, { type: 'NEW_GAME', dealer: 3 })
       expect(next.phase).toBe('dealing')
       expect(next.dealer).toBe(3)
       expect(next.scoresByTeam).toEqual({ 0: 0, 1: 0 })
       expect(next.gameOverData).toBeNull()
+    })
+
+    it('redraws seat and team names for the new game (#73)', () => {
+      const state: GameFlowState = { ...initGameFlowState(1), phase: 'game-over' }
+      const next = gameFlowReducer(state, { type: 'NEW_GAME', dealer: 3 })
+      expect(next.seatNames[0]).toBe('You')
+      const opponents = [next.seatNames[1], next.seatNames[2], next.seatNames[3]]
+      expect(new Set(opponents).size).toBe(3)
+      expect(next.teamNames[0]).not.toBe(next.teamNames[1])
     })
   })
 })

--- a/web/src/components/gameFlowReducer.ts
+++ b/web/src/components/gameFlowReducer.ts
@@ -17,7 +17,9 @@
 
 import { checkGameOutcome } from '../engine/game'
 import { scoreMelds } from '../engine/melds'
+import { sampleNames } from '../engine/names'
 import { scoreRound, teamOf, type Hands, type TeamId } from '../engine/round'
+import { sampleTeamNames } from '../engine/teamNames'
 import type { PlayerIndex } from '../engine/trick'
 import type { AuctionResult } from './auctionTypes'
 import type { GameOverData, RoundSummaryData } from './scoreTypes'
@@ -53,6 +55,17 @@ export interface GameFlowState {
    * reload lands back on the exact trick in progress rather than the start
    * of the round. */
   readonly trickPlayCheckpoint: TrickPlayState | null
+  /** Randomized per-seat display names (#73): seat 0 (the human) is always
+   * 'You'; seats 1/2/3 get 3 unique names drawn from names.ts's NAME_POOL.
+   * Generated once when a new game starts (initGameFlowState/NEW_GAME) —
+   * not regenerated on every render/action — so a resumed game (via the
+   * autosave/resume machinery, persistence/gameSave.ts) keeps the same
+   * opponent names rather than redrawing them. */
+  readonly seatNames: Record<PlayerIndex, string>
+  /** Randomized per-team display names (#73), drawn from teamNames.ts's
+   * TEAM_NAME_POOL — same once-per-new-game generation and
+   * autosave/resume persistence as seatNames above. */
+  readonly teamNames: Record<TeamId, string>
 }
 
 export type GameFlowAction =
@@ -77,16 +90,24 @@ export type GameFlowAction =
 // component itself; oxlint's react/only-export-components rule flags mixed
 // component+value exports since it breaks fast refresh (same reason these
 // don't live in AuctionFlow.tsx/TrickPlayFlow.tsx either).
-export const SEAT_NAMES: Record<PlayerIndex, string> = {
-  0: 'You',
-  1: 'West',
-  2: 'Partner',
-  3: 'East',
-}
 export const HUMAN_PLAYER: PlayerIndex = 0
 export const INITIAL_DEALER: PlayerIndex = 3
 
 const TEAM_IDS: readonly TeamId[] = [0, 1]
+
+/** Draws a fresh set of randomized seat names (#73): seat 0 is always
+ * 'You', seats 1/2/3 get 3 unique names from names.ts's NAME_POOL. */
+function randomSeatNames(): Record<PlayerIndex, string> {
+  const [west, partner, east] = sampleNames(3)
+  return { 0: 'You', 1: west, 2: partner, 3: east }
+}
+
+/** Draws a fresh set of randomized team names (#73) from teamNames.ts's
+ * TEAM_NAME_POOL. */
+function randomTeamNames(): Record<TeamId, string> {
+  const [team0, team1] = sampleTeamNames(2)
+  return { 0: team0, 1: team1 }
+}
 
 export function initGameFlowState(dealer: PlayerIndex): GameFlowState {
   return {
@@ -99,6 +120,8 @@ export function initGameFlowState(dealer: PlayerIndex): GameFlowState {
     roundSummary: null,
     gameOverData: null,
     trickPlayCheckpoint: null,
+    seatNames: randomSeatNames(),
+    teamNames: randomTeamNames(),
   }
 }
 
@@ -173,6 +196,7 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         bidWinnerTeam,
         bid,
         cumulativeScoresByTeam,
+        teamNames: state.teamNames,
       }
       return {
         ...state,
@@ -189,7 +213,7 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         return {
           ...state,
           phase: 'game-over',
-          gameOverData: { winningTeam: winner, finalScoresByTeam: state.scoresByTeam },
+          gameOverData: { winningTeam: winner, finalScoresByTeam: state.scoresByTeam, teamNames: state.teamNames },
         }
       }
       return {
@@ -210,6 +234,10 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         roundSummary: null,
         gameOverData: null,
         trickPlayCheckpoint: null,
+        // Fresh names per new game (#73) — a brand new game, not a resume,
+        // so opponents/teams should be redrawn rather than carried over.
+        seatNames: randomSeatNames(),
+        teamNames: randomTeamNames(),
       }
     }
     case 'TRICK_CHECKPOINT': {

--- a/web/src/components/scoreTypes.ts
+++ b/web/src/components/scoreTypes.ts
@@ -7,9 +7,13 @@
 
 import type { TeamId } from '../engine/round'
 
-/** Display names for the two fixed teams — matches Scoreboard's "Team A" /
- * "Team B" labels (Player 0 & 2 = Team A, Player 1 & 3 = Team B). */
-export const TEAM_NAMES: Record<TeamId, string> = {
+/** Fallback team display names (#73) for callers that don't have live
+ * per-game team names yet — e.g. AuctionFlow/TrickPlayFlow's `teamNames`
+ * prop defaults to this when omitted (component tests that predate #73 and
+ * don't care about team-name text). GameFlow.tsx always supplies real,
+ * randomized `GameFlowState.teamNames` instead, so this default is never
+ * seen in an actual game. */
+export const DEFAULT_TEAM_NAMES: Record<TeamId, string> = {
   0: 'Team A',
   1: 'Team B',
 }
@@ -32,6 +36,10 @@ export interface RoundSummaryData {
   readonly bid: number
   /** Cumulative totals after this round's score has been added. */
   readonly cumulativeScoresByTeam: Record<TeamId, number>
+  /** Randomized per-game team display names (#73), from
+   * GameFlowState.teamNames — replaces the old static "Team A"/"Team B"
+   * labels. */
+  readonly teamNames: Record<TeamId, string>
 }
 
 /** Everything the win/loss screen needs once `checkGameOutcome` (game.ts)
@@ -39,4 +47,8 @@ export interface RoundSummaryData {
 export interface GameOverData {
   readonly winningTeam: TeamId
   readonly finalScoresByTeam: Record<TeamId, number>
+  /** Randomized per-game team display names (#73), from
+   * GameFlowState.teamNames — replaces the old static "Team A"/"Team B"
+   * labels. */
+  readonly teamNames: Record<TeamId, string>
 }

--- a/web/src/components/tableTypes.ts
+++ b/web/src/components/tableTypes.ts
@@ -29,6 +29,9 @@ export interface TableState {
   /** null before the auction (#34) has a winner. */
   readonly bidWinner: PlayerIndex | null
   readonly scoresByTeam: Record<TeamId, number>
+  /** Randomized per-game team display names (#73), replacing the old
+   * static "Team A"/"Team B" labels — threaded down to Scoreboard. */
+  readonly teamNames: Record<TeamId, string>
   /** Trick-play (#35): legal cards for the human's turn to play, and the
    * callback to fire when one of them is clicked/tapped. Omitted outside
    * the human's trick-play turn (auction phases, AI turns, mid-settle) —

--- a/web/src/engine/names.test.ts
+++ b/web/src/engine/names.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { NAME_POOL, sampleNames } from './names'
+
+describe('NAME_POOL', () => {
+  it('has exactly 200 entries', () => {
+    expect(NAME_POOL.length).toBe(200)
+  })
+
+  it('has no duplicate entries', () => {
+    expect(new Set(NAME_POOL).size).toBe(200)
+  })
+})
+
+describe('sampleNames', () => {
+  it('draws the requested count of unique names, all from the pool', () => {
+    const names = sampleNames(3)
+    expect(names.length).toBe(3)
+    expect(new Set(names).size).toBe(3)
+    for (const name of names) expect(NAME_POOL).toContain(name)
+  })
+
+  it('caps at the pool size when count exceeds it', () => {
+    const names = sampleNames(NAME_POOL.length + 50)
+    expect(names.length).toBe(NAME_POOL.length)
+    expect(new Set(names).size).toBe(NAME_POOL.length)
+  })
+
+  it('draws different results across calls (probabilistically)', () => {
+    // Not strictly guaranteed, but astronomically likely across 20 draws of
+    // 3-of-200 — a flake here would indicate a real determinism bug.
+    const draws = Array.from({ length: 20 }, () => sampleNames(3).join(','))
+    expect(new Set(draws).size).toBeGreaterThan(1)
+  })
+})

--- a/web/src/engine/names.ts
+++ b/web/src/engine/names.ts
@@ -1,0 +1,49 @@
+// 200-name pool for randomizing AI opponent names (#73). Ported verbatim
+// from names.py's NAME_POOL — same 200 names, same order, so the two
+// engines stay in sync if the pool is ever revised. Themed in blocks of 20
+// (dog names, high fantasy, birds, elvish, Victorian, biblical,
+// aristocratic, modern, sci-fi, ocean); see names.py's docstring / the
+// repo's name_pool.md for the breakdown.
+
+export const NAME_POOL: readonly string[] = [
+  'Buster', 'Cooper', 'Baxter', 'Duncan', 'Marley', 'Gunner', 'Bandit', 'Diesel', 'Ranger', 'Maddox',
+  'Bailey', 'Willow', 'Ginger', 'Harley', 'Sadie', 'Roxie', 'Daisy', 'Maggie', 'Bella', 'Molly',
+  'Zorvan', 'Kaelor', 'Threxis', 'Bendrix', 'Xandor', 'Vanteus', 'Korrath', 'Jaxeon', 'Renthar', 'Drayven',
+  'Seraya', 'Vantha', 'Kyrelle', 'Nyxara', 'Thessia', 'Zerina', 'Aveline', 'Corvana', 'Zylenne', 'Xandrie',
+  'Robin', 'Falcon', 'Raven', 'Heron', 'Kestrel', 'Osprey', 'Merlin', 'Talon', 'Sparrow', 'Corvin',
+  'Paloma', 'Wrenna', 'Larkspur', 'Robyn', 'Starling', 'Skylar', 'Aviana', 'Ravenna', 'Merla', 'Falcona',
+  'Faendril', 'Lorathon', 'Sylnoril', 'Eldrian', 'Thaewyn', 'Caelthir', 'Ravendel', 'Sindolen', 'Aramyth', 'Velthorn',
+  'Lorathien', 'Sylvara', 'Aeliana', 'Faelora', 'Nyriel', 'Thalindra', 'Celestrin', 'Eldara', 'Sindril', 'Vaelora',
+  'Beauregard', 'Jefferson', 'Nathaniel', 'Ambrose', 'Silas', 'Clayton', 'Wendell', 'Garland', 'Sherman', 'Ellison',
+  'Scarlett', 'Magnolia', 'Adelaide', 'Beulah', 'Josephine', 'Charlotte', 'Eudora', 'Delphine', 'Loretta', 'Savannah',
+  'Jeremiah', 'Solomon', 'Zachariah', 'Abraham', 'Malachi', 'Obadiah', 'Ezekiel', 'Jedidiah', 'Elijah', 'Nehemiah',
+  'Rebekah', 'Deborah', 'Jezebel', 'Delilah', 'Bathsheba', 'Miriam', 'Abigail', 'Hadassah', 'Naomi', 'Susanna',
+  'Reginald', 'Frederick', 'Maximilian', 'Alexander', 'Leopold', 'Augustus', 'Theodore', 'William', 'Edmund', 'Richard',
+  'Isabella', 'Victoria', 'Eleanora', 'Anastasia', 'Genevieve', 'Marguerite', 'Beatrice', 'Theodora', 'Cordelia', 'Rosalind',
+  'Michael', 'Jonathan', 'Matthew', 'Anthony', 'Benjamin', 'Nicholas', 'Kenneth', 'Timothy', 'Douglas', 'Raymond',
+  'Jennifer', 'Michelle', 'Rebecca', 'Amanda', 'Kimberly', 'Stephanie', 'Melissa', 'Vanessa', 'Cynthia', 'Danielle',
+  'Zynthar', 'Qorvex', 'Xantiel', 'Vroxnar', 'Thexlon', 'Krevash', 'Nyxoran', 'Zeltrix', 'Quorven', 'Ithracon',
+  'Xylessa', 'Vexanya', 'Qintara', 'Zorielle', 'Nythera', 'Vaelixi', 'Threxia', 'Zynara', 'Qelvana', 'Xantrel',
+  'Marlin', 'Triton', 'Caspian', 'Nereus', 'Pacifico', 'Delmar', 'Marino', 'Oceanus', 'Marner', 'Finnian',
+  'Marina', 'Coral', 'Nerida', 'Kaimana', 'Marisol', 'Oceana', 'Nixie', 'Thalassa', 'Naida', 'Pearla',
+]
+
+/**
+ * Fisher-Yates partial shuffle sample of `count` unique names from
+ * NAME_POOL (mirrors Python's `random.sample(NAME_POOL, count)`, used by
+ * play_local.py/human_play.py for the 3 AI opponents' names). Same
+ * algorithm as passing.ts's sampleRandom, specialized to strings here
+ * rather than sharing a generic helper across engine modules that don't
+ * otherwise depend on each other.
+ */
+export function sampleNames(count: number): string[] {
+  const copy = [...NAME_POOL]
+  const n = Math.min(count, copy.length)
+  const result: string[] = []
+  for (let i = 0; i < n; i++) {
+    const j = i + Math.floor(Math.random() * (copy.length - i))
+    ;[copy[i], copy[j]] = [copy[j], copy[i]]
+    result.push(copy[i])
+  }
+  return result
+}

--- a/web/src/engine/teamNames.test.ts
+++ b/web/src/engine/teamNames.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { sampleTeamNames, TEAM_NAME_POOL } from './teamNames'
+
+describe('TEAM_NAME_POOL', () => {
+  it('has exactly 50 entries', () => {
+    expect(TEAM_NAME_POOL.length).toBe(50)
+  })
+
+  it('has no duplicate entries', () => {
+    expect(new Set(TEAM_NAME_POOL).size).toBe(50)
+  })
+})
+
+describe('sampleTeamNames', () => {
+  it('draws the requested count of unique names, all from the pool', () => {
+    const names = sampleTeamNames(2)
+    expect(names.length).toBe(2)
+    expect(new Set(names).size).toBe(2)
+    for (const name of names) expect(TEAM_NAME_POOL).toContain(name)
+  })
+
+  it('caps at the pool size when count exceeds it', () => {
+    const names = sampleTeamNames(TEAM_NAME_POOL.length + 10)
+    expect(names.length).toBe(TEAM_NAME_POOL.length)
+    expect(new Set(names).size).toBe(TEAM_NAME_POOL.length)
+  })
+
+  it('draws different results across calls (probabilistically)', () => {
+    const draws = Array.from({ length: 20 }, () => sampleTeamNames(2).join(','))
+    expect(new Set(draws).size).toBeGreaterThan(1)
+  })
+})

--- a/web/src/engine/teamNames.ts
+++ b/web/src/engine/teamNames.ts
@@ -1,0 +1,40 @@
+// 50-name pool for randomizing team display names (#73), split across 4
+// themes (15 medieval, 15 fantasy, 10 sci-fi, 10 normal/casual). Curated
+// list from the issue — not derived from names.py (that pool is
+// individual-name-shaped, this one is team-name-shaped).
+
+export const TEAM_NAME_POOL: readonly string[] = [
+  // Medieval (15)
+  'Ironclad Vanguard', 'Crimson Knights', 'Silver Lions', 'Iron Wardens', 'Golden Halberds',
+  'Stonegate Guardians', 'Ravenkeep Sentinels', 'Blackthorn Legion', 'Ashen Crusaders', 'Wolfsbane Company',
+  'Thornwood Rangers', "Gryphon's Watch", 'Ironhold Banners', 'Crownguard Regiment', 'Oakshield Company',
+  // Fantasy (15)
+  'Dragonfire Order', 'Moonveil Wanderers', 'Emberfall Coven', 'Shadowmere Pact', 'Starforge Guild',
+  'Wraithbound Circle', 'Sylvan Wardens', 'Duskwhisper Clan', 'Frostspire Legion', 'Thornveil Ascendancy',
+  'Netherglow Syndicate', 'Wyrmscale Brotherhood', 'Runecarved Vanguard', 'Nightbloom Coven', 'Stormcaller Enclave',
+  // Sci-fi (10)
+  'Nova Squadron', 'Quantum Drifters', 'Voidrunner Fleet', 'Ironstar Collective', 'Photon Vanguard',
+  'Nebula Task Force', 'Cryo Raiders', 'Orbital Sentinels', 'Fusion Reactants', 'Starforge Division',
+  // Normal / casual (10)
+  'The Card Sharks', 'Trump Tight', 'Meld Squad', 'The Bid Bandits', 'Table Talk',
+  'Deal Breakers', 'The Aces High', 'Suit Yourselves', 'Full House Crew', 'Pinochle Posse',
+]
+
+/**
+ * Fisher-Yates partial shuffle sample of `count` unique names from
+ * TEAM_NAME_POOL (same algorithm as names.ts's sampleNames — kept as a
+ * separate function rather than a shared generic helper since the two
+ * pools don't otherwise depend on each other). Only 2 draws are needed
+ * (one per team), but kept general like sampleNames.
+ */
+export function sampleTeamNames(count: number): string[] {
+  const copy = [...TEAM_NAME_POOL]
+  const n = Math.min(count, copy.length)
+  const result: string[] = []
+  for (let i = 0; i < n; i++) {
+    const j = i + Math.floor(Math.random() * (copy.length - i))
+    ;[copy[i], copy[j]] = [copy[j], copy[i]]
+    result.push(copy[i])
+  }
+  return result
+}

--- a/web/src/mock/scoreState.ts
+++ b/web/src/mock/scoreState.ts
@@ -29,6 +29,7 @@ export function buildMockRoundSummary(): RoundSummaryData {
       0: 420 + roundScoreByTeam[0],
       1: 380 + roundScoreByTeam[1],
     },
+    teamNames: { 0: 'Team A', 1: 'Team B' },
   }
 }
 
@@ -36,5 +37,6 @@ export function buildMockGameOver(): GameOverData {
   return {
     winningTeam: 0,
     finalScoresByTeam: { 0: 1040, 1: 760 },
+    teamNames: { 0: 'Team A', 1: 'Team B' },
   }
 }

--- a/web/src/mock/tableState.ts
+++ b/web/src/mock/tableState.ts
@@ -53,5 +53,6 @@ export function buildMockTableState(): TableState {
     currentBid: CURRENT_BID,
     bidWinner: BID_WINNER,
     scoresByTeam: { 0: 180, 1: 220 },
+    teamNames: { 0: 'Team A', 1: 'Team B' },
   }
 }


### PR DESCRIPTION
## Summary
- Ports `names.py`'s 200-name pool verbatim to `web/src/engine/names.ts` (`NAME_POOL`, `sampleNames`) and adds a curated 50-name team pool at `web/src/engine/teamNames.ts` (`TEAM_NAME_POOL`, `sampleTeamNames`), split across medieval/fantasy/sci-fi/casual themes per the issue's exact list.
- Moves `seatNames`/`teamNames` from static module constants (`gameFlowReducer.ts`'s old `SEAT_NAMES`, `scoreTypes.ts`'s old `TEAM_NAMES`) into `GameFlowState`, generated once in `initGameFlowState`/`NEW_GAME` — not regenerated on every render/action.
- Threads `teamNames` down through `TableState` (`tableTypes.ts`) -> `Table.tsx` -> `Scoreboard.tsx`, and through `RoundSummaryData`/`GameOverData` (`scoreTypes.ts`) -> `RoundSummary.tsx`/`GameOverScreen.tsx`. `AuctionFlow.tsx`/`TrickPlayFlow.tsx` gained an optional `teamNames` prop (defaulting to `scoreTypes.ts`'s `DEFAULT_TEAM_NAMES` fallback) so their existing component tests don't need to know about per-game team names.
- Both pools persist correctly through the existing autosave/resume machinery (`persistence/gameSave.ts`) since they now live in `GameFlowState`, which that machinery already round-trips wholesale.

## Tests
- New: `web/src/engine/names.test.ts`, `web/src/engine/teamNames.test.ts` (pool size/uniqueness, sample uniqueness/capping).
- New: `gameFlowReducer.test.ts` cases for `initGameFlowState`/`NEW_GAME` drawing valid seat/team names.
- New: `GameShell.test.tsx` case confirming a save/Continue cycle keeps the same opponent and team names rather than redrawing them.
- Updated fixtures requiring the now-required `teamNames` field: `GameOverScreen.test.tsx`, `RoundSummary.test.tsx`, `gameFlowReducer.test.ts`, plus non-test fixtures `mock/scoreState.ts`, `mock/tableState.ts`.
- `AuctionFlow.test.tsx`, `TrickPlayFlow.test.tsx`, and other component tests listed in the issue as unaffected were verified unaffected (they construct their own local seat-name fixtures and don't hit the new required-teamNames path since it's optional on those two components).

`npx tsc -b`, `npx oxlint`, and `npx vitest run` (253 tests) all pass clean.

## Manual verification
Started the dev server and played through the flow in a real browser:
- New game 1: opponents **Bandit, Diesel, Sparrow**; teams **Emberfall Coven** / **Gryphon's Watch**.
- New game 2: opponents **Scarlett, Delilah, Xantrel**; teams **Crownguard Regiment** / **Pinochle Posse**.
- Reloaded the page mid-auction and clicked Continue: resumed with the exact same names as game 2 (Scarlett/Delilah/Xantrel, Crownguard Regiment/Pinochle Posse) — confirming save/resume doesn't redraw names.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)