### PR TITLE
feat: mark dealer during bidding (#76)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,7 @@
       "name": "pinochle-web",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "cwd": "web",
+      "cwd": "C:\\Users\\paulr\\source\\repos\\pinochle\\web",
       "port": 5173
     }
   ]

--- a/run_practice_games.py
+++ b/run_practice_games.py
@@ -1,0 +1,176 @@
+"""
+Run 1000 games across varied player-type & skill-level matchups.
+Tests whether higher skill reliably beats lower skill, or if it's
+mostly variance.
+"""
+
+import random
+import time
+from collections import Counter
+
+from pinochle_engine import GeneralStrategy, Player, EasyPlayer, Game
+from tournament_sim import PlayerConfig
+
+N_GAMES = 1000
+
+def team_easy():
+    return [PlayerConfig(EasyPlayer), PlayerConfig(EasyPlayer)]
+
+def team_proficient():
+    return [PlayerConfig(Player), PlayerConfig(Player)]
+
+def team_gs(skill):
+    return [
+        PlayerConfig(GeneralStrategy, {"skill_level": skill}),
+        PlayerConfig(GeneralStrategy, {"skill_level": skill}),
+    ]
+
+# Wrap team_gs calls into nullary callables
+def _gs(skill):
+    return lambda: team_gs(skill)
+
+def make_label(label_a, label_b):
+    return label_a, label_b
+
+# Matchup plan: distribute 1000 games across these scenarios
+# Format: (team_a_builder, label_a, team_b_builder, label_b, weight)
+MATCHUPS = [
+    # --- Controls: same-skill mirrors (~50/50 expected) ---
+    (team_easy,        "Easy",       team_easy,        "Easy",        30),
+    (team_proficient,  "Proficient", team_proficient,  "Proficient",  30),
+    (_gs(1),           "GS-S1",      _gs(1),           "GS-S1",       30),
+    (_gs(3),           "GS-S3",      _gs(3),           "GS-S3",       30),
+    (_gs(5),           "GS-S5",      _gs(5),           "GS-S5",       30),
+
+    # --- Easy vs everybody ---
+    (team_easy,        "Easy",       team_proficient,  "Proficient",  50),
+    (team_easy,        "Easy",       _gs(1),           "GS-S1",       40),
+    (team_easy,        "Easy",       _gs(2),           "GS-S2",       40),
+    (team_easy,        "Easy",       _gs(3),           "GS-S3",       40),
+    (team_easy,        "Easy",       _gs(4),           "GS-S4",       40),
+    (team_easy,        "Easy",       _gs(5),           "GS-S5",       40),
+
+    # --- Proficient vs GeneralStrategy ---
+    (team_proficient,  "Proficient", _gs(1),           "GS-S1",       50),
+    (team_proficient,  "Proficient", _gs(2),           "GS-S2",       50),
+    (team_proficient,  "Proficient", _gs(3),           "GS-S3",       50),
+    (team_proficient,  "Proficient", _gs(4),           "GS-S4",       50),
+    (team_proficient,  "Proficient", _gs(5),           "GS-S5",       50),
+
+    # --- GeneralStrategy adjacent skill gaps ---
+    (_gs(1),           "GS-S1",      _gs(2),           "GS-S2",       40),
+    (_gs(2),           "GS-S2",      _gs(3),           "GS-S3",       40),
+    (_gs(3),           "GS-S3",      _gs(4),           "GS-S4",       40),
+    (_gs(4),           "GS-S4",      _gs(5),           "GS-S5",       40),
+
+    # --- GeneralStrategy wide gaps ---
+    (_gs(1),           "GS-S1",      _gs(3),           "GS-S3",       30),
+    (_gs(1),           "GS-S1",      _gs(5),           "GS-S5",       30),
+    (_gs(2),           "GS-S2",      _gs(4),           "GS-S4",       30),
+    (_gs(2),           "GS-S2",      _gs(5),           "GS-S5",       30),
+    (_gs(3),           "GS-S3",      _gs(5),           "GS-S5",       30),
+
+    # --- Cross-type extremes ---
+    (team_easy,        "Easy",       _gs(3),           "GS-S3",       30),
+    (team_proficient,  "Proficient", _gs(3),           "GS-S3",       30),
+]
+
+def run_one_game(team_a_cfgs, team_b_cfgs, game_index):
+    swap = (game_index % 2 == 1)
+    if not swap:
+        seat_cfgs = [team_a_cfgs[0], team_b_cfgs[0], team_a_cfgs[1], team_b_cfgs[1]]
+        a_is_first = True
+    else:
+        seat_cfgs = [team_b_cfgs[0], team_a_cfgs[0], team_b_cfgs[1], team_a_cfgs[1]]
+        a_is_first = False
+
+    players = [cfg.build(f"P{seat}") for seat, cfg in enumerate(seat_cfgs)]
+    game = Game.from_players(players)
+    winner = game.play()
+
+    team_a_obj = game.teams[0] if a_is_first else game.teams[1]
+    team_b_obj = game.teams[1] if a_is_first else game.teams[0]
+    return team_a_obj, team_b_obj, winner
+
+def main():
+    random.seed(42)
+
+    # Build game plan
+    plan = []
+    for builder_a, label_a, builder_b, label_b, count in MATCHUPS:
+        for _ in range(count):
+            plan.append((builder_a, label_a, builder_b, label_b))
+    # Shuffle so order doesn't bias
+    random.shuffle(plan)
+
+    # Trim to N_GAMES
+    plan = plan[:N_GAMES]
+    actual_total = len(plan)
+
+    results = {}  # (label_a, label_b) -> {"games": n, "wins_a": n, "wins_b": n, "margin_a": [...]}
+
+    start = time.perf_counter()
+
+    for idx, (builder_a, label_a, builder_b, label_b) in enumerate(plan):
+        team_a_cfgs = builder_a()
+        team_b_cfgs = builder_b()
+        team_a_obj, team_b_obj, winner = run_one_game(team_a_cfgs, team_b_cfgs, idx)
+
+        key = (label_a, label_b)
+        if key not in results:
+            results[key] = {"games": 0, "wins_a": 0, "wins_b": 0, "margins": []}
+        r = results[key]
+        r["games"] += 1
+        r["margins"].append(team_a_obj.score - team_b_obj.score)
+        if winner is team_a_obj:
+            r["wins_a"] += 1
+        else:
+            r["wins_b"] += 1
+
+    elapsed = time.perf_counter() - start
+    ms_per = elapsed / actual_total * 1000
+
+    print(f"=== Comprehensive Tournament: {actual_total} games ({elapsed:.1f}s, {ms_per:.0f} ms/game) ===\n")
+
+    # Print by matchup, sorted by win rate disparity
+    rows = []
+    for (la, lb), r in results.items():
+        g = r["games"]
+        wa = r["wins_a"]
+        wb = r["wins_b"]
+        pct_a = wa / g * 100
+        pct_b = wb / g * 100
+        avg_margin = sum(r["margins"]) / g
+        rows.append((la, lb, g, wa, wb, pct_a, pct_b, avg_margin))
+
+    # Sort by how far from 50/50 (absolute difference)
+    rows.sort(key=lambda x: abs(x[5] - 50), reverse=True)
+
+    print(f"{'Matchup':<30s} {'Games':>5s} {'Wins A':>7s} {'Wins B':>7s} {'A%':>5s} {'B%':>5s} {'Avg Margin':>10s}")
+    print("-" * 70)
+    for la, lb, g, wa, wb, pct_a, pct_b, margin in rows:
+        label = f"{la} vs {lb}"
+        print(f"{label:<30s} {g:>5d} {wa:>7d} {wb:>7d} {pct_a:>4.0f}% {pct_b:>4.0f}% {margin:>+9.0f}")
+
+    print()
+
+    # Summary by skill tier (flatten)
+    print("--- Summary by skill tier (aggregated) ---")
+    tier_wins = Counter()
+    tier_games = Counter()
+    for (la, lb), r in results.items():
+        # Try to extract a numeric skill for comparison
+        tier_wins[la] += r["wins_a"]
+        tier_wins[lb] += r["wins_b"]
+        tier_games[la] += r["games"]
+        tier_games[lb] += r["games"]
+
+    tier_order = ["Easy", "GS-S1", "GS-S2", "Proficient", "GS-S3", "GS-S4", "GS-S5"]
+    for tier in tier_order:
+        g = tier_games.get(tier, 0)
+        w = tier_wins.get(tier, 0)
+        if g:
+            print(f"  {tier:<15s}: {w:>3d} wins / {g:>3d} games ({w/g:.0%})")
+
+if __name__ == "__main__":
+    main()

--- a/serve_local.ps1
+++ b/serve_local.ps1
@@ -1,0 +1,5 @@
+Write-Host "Starting Pinochle web app at http://localhost:8000"
+Write-Host "Open that URL in your browser."
+Write-Host "Press Ctrl+C to stop the server."
+Write-Host "----------------------------------------"
+python -m http.server 8000

--- a/web/src/components/AuctionFlow.test.tsx
+++ b/web/src/components/AuctionFlow.test.tsx
@@ -1,8 +1,8 @@
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Card, FORCED_BID, Suit } from '../engine/card'
 import type { PlayerIndex } from '../engine/trick'
-import { AuctionFlow } from './AuctionFlow'
+import { AI_BID_DELAY_MS, AuctionFlow } from './AuctionFlow'
 import type { AuctionState } from './auctionReducer'
 import { auctionReducer, initAuctionState } from './auctionReducer'
 import type { AuctionResult } from './auctionTypes'
@@ -86,9 +86,6 @@ describe('auctionReducer', () => {
     const afterFirstPass = auctionReducer(state, { type: 'PASS_BID', player: 0 })
     expect(afterFirstPass.bidding.passes).toBe(1)
     expect(afterFirstPass.bidding.turn).toBe(1)
-    // A duplicate dispatch for seat 0 (e.g. StrictMode re-firing an AI
-    // decision effect against a stale closure) must not double-count the
-    // pass or log it twice, now that seat 1 is up.
     const stale = auctionReducer(afterFirstPass, { type: 'PASS_BID', player: 0 })
     expect(stale).toBe(afterFirstPass)
   })
@@ -101,39 +98,53 @@ describe('auctionReducer', () => {
     expect(stale).toBe(afterFirstBid)
   })
 
-  it('records a trump call and moves to the partner-to-bidder pass step', () => {
+  it('records a trump call and moves to the passing phase', () => {
     let state = baseState(3)
     state = auctionReducer(state, { type: 'PASS_BID', player: 0 })
     state = auctionReducer(state, { type: 'PASS_BID', player: 1 })
     state = auctionReducer(state, { type: 'PASS_BID', player: 2 }) // forces dealer (3)
     state = auctionReducer(state, { type: 'CHOOSE_TRUMP', player: 3, suit: Suit.Hearts })
     expect(state.trumpSuit).toBe(Suit.Hearts)
-    expect(state.phase).toBe('passing-partner-to-bidder')
+    expect(state.phase).toBe('passing')
     expect(state.log.at(-1)).toEqual({ kind: 'trump', player: 3, name: 'East', suit: Suit.Hearts })
   })
 
-  it('moves cards between hands and logs a count-only card-pass entry', () => {
+  it('simultaneously exchanges cards when both passers have selected — both log entries appear at once', () => {
     let state = baseState(3)
-    const card = new Card(Suit.Spades, 'A', 1)
-    state = { ...state, hands: [[card], [], [], []] as [Card[], Card[], Card[], Card[]], phase: 'passing-partner-to-bidder' }
-    state = auctionReducer(state, { type: 'PASS_CARDS', from: 0, to: 1, cards: [card] })
-    expect(state.hands[0]).toEqual([])
-    expect(state.hands[1]).toEqual([card])
-    expect(state.phase).toBe('passing-bidder-to-partner')
-    expect(state.log.at(-1)).toEqual({
-      kind: 'card-pass',
-      fromPlayer: 0,
-      fromName: 'You',
-      toPlayer: 1,
-      toName: 'West',
-      count: 1,
-    })
+    const card1 = new Card(Suit.Spades, 'A', 1)
+    const card2 = new Card(Suit.Clubs, 'K', 1)
+    state = { ...state, hands: [[card1], [], [card2], []] as [Card[], Card[], Card[], Card[]], phase: 'passing', bidWinner: 0 }
+
+    // Partner (2) passes first — cards are stored but hand isn't modified yet
+    state = auctionReducer(state, { type: 'PASS_CARDS', from: 2, cards: [card2] })
+    expect(state.phase).toBe('passing')
+    expect(state.passing.fromBidderCards).toBeNull()
+    expect(state.passing.fromPartnerCards).toEqual([card2])
+    expect(state.log).toHaveLength(0)
+
+    // Bidder (0) passes too — exchange happens atomically
+    state = auctionReducer(state, { type: 'PASS_CARDS', from: 0, cards: [card1] })
+    expect(state.phase).toBe('pass-reveal')
+    expect(state.hands[0]).toEqual([card2])
+    expect(state.hands[2]).toEqual([card1])
+    expect(state.log).toEqual([
+      { kind: 'card-pass', fromPlayer: 2, fromName: 'Partner', toPlayer: 0, toName: 'You', count: 1 },
+      { kind: 'card-pass', fromPlayer: 0, fromName: 'You', toPlayer: 2, toName: 'Partner', count: 1 },
+    ])
+
+    // Confirm reveal to reach complete
+    state = auctionReducer(state, { type: 'CONFIRM_PASS_REVEAL' })
+    expect(state.phase).toBe('complete')
   })
 
-  it('completes the auction after the second (bidder-to-partner) pass', () => {
+  it('completes the auction when both passers have selected their cards', () => {
     let state = baseState(3)
-    state = { ...state, phase: 'passing-bidder-to-partner' }
-    state = auctionReducer(state, { type: 'PASS_CARDS', from: 0, to: 2, cards: [] })
+    state = { ...state, phase: 'passing', bidWinner: 0 }
+    state = auctionReducer(state, { type: 'PASS_CARDS', from: 2, cards: [] })
+    expect(state.phase).toBe('passing')
+    state = auctionReducer(state, { type: 'PASS_CARDS', from: 0, cards: [] })
+    expect(state.phase).toBe('pass-reveal')
+    state = auctionReducer(state, { type: 'CONFIRM_PASS_REVEAL' })
     expect(state.phase).toBe('complete')
   })
 })
@@ -162,10 +173,14 @@ function buildTestHands(): [Card[], Card[], Card[], Card[]] {
   return [human, west, partner, east]
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
 
 describe('AuctionFlow (component)', () => {
   it('walks the human through bidding, naming trump, and passing cards, then reports the result', () => {
+    vi.useFakeTimers()
     const hands = buildTestHands()
     const onComplete = vi.fn()
 
@@ -183,14 +198,19 @@ describe('AuctionFlow (component)', () => {
     // Left of dealer (3) is seat 0 — the human bids first.
     fireEvent.click(screen.getByRole('button', { name: 'Bid' }))
 
-    // West, Partner, and East all pass automatically (weak hands) — the
-    // auction should already have resolved to trump selection.
+    // West, Partner, and East all pass automatically (weak hands) after delays.
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+
     expect(screen.getByText('Name trump')).not.toBeNull()
 
     fireEvent.click(screen.getByText('Hearts'))
 
-    // Partner (AI) passes 3 cards to the human automatically; the human is
-    // now on the bidder-to-partner leg and sees the pass selector.
+    // Partner (AI) passes 3 cards to the human automatically after a delay.
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+
+    // The human (bidder) sees the pass selector for their send-back.
     const passHeading = screen.getByRole('heading', { name: /Choose 3 cards to pass/ })
     const passPanel = within(passHeading.closest('div') as HTMLElement)
 
@@ -198,6 +218,10 @@ describe('AuctionFlow (component)', () => {
     fireEvent.click(passPanel.getByRole('img', { name: 'K of D' }))
     fireEvent.click(passPanel.getByRole('img', { name: 'Q of H' }))
     fireEvent.click(passPanel.getByRole('button', { name: 'Confirm pass' }))
+
+    // Pass-reveal dialog shows before completing
+    expect(screen.getByText('Partner passed you 3 cards')).not.toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
     expect(onComplete).toHaveBeenCalledOnce()
     const result = onComplete.mock.calls[0][0] as AuctionResult
@@ -208,19 +232,10 @@ describe('AuctionFlow (component)', () => {
     expect(result.hands[0].some((c) => c.suit === Suit.Clubs && c.rank === 'A')).toBe(false)
     expect(result.hands[0].some((c) => c.suit === Suit.Diamonds && c.rank === 'K')).toBe(false)
     expect(result.hands[0].some((c) => c.suit === Suit.Hearts && c.rank === 'Q')).toBe(false)
-
-    // The auction/pass log surfaced every AI decision along the way.
-    expect(screen.getByText('West passed')).not.toBeNull()
-    expect(screen.getByText('Partner passed 3 cards to You')).not.toBeNull()
   })
 
-  it('lets a weak-handed AI 3rd bidder open anyway, per chooseBid\'s "3rd bidder opens cheap" rule', () => {
-    // All 4 hands here are weak (bestBaseBid ceiling well under
-    // OPENER_THRESHOLD) — under the old mock/aiDecisions.ts stand-in every
-    // seat would just pass. The real chooseBid wrapper (#29) still opens
-    // for the 3rd bidder (2 prior passes, nobody's bid yet, score under
-    // 800) regardless of hand strength, so this exercises a decision the
-    // mock never made.
+  it('lets a weak-handed AI open as first bidder (partner has not yet had a turn)', () => {
+    vi.useFakeTimers()
     const hands = buildTestHands()
     const onComplete = vi.fn()
 
@@ -229,30 +244,31 @@ describe('AuctionFlow (component)', () => {
         initialHands={hands}
         seatNames={SEAT_NAMES}
         humanPlayer={0}
-        dealer={3}
+        dealer={1}
         scoresByTeam={SCORES}
         onComplete={onComplete}
       />,
     )
 
-    // Left of dealer (3) is seat 0 — the human passes first, then West
-    // (weak hand, not yet the 3rd bidder) passes too. Partner is now the
-    // 3rd bidder (2 passes so far, nobody's bid) and opens at OPENING_BID
-    // despite a weak hand; East (opponent, weak hand) then passes, ending
-    // the auction with Partner as bid winner.
+    // Left of dealer (1) is seat 2 (Partner) — always opens as first bidder.
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+    // Bid amount visible in Scoreboard
+    expect(screen.getByText('300')).not.toBeNull()
+
+    // East (seat 3, opponent holds the bid) passes automatically — the human's turn now.
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+    expect(screen.getByRole('button', { name: 'Pass' })).not.toBeNull()
+
+    // Human (seat 0, teammate holds the bid) manually passes.
     fireEvent.click(screen.getByRole('button', { name: 'Pass' }))
 
-    expect(screen.getByText('You passed')).not.toBeNull()
-    expect(screen.getByText('West passed')).not.toBeNull()
-    expect(screen.getByText('Partner bid 300')).not.toBeNull()
-    expect(screen.getByText('East passed')).not.toBeNull()
+    // West (seat 1, opponent holds the bid, weak hand) passes — 3 passes
+    // after a bid ends the auction. The AI bid winner (Partner) chooses trump
+    // automatically after a delay, then the AI selects pass cards.
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
 
-    // Partner's own hand (9C, JD, 10S) values highest at Clubs (the lone
-    // Dix) — chooseTrump picks it automatically since the bid winner is AI.
-    expect(screen.getByText('Partner named Clubs trump')).not.toBeNull()
-
-    // Bid winner is Partner (AI) — the human is Partner's partner, so the
-    // human is the sender on the first (partner-to-bidder) pass leg.
+    // The human (Partner's partner) sees the pass selector to send cards to the bidder.
     const passHeading = screen.getByRole('heading', { name: /Choose 3 cards to pass/ })
     const passPanel = within(passHeading.closest('div') as HTMLElement)
 
@@ -260,6 +276,13 @@ describe('AuctionFlow (component)', () => {
     fireEvent.click(passPanel.getByRole('img', { name: 'K of D' }))
     fireEvent.click(passPanel.getByRole('img', { name: 'Q of H' }))
     fireEvent.click(passPanel.getByRole('button', { name: 'Confirm pass' }))
+
+    // AI bidder passes 3 cards back to the human (simultaneous — already queued).
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+
+    // Pass-reveal: human sees what the bidder sent back
+    expect(screen.getByText('Partner passed you 3 cards')).not.toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
     expect(onComplete).toHaveBeenCalledOnce()
     const result = onComplete.mock.calls[0][0] as AuctionResult

--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -5,20 +5,19 @@ import { PASS_COUNT, choosePassCards } from '../engine/passing'
 import { teamOf, type Hands, type TeamId } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
-import { AuctionLog } from './AuctionLog'
 import { auctionReducer, initAuctionState } from './auctionReducer'
 import type { AuctionResult } from './auctionTypes'
 import { partnerOf } from './auctionTypes'
 import { BiddingControls } from './BiddingControls'
+import { PassRevealDialog } from './PassRevealDialog'
 import { PassSelector } from './PassSelector'
 import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
-import type { TableState } from './tableTypes'
+import type { SeatState, TableState } from './tableTypes'
 import { TrumpSelector } from './TrumpSelector'
 
-// Min raise over the current bid once someone has opened — mirrors
-// pinochle_engine.py's Round._bidding_loop, which always calls
-// choose_bid(current_bid, 10, ...).
+export const AI_BID_DELAY_MS = 600
+
 const MIN_INCREMENT = 10
 
 export interface AuctionFlowProps {
@@ -27,32 +26,12 @@ export interface AuctionFlowProps {
   humanPlayer: PlayerIndex
   dealer: PlayerIndex
   scoresByTeam: Record<TeamId, number>
-  /** Randomized per-game team display names (#73), threaded straight into
-   * the TableState this component builds for Table/Scoreboard. Defaults to
-   * scoreTypes.ts's DEFAULT_TEAM_NAMES ("Team A"/"Team B") when omitted —
-   * GameFlow.tsx always supplies real per-game names in practice. */
   teamNames?: Record<TeamId, string>
-  /** Opens the persistent mid-game menu (#54: New Game / Continue /
-   * Options) — rendered by Table.tsx as a small corner button. Omit to
-   * render without one (e.g. existing tests that don't exercise it). */
   onOpenMenu?: () => void
-  /** Options toggles (#54) affecting rendering. Defaults to
-   * DEFAULT_OPTIONS (current pre-#54 behavior) when omitted. */
   options?: GameOptions
-  /** Fired once, when both passes have completed, with everything a live
-   * Round orchestrator (trick-play, #35) needs to take over. */
   onComplete?: (result: AuctionResult) => void
 }
 
-/**
- * Drives the auction (#34): bidding, the winner's trump call, and the
- * 3-card pass, mounted into the Table scaffold (#33) so the human always
- * sees seats/hands/scoreboard behind whichever control is active. Human
- * turns wait for input via BiddingControls/TrumpSelector/PassSelector; AI
- * turns resolve automatically (bidding.ts's real chooseBid/chooseTrump
- * (#29), passing.ts's real choosePassCards) and always log a visible
- * AuctionLog entry — no AI decision happens silently.
- */
 export function AuctionFlow({
   initialHands,
   seatNames,
@@ -71,10 +50,6 @@ export function AuctionFlow({
   )
   const completedRef = useRef(false)
 
-  // Resolve AI turns automatically. Runs after every state change; each
-  // branch either dispatches exactly one AI decision (re-triggering this
-  // effect for the next turn) or returns without dispatching because it's
-  // the human's turn / there's nothing left to do this phase.
   useEffect(() => {
     if (state.phase === 'bidding') {
       const turn = state.bidding.turn
@@ -85,42 +60,84 @@ export function AuctionFlow({
         bidHistory: state.bidding.bidHistory,
         dealer: state.dealer,
         scores: state.scoresByTeam,
+        passedPlayers: (Array.from({ length: 4 }) as PlayerIndex[]).filter(
+          (_, i) => !state.bidding.active[i],
+        ),
       }
       const decision = chooseBid(turn, state.hands[turn], state.bidding.currentBid, MIN_INCREMENT, context)
-      if (decision === null) dispatch({ type: 'PASS_BID', player: turn })
-      else dispatch({ type: 'BID', player: turn, amount: decision })
-      return
+      const timer = setTimeout(() => {
+        if (decision === null) dispatch({ type: 'PASS_BID', player: turn })
+        else dispatch({ type: 'BID', player: turn, amount: decision })
+      }, AI_BID_DELAY_MS)
+      return () => clearTimeout(timer)
     }
 
     if (state.phase === 'trump') {
       if (state.bidWinner === null || state.bidWinner === humanPlayer) return
-      const suit = chooseTrump(state.hands[state.bidWinner])
-      dispatch({ type: 'CHOOSE_TRUMP', player: state.bidWinner, suit })
+      const bidWinner = state.bidWinner
+      const suit = chooseTrump(state.hands[bidWinner])
+      const timer = setTimeout(() => {
+        dispatch({ type: 'CHOOSE_TRUMP', player: bidWinner, suit })
+      }, AI_BID_DELAY_MS)
+      return () => clearTimeout(timer)
+    }
+
+    if (state.phase === 'pass-reveal') {
+      const bidder = state.bidWinner!
+      const partner = partnerOf(bidder)
+      if (humanPlayer !== bidder && humanPlayer !== partner) {
+        dispatch({ type: 'CONFIRM_PASS_REVEAL' })
+      }
       return
     }
 
-    if (state.phase === 'passing-partner-to-bidder' || state.phase === 'passing-bidder-to-partner') {
+    if (state.phase === 'passing') {
       if (state.bidWinner === null || state.trumpSuit === null) return
-      const partner = partnerOf(state.bidWinner)
-      const isPartnerStep = state.phase === 'passing-partner-to-bidder'
-      const sender = isPartnerStep ? partner : state.bidWinner
-      const receiver = isPartnerStep ? state.bidWinner : partner
-      if (sender === humanPlayer) return
-      const cards = choosePassCards(state.hands[sender], PASS_COUNT, state.trumpSuit, sender === state.bidWinner)
-      dispatch({ type: 'PASS_CARDS', from: sender, to: receiver, cards })
+      const bidder = state.bidWinner
+      const partner = partnerOf(bidder)
+      const bidderReady = state.passing.fromBidderCards !== null
+      const partnerReady = state.passing.fromPartnerCards !== null
+
+      const needsAI = (bidder !== humanPlayer && !bidderReady) || (partner !== humanPlayer && !partnerReady)
+      if (!needsAI) return
+
+      const timer = setTimeout(() => {
+        if (bidder !== humanPlayer && !bidderReady) {
+          const cards = choosePassCards(state.hands[bidder], PASS_COUNT, state.trumpSuit!, true)
+          dispatch({ type: 'PASS_CARDS', from: bidder, cards })
+        }
+        if (partner !== humanPlayer && !partnerReady) {
+          const cards = choosePassCards(state.hands[partner], PASS_COUNT, state.trumpSuit!, false)
+          dispatch({ type: 'PASS_CARDS', from: partner, cards })
+        }
+      }, AI_BID_DELAY_MS)
+      return () => clearTimeout(timer)
     }
   }, [state, humanPlayer])
 
-  // Fire onComplete exactly once, when the pass phase finishes.
   useEffect(() => {
     if (state.phase !== 'complete' || completedRef.current) return
     if (state.bidWinner === null || state.trumpSuit === null) return
     completedRef.current = true
-    onComplete?.({ hands: state.hands, trumpSuit: state.trumpSuit, bidWinner: state.bidWinner, bid: state.bid })
+    onComplete?.({ hands: state.hands, trumpSuit: state.trumpSuit, bidWinner: state.bidWinner, bid: state.bid, log: state.log })
   }, [state, onComplete])
 
   const tableState: TableState = useMemo(() => {
-    const seatFor = (p: PlayerIndex) => ({ player: p, name: seatNames[p], hand: state.hands[p] })
+    const seatFor = (p: PlayerIndex): SeatState => {
+      const active = state.bidding.active[p]
+      const isBidWinner = p === state.bidding.bidWinner && state.bidding.currentBid > 0
+      let statusText: string | undefined
+      if (!active) {
+        statusText = 'Pass'
+      } else if (isBidWinner) {
+        statusText = `(${state.bidding.currentBid})`
+      } else if (state.phase === 'bidding' && p === state.bidding.turn) {
+        // current turn — no status overlay needed
+      } else {
+        statusText = '(Waiting)'
+      }
+      return { player: p, name: seatNames[p], hand: state.hands[p], statusText }
+    }
     const seats: TableState['seats'] = [seatFor(0), seatFor(1), seatFor(2), seatFor(3)]
     return {
       seats,
@@ -131,6 +148,7 @@ export function AuctionFlow({
       bidWinner: state.bidWinner,
       scoresByTeam: state.scoresByTeam,
       teamNames,
+      dealer: state.dealer,
     }
   }, [state, seatNames, humanPlayer, teamNames])
 
@@ -139,9 +157,6 @@ export function AuctionFlow({
       const minBid = state.bidding.everBid ? state.bidding.currentBid + 10 : OPENING_BID
       const myTeam = teamOf(humanPlayer)
       const oppTeam: TeamId = myTeam === 0 ? 1 : 0
-      // bestBaseBid's returned total is already the capped ceiling (it
-      // applies cappedBid internally per trump candidate before picking
-      // the best one) — a direct, non-binding hint for the human bidder.
       const { total: suggestedCeiling } = bestBaseBid(
         state.hands[humanPlayer],
         state.scoresByTeam[myTeam],
@@ -163,25 +178,43 @@ export function AuctionFlow({
       return <TrumpSelector onSelect={(suit) => dispatch({ type: 'CHOOSE_TRUMP', player: humanPlayer, suit })} />
     }
 
-    if (
-      (state.phase === 'passing-partner-to-bidder' || state.phase === 'passing-bidder-to-partner') &&
-      state.bidWinner !== null &&
-      state.trumpSuit !== null
-    ) {
-      const partner = partnerOf(state.bidWinner)
-      const isPartnerStep = state.phase === 'passing-partner-to-bidder'
-      const sender = isPartnerStep ? partner : state.bidWinner
-      const receiver = isPartnerStep ? state.bidWinner : partner
-      if (sender === humanPlayer) {
+    if (state.phase === 'passing' && state.bidWinner !== null && state.trumpSuit !== null) {
+      const bidder = state.bidWinner
+      const partner = partnerOf(bidder)
+      const myPassDone =
+        (humanPlayer === bidder && state.passing.fromBidderCards !== null) ||
+        (humanPlayer === partner && state.passing.fromPartnerCards !== null)
+
+      if (!myPassDone && (humanPlayer === bidder || humanPlayer === partner)) {
         return (
           <PassSelector
             hand={state.hands[humanPlayer]}
             count={PASS_COUNT}
             trumpSuit={state.trumpSuit}
-            onConfirm={(cards) => dispatch({ type: 'PASS_CARDS', from: sender, to: receiver, cards })}
+            onConfirm={(cards) => dispatch({ type: 'PASS_CARDS', from: humanPlayer, cards })}
           />
         )
       }
+    }
+
+    if (state.phase === 'pass-reveal') {
+      const bidder = state.bidWinner!
+      const partner = partnerOf(bidder)
+      const receivedCards =
+        humanPlayer === bidder ? state.passing.fromPartnerCards
+        : humanPlayer === partner ? state.passing.fromBidderCards
+        : null
+      const senderName =
+        humanPlayer === bidder ? state.seatNames[partner]
+        : humanPlayer === partner ? state.seatNames[bidder]
+        : ''
+      return (
+        <PassRevealDialog
+          cards={receivedCards}
+          partnerName={senderName}
+          onContinue={() => dispatch({ type: 'CONFIRM_PASS_REVEAL' })}
+        />
+      )
     }
 
     return null
@@ -191,7 +224,6 @@ export function AuctionFlow({
     <Table
       state={tableState}
       overlay={overlay}
-      logPanel={<AuctionLog entries={state.log} />}
       onOpenMenu={onOpenMenu}
       hideOpponentCards={options.hideOpponentCards}
     />

--- a/web/src/components/GameFlow.test.tsx
+++ b/web/src/components/GameFlow.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Card, Deck, Suit } from '../engine/card'
 import { GameFlow } from './GameFlow'
+import { initGameFlowState } from './gameFlowReducer'
 
 // Deterministic dealt hands, standing in for Deck.deal()'s real (shuffled)
 // output — these tests care about the misdeal-check wiring and the
@@ -46,9 +47,9 @@ describe('GameFlow (component)', () => {
   it('deals straight into the auction when no seat is misdeal-eligible', async () => {
     mockDeals([weakHand(), weakHand(), weakHand(), weakHand()])
 
-    render(<GameFlow />)
+    // Fixed dealer=3 so the human (seat 0, left of dealer) bids first.
+    render(<GameFlow initialState={initGameFlowState(3)} />)
 
-    // Dealer is East (3); left of dealer is the human (0) — they bid first.
     await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
     expect(screen.queryByText('Misdeal?')).toBeNull()
   })
@@ -56,7 +57,7 @@ describe('GameFlow (component)', () => {
   it('asks the human to confirm a reshuffle when they hold 5+ nines, and proceeds on decline', async () => {
     mockDeals([handWithNines(5), weakHand(), weakHand(), weakHand()])
 
-    render(<GameFlow />)
+    render(<GameFlow initialState={initGameFlowState(3)} />)
 
     await waitFor(() => expect(screen.getByText('Misdeal?')).not.toBeNull())
     expect(screen.getByText(/You have 5 nines/)).not.toBeNull()
@@ -73,7 +74,7 @@ describe('GameFlow (component)', () => {
       [weakHand(), weakHand(), weakHand(), weakHand()],
     )
 
-    render(<GameFlow />)
+    render(<GameFlow initialState={initGameFlowState(3)} />)
 
     await waitFor(() => expect(screen.getByText('Misdeal?')).not.toBeNull())
     expect(screen.getByText(/You have 6 nines/)).not.toBeNull()
@@ -91,7 +92,8 @@ describe('GameFlow (component)', () => {
       [weakHand(), weakHand(), weakHand(), weakHand()],
     )
 
-    render(<GameFlow />)
+    // Fixed dealer=3 so the human bids first after the auto-reshuffle.
+    render(<GameFlow initialState={initGameFlowState(3)} />)
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
     expect(screen.queryByText('Misdeal?')).toBeNull()

--- a/web/src/components/GameFlow.tsx
+++ b/web/src/components/GameFlow.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useReducer } from 'react'
 import { Deck } from '../engine/card'
 import { MISDEAL_NINE_THRESHOLD, nineCount } from '../engine/misdeal'
-import type { Hands } from '../engine/round'
+import { teamOf, type Hands, type TeamId } from '../engine/round'
+import { meldPointsByTeam } from './gameFlowReducer'
 import type { PlayerIndex } from '../engine/trick'
 import { clearSave, saveGame } from '../persistence/gameSave'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
@@ -11,10 +12,11 @@ import {
   gameFlowReducer,
   HUMAN_PLAYER,
   initGameFlowState,
-  INITIAL_DEALER,
+  randomDealer,
   type GameFlowState,
 } from './gameFlowReducer'
 import { GameOverScreen } from './GameOverScreen'
+import { MeldFlow } from './MeldFlow'
 import { MisdealPrompt } from './MisdealPrompt'
 import { RoundSummary } from './RoundSummary'
 import { Table } from './Table'
@@ -56,7 +58,7 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
   const [state, dispatch] = useReducer(
     gameFlowReducer,
     undefined,
-    () => initialState ?? initGameFlowState(INITIAL_DEALER),
+    () => initialState ?? initGameFlowState(randomDealer()),
   )
 
   // Deal (or redeal) a fresh shuffled 48-card hand whenever entering the
@@ -97,6 +99,21 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
     (result: AuctionResult) => dispatch({ type: 'AUCTION_COMPLETE', result }),
     [],
   )
+  const handleMeldComplete = useCallback(
+    (meldPointsByTeam: Record<0 | 1, number>) => dispatch({ type: 'MELD_COMPLETE', meldPointsByTeam }),
+    [],
+  )
+  const handleMeldConcede = useCallback(() => {
+    if (state.phase !== 'meld' || !state.auctionResult) return
+    const { hands, trumpSuit, bidWinner } = state.auctionResult
+    const mp = meldPointsByTeam(hands, trumpSuit)
+    const bidderTeam = teamOf(bidWinner)
+    // Fold: bidding team forfeits meld and loses the bid (-bid); opponents
+    // keep their meld but no trick points.
+    const adjusted: Record<TeamId, number> = { ...mp, [bidderTeam]: 0 }
+    dispatch({ type: 'MELD_COMPLETE', meldPointsByTeam: adjusted })
+    dispatch({ type: 'TRICK_COMPLETE', result: { trickPointsByTeam: { 0: 0, 1: 0 } as Record<0 | 1, number>, trickWinners: [], conceded: true } })
+  }, [state.phase, state.auctionResult])
   const handleTrickComplete = useCallback(
     (result: TrickPlayResult) => dispatch({ type: 'TRICK_COMPLETE', result }),
     [],
@@ -144,6 +161,27 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
     )
   }
 
+  if (state.phase === 'meld' && state.auctionResult) {
+    const { hands, trumpSuit, bidWinner, bid } = state.auctionResult
+    return (
+      <MeldFlow
+        hands={hands.map((h) => [...h]) as Hands}
+        trumpSuit={trumpSuit}
+        bidWinner={bidWinner}
+        bid={bid}
+        seatNames={state.seatNames}
+        humanPlayer={HUMAN_PLAYER}
+        scoresByTeam={state.scoresByTeam}
+        teamNames={state.teamNames}
+        dealer={state.dealer}
+        onOpenMenu={onOpenMenu}
+        options={options}
+        onComplete={handleMeldComplete}
+        onConcede={handleMeldConcede}
+      />
+    )
+  }
+
   if (state.phase === 'trick-play' && state.auctionResult) {
     const { hands, trumpSuit, bidWinner, bid } = state.auctionResult
     return (
@@ -152,6 +190,8 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
         trumpSuit={trumpSuit}
         bidWinner={bidWinner}
         bid={bid}
+        meldPointsByTeam={state.meldPointsByTeam ?? meldPointsByTeam(hands, trumpSuit)}
+        auctionLog={state.auctionResult?.log}
         seatNames={state.seatNames}
         humanPlayer={HUMAN_PLAYER}
         scoresByTeam={state.scoresByTeam}
@@ -164,6 +204,7 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
         onCheckpoint={handleTrickCheckpoint}
         onOpenMenu={onOpenMenu}
         options={options}
+        dealer={state.dealer}
         onComplete={handleTrickComplete}
       />
     )
@@ -185,7 +226,7 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
           // that window can't offer "Continue" back into a game that's
           // already over.
           clearSave()
-          dispatch({ type: 'NEW_GAME', dealer: INITIAL_DEALER })
+          dispatch({ type: 'NEW_GAME', dealer: randomDealer() })
         }}
       />
     )
@@ -205,6 +246,7 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
     bidWinner: null,
     scoresByTeam: state.scoresByTeam,
     teamNames: state.teamNames,
+    dealer: state.dealer,
   }
 
   const humanMisdealEligible =

--- a/web/src/components/GameShell.test.tsx
+++ b/web/src/components/GameShell.test.tsx
@@ -3,6 +3,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Card, Deck, Suit } from '../engine/card'
 import { GameShell } from './GameShell'
 
+// Random dealer causes flaky tests (human might not be first to bid).
+// Fix dealer to East (3) so the human (seat 0, left of dealer) always bids first.
+vi.mock('./gameFlowReducer', async (importOriginal) => {
+  const actual: object = await importOriginal()
+  return { ...actual, randomDealer: () => 3 as const }
+})
+
 // Same deterministic-weak-hand approach GameFlow.test.tsx uses: no nines
 // means nobody's misdeal-eligible, so dealing lands straight in the
 // auction (dealer East (3), human (0) bids first).

--- a/web/src/components/MeldFlow.tsx
+++ b/web/src/components/MeldFlow.tsx
@@ -1,0 +1,167 @@
+import { useMemo } from 'react'
+import { type Suit, sortHandForDisplay } from '../engine/card'
+import { extractMeldCards, type MeldCardsResult } from '../engine/melds'
+import { teamOf, type Hands, type TeamId } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
+import { PlayingCard } from './PlayingCard'
+import { DEFAULT_TEAM_NAMES } from './scoreTypes'
+import { Table } from './Table'
+import type { TableState } from './tableTypes'
+
+export interface MeldFlowProps {
+  hands: Hands
+  trumpSuit: Suit
+  bidWinner: PlayerIndex
+  bid: number
+  seatNames: Record<PlayerIndex, string>
+  humanPlayer: PlayerIndex
+  scoresByTeam: Record<TeamId, number>
+  teamNames?: Record<TeamId, string>
+  dealer: PlayerIndex
+  onOpenMenu?: () => void
+  options?: GameOptions
+  onComplete: (meldPointsByTeam: Record<TeamId, number>) => void
+  onConcede?: () => void
+}
+
+function MeldGroupList({ groups }: { groups: MeldCardsResult['groups'] }) {
+  return (
+    <div className="mt-1 space-y-1">
+      {groups.map((g, i) => (
+        <div key={i} className="flex items-center gap-2 text-sm">
+          <span className="text-neutral-500">{g.name}:</span>
+          <span className="font-semibold">{g.points}</span>
+          <div className="flex gap-0.5">
+            {sortHandForDisplay(g.cards).map((c, j) => (
+              <PlayingCard key={j} suit={c.suit} rank={c.rank} className="w-6" />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function MeldFlow({
+  hands,
+  trumpSuit,
+  bidWinner,
+  bid,
+  seatNames,
+  humanPlayer,
+  scoresByTeam,
+  teamNames = DEFAULT_TEAM_NAMES,
+  dealer,
+  onOpenMenu,
+  options = DEFAULT_OPTIONS,
+  onComplete,
+  onConcede,
+}: MeldFlowProps) {
+  const allMeldData = useMemo(() => {
+    const result: Record<PlayerIndex, MeldCardsResult> = {} as Record<PlayerIndex, MeldCardsResult>
+    for (let i = 0; i < 4; i++) {
+      const player = i as PlayerIndex
+      result[player] = extractMeldCards(hands[player], trumpSuit)
+    }
+    return result
+  }, [hands, trumpSuit])
+
+  const humanMeld = allMeldData[humanPlayer]
+
+  const allMeldPoints = useMemo(() => {
+    const byTeam: Record<TeamId, number> = { 0: 0, 1: 0 }
+    for (let i = 0; i < 4; i++) {
+      const player = i as PlayerIndex
+      const { meldCards: _mc, groups } = allMeldData[player]
+      byTeam[teamOf(player)] += groups.reduce((s, g) => s + g.points, 0)
+    }
+    return byTeam
+  }, [allMeldData])
+
+  const tableState: TableState = useMemo(() => {
+    const seatFor = (p: PlayerIndex) => ({
+      player: p,
+      name: seatNames[p],
+      hand: p === humanPlayer ? hands[p] : allMeldData[p].meldCards,
+    })
+    return {
+      seats: [seatFor(0), seatFor(1), seatFor(2), seatFor(3)],
+      humanPlayer,
+      trick: [],
+      trumpSuit,
+      currentBid: bid,
+      bidWinner,
+      scoresByTeam,
+      teamNames,
+      dealer,
+      meldPoints: allMeldPoints[teamOf(bidWinner)],
+    }
+  }, [hands, allMeldData, seatNames, humanPlayer, trumpSuit, bid, bidWinner, scoresByTeam, teamNames, allMeldPoints, dealer])
+
+  const humanTotal = humanMeld.groups.reduce((s, g) => s + g.points, 0)
+
+  const overlay = (
+    <div className="w-full max-w-sm rounded-lg bg-white p-5 text-neutral-900 shadow-xl">
+      <h3 className="text-base font-bold">Meld Declaration</h3>
+
+      <p className="mt-2 text-sm text-neutral-600">
+        Your melds: <span className="font-bold text-green-700">{humanTotal}</span> points
+      </p>
+      {humanMeld.groups.length > 0 ? (
+        <div className="mt-2">
+          <MeldGroupList groups={humanMeld.groups} />
+        </div>
+      ) : (
+        <p className="mt-2 text-sm text-neutral-500">No melds detected in your hand.</p>
+      )}
+
+      {[0, 1, 2, 3]
+        .filter((p) => p !== humanPlayer)
+        .map((p) => {
+          const md = allMeldData[p as PlayerIndex]
+          return (
+            <div key={p} className="mt-4 border-t border-neutral-200 pt-3">
+              <p className="text-sm font-semibold text-neutral-700">
+                {seatNames[p as PlayerIndex]} — {md.groups.reduce((s, g) => s + g.points, 0)} meld points
+              </p>
+              {md.groups.length > 0 ? (
+                <MeldGroupList groups={md.groups} />
+              ) : (
+                <p className="text-sm text-neutral-500">No melds</p>
+              )}
+            </div>
+          )
+        })}
+
+      <div className="mt-5 flex gap-2">
+        <button
+          type="button"
+          onClick={() => onComplete(allMeldPoints)}
+          className="flex-1 rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900"
+        >
+          Continue
+        </button>
+        {onConcede && bidWinner === humanPlayer && (
+          <button
+            type="button"
+            onClick={onConcede}
+            className="rounded bg-red-800 px-4 py-2 font-semibold text-white hover:bg-red-900"
+          >
+            Fold
+          </button>
+        )}
+      </div>
+    </div>
+  )
+
+  return (
+    <Table
+      state={tableState}
+      overlay={overlay}
+      onOpenMenu={onOpenMenu}
+      hideOpponentCards={options.hideOpponentCards}
+      exposeCards
+    />
+  )
+}

--- a/web/src/components/OptionsPanel.test.tsx
+++ b/web/src/components/OptionsPanel.test.tsx
@@ -9,27 +9,29 @@ describe('OptionsPanel', () => {
   it('reflects the current options in the two checkboxes', () => {
     render(
       <OptionsPanel
-        options={{ hideOpponentCards: true, showBaseBidHint: false }}
+        options={{ hideOpponentCards: true, showBaseBidHint: false, opponentSkill: 'proficient', teammateSkill: 'hard', showMeldHint: false, hideTrickLog: true }}
         onChange={() => {}}
         onClose={() => {}}
       />,
     )
     expect((screen.getByLabelText('Hide opponent cards') as HTMLInputElement).checked).toBe(true)
     expect((screen.getByLabelText('Show base-bid hint') as HTMLInputElement).checked).toBe(false)
+    expect((screen.getByLabelText('Opponents') as HTMLSelectElement).value).toBe('proficient')
+    expect((screen.getByLabelText('Teammate') as HTMLSelectElement).value).toBe('hard')
   })
 
   it('calls onChange with the hideOpponentCards toggle flipped, leaving the other field alone', () => {
     const onChange = vi.fn()
     render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={onChange} onClose={() => {}} />)
     fireEvent.click(screen.getByLabelText('Hide opponent cards'))
-    expect(onChange).toHaveBeenCalledWith({ hideOpponentCards: true, showBaseBidHint: true })
+    expect(onChange).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS, hideOpponentCards: true, showBaseBidHint: true })
   })
 
   it('calls onChange with the showBaseBidHint toggle flipped', () => {
     const onChange = vi.fn()
     render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={onChange} onClose={() => {}} />)
     fireEvent.click(screen.getByLabelText('Show base-bid hint'))
-    expect(onChange).toHaveBeenCalledWith({ hideOpponentCards: false, showBaseBidHint: false })
+    expect(onChange).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS, hideOpponentCards: false, showBaseBidHint: false })
   })
 
   it('calls onClose from the Done button', () => {
@@ -39,9 +41,15 @@ describe('OptionsPanel', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('has no AI-difficulty or bid-window controls yet (explicitly out of scope for #54)', () => {
+  it('has skill-level controls for Opponent and Teammate (#79)', () => {
     render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={() => {}} onClose={() => {}} />)
-    expect(screen.queryByText(/difficulty/i)).toBeNull()
+    expect(screen.getByLabelText('Opponents')).toBeTruthy()
+    expect(screen.getByLabelText('Teammate')).toBeTruthy()
+  })
+
+
+  it('has no bid-window controls yet (explicitly out of scope for #54)', () => {
+    render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={() => {}} onClose={() => {}} />)
     expect(screen.queryByText(/bid window/i)).toBeNull()
   })
 })

--- a/web/src/components/OptionsPanel.tsx
+++ b/web/src/components/OptionsPanel.tsx
@@ -1,19 +1,20 @@
-// Options panel (#54): exactly two toggles for this issue — hiding
-// opponents' face-down card fans (Seat.tsx) and the base-bid hint
-// (BiddingControls.tsx). Deliberately not here yet: an AI-difficulty picker
-// and a "bid window" hint based on assumed opponent skill, both out of
-// scope for #54 since they depend on AI difficulty tiers that don't exist
-// in the TS engine yet (bidding.ts only has the one Proficient strategy).
-// The layout below leaves room for those as a later addition rather than
-// stubbing UI for them now.
-
-import type { GameOptions } from '../persistence/options'
+import type { GameOptions, SkillLevel } from '../persistence/options'
 
 export interface OptionsPanelProps {
   options: GameOptions
   onChange: (options: GameOptions) => void
   onClose: () => void
 }
+
+const SKILL_LABELS: Record<SkillLevel, string> = {
+  easy: 'Novice',
+  medium: 'Apprentice',
+  hard: 'Journeyman',
+  proficient: 'Expert',
+  expert: 'Master',
+}
+
+const DISPLAYED_SKILLS: SkillLevel[] = ['easy', 'medium', 'hard', 'proficient', 'expert']
 
 export function OptionsPanel({ options, onChange, onClose }: OptionsPanelProps) {
   return (
@@ -38,11 +39,51 @@ export function OptionsPanel({ options, onChange, onClose }: OptionsPanelProps) 
             />
             Show base-bid hint
           </label>
-        </div>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={options.showMeldHint}
+              onChange={(e) => onChange({ ...options, showMeldHint: e.target.checked })}
+            />
+            Show meld breakdown
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={!options.hideTrickLog}
+              onChange={(e) => onChange({ ...options, hideTrickLog: !e.target.checked })}
+            />
+            Show trick-play log
+          </label>
 
-        {/* Room for an AI-difficulty picker and a bid-window hint once AI
-            difficulty tiers exist — see the comment at the top of this
-            file. Deliberately left blank, not stubbed. */}
+          <hr className="my-1 border-neutral-200" />
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Skill Level</h3>
+
+          <label className="flex items-center justify-between gap-2">
+            <span>Opponents</span>
+            <select
+              className="rounded border border-neutral-300 px-2 py-1 text-sm"
+              value={options.opponentSkill}
+              onChange={(e) => onChange({ ...options, opponentSkill: e.target.value as SkillLevel })}
+            >
+              {DISPLAYED_SKILLS.map((s) => (
+                <option key={s} value={s}>{SKILL_LABELS[s]}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center justify-between gap-2">
+            <span>Teammate</span>
+            <select
+              className="rounded border border-neutral-300 px-2 py-1 text-sm"
+              value={options.teammateSkill}
+              onChange={(e) => onChange({ ...options, teammateSkill: e.target.value as SkillLevel })}
+            >
+              {DISPLAYED_SKILLS.map((s) => (
+                <option key={s} value={s}>{SKILL_LABELS[s]}</option>
+              ))}
+            </select>
+          </label>
+        </div>
 
         <button
           type="button"

--- a/web/src/components/PassRevealDialog.tsx
+++ b/web/src/components/PassRevealDialog.tsx
@@ -1,0 +1,38 @@
+import { type Card, sortHandForDisplay } from '../engine/card'
+import { useMemo } from 'react'
+import { PlayingCard } from './PlayingCard'
+
+export interface PassRevealDialogProps {
+  readonly cards: readonly Card[] | null
+  readonly partnerName: string
+  readonly onContinue: () => void
+}
+
+export function PassRevealDialog({ cards, partnerName, onContinue }: PassRevealDialogProps) {
+  const sorted = useMemo(() => (cards ? sortHandForDisplay(cards) : []), [cards])
+
+  return (
+    <div className="rounded-lg bg-slate-800 p-6 shadow-xl">
+      <h2 className="mb-4 text-center text-lg font-semibold text-white">
+        {cards && cards.length > 0 ? `${partnerName} passed you ${cards.length} card${cards.length !== 1 ? 's' : ''}` : 'No cards passed'}
+      </h2>
+      {cards && cards.length > 0 && (
+        <div className="mb-6 flex justify-center gap-0">
+          {sorted.map((card, i) => (
+            <div key={i} className="-ml-10 first:ml-0">
+              <PlayingCard suit={card.suit} rank={card.rank} />
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex justify-center">
+        <button
+          className="rounded bg-blue-600 px-6 py-2 text-white hover:bg-blue-500"
+          onClick={onContinue}
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/Scoreboard.tsx
+++ b/web/src/components/Scoreboard.tsx
@@ -12,12 +12,14 @@ export interface ScoreboardProps {
   bidWinnerName?: string
   /** null while the auction (#34) hasn't settled on trump yet. */
   trumpSuit: Suit | null
+  /** Meld points of the bidding team, shown after meld declaration. */
+  meldPoints?: number
 }
 
 /** Top strip: cumulative team scores, the standing bid, and trump. Stays
  * mounted throughout bidding/passing/trick-play so those flows (separate
  * issues) can render alongside it without needing their own scoreboard. */
-export function Scoreboard({ scoresByTeam, teamNames, currentBid, bidWinnerName, trumpSuit }: ScoreboardProps) {
+export function Scoreboard({ scoresByTeam, teamNames, currentBid, bidWinnerName, trumpSuit, meldPoints }: ScoreboardProps) {
   const trumpColor = trumpSuit && RED_SUITS.includes(trumpSuit) ? 'text-red-400' : 'text-white'
 
   return (
@@ -38,6 +40,11 @@ export function Scoreboard({ scoresByTeam, teamNames, currentBid, bidWinnerName,
         Bid: <span className="font-semibold">{currentBid || '—'}</span>
         {bidWinnerName ? ` (${bidWinnerName})` : ''}
       </span>
+      {meldPoints !== undefined && (
+        <span>
+          Meld: <span className="font-semibold text-amber-300">{meldPoints}</span>
+        </span>
+      )}
     </div>
   )
 }

--- a/web/src/components/Seat.test.tsx
+++ b/web/src/components/Seat.test.tsx
@@ -16,13 +16,13 @@ function opponentSeat(cardCount: number): SeatState {
 
 describe('Seat', () => {
   it('renders a face-down fan for an AI seat by default', () => {
-    render(<Seat seat={opponentSeat(3)} position="left" isHuman={false} isBidWinner={false} />)
+    render(<Seat seat={opponentSeat(3)} position="left" isHuman={false} isBidWinner={false} isDealer={false} />)
     expect(screen.getAllByLabelText('face-down card')).toHaveLength(3)
     expect(screen.getByText('West')).not.toBeNull()
   })
 
   it('omits the face-down fan when hideOpponentHand is set (Options toggle, #54)', () => {
-    render(<Seat seat={opponentSeat(3)} position="left" isHuman={false} isBidWinner={false} hideOpponentHand />)
+    render(<Seat seat={opponentSeat(3)} position="left" isHuman={false} isBidWinner={false} isDealer={false} hideOpponentHand />)
     expect(screen.queryAllByLabelText('face-down card')).toHaveLength(0)
     // The seat label/count stays visible — only the card fan is hidden.
     expect(screen.getByText('West')).not.toBeNull()
@@ -30,7 +30,7 @@ describe('Seat', () => {
 
   it('never hides the human seat, regardless of hideOpponentHand', () => {
     const humanSeat: SeatState = { player: 0, name: 'You', hand: [new Card(Suit.Hearts, 'A', 1)] }
-    render(<Seat seat={humanSeat} position="bottom" isHuman isBidWinner={false} hideOpponentHand />)
+    render(<Seat seat={humanSeat} position="bottom" isHuman isBidWinner={false} isDealer={false} hideOpponentHand />)
     expect(screen.getByLabelText('A of H')).not.toBeNull()
   })
 })

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -8,6 +8,7 @@ export interface SeatProps {
   position: SeatPosition
   isHuman: boolean
   isBidWinner: boolean
+  isDealer: boolean
   /** Trick-play (#35): legal cards for the human's turn to play, and the
    * callback to fire on a legal card's click/tap. Legal cards render
    * highlighted and clickable; illegal ones render dimmed and disabled.
@@ -18,6 +19,9 @@ export interface SeatProps {
    * count — the face-down fan is skipped entirely to save screen space.
    * No-op for the human seat, which always renders its real hand. */
   hideOpponentHand?: boolean
+  /** Meld phase (#??): when true, a non-human seat renders its cards face-up
+   * (meld cards laid on the table) instead of face-down or hidden. */
+  exposeCards?: boolean
 }
 
 // Placeholder face used for AI seats' face-down fan. The suit/rank props
@@ -39,11 +43,16 @@ const POSITION_LAYOUT: Record<SeatPosition, string> = {
  * sized to their card count — never the actual cards, since an AI's hand
  * is hidden information from the human player's point of view.
  */
-export function Seat({ seat, position, isHuman, isBidWinner, playable, hideOpponentHand }: SeatProps) {
+export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable, hideOpponentHand, exposeCards }: SeatProps) {
   return (
     <div className={`flex gap-1 ${POSITION_LAYOUT[position]}`}>
       <div className="flex items-center gap-2 text-sm font-medium">
         <span>{seat.name}</span>
+        {isDealer && (
+          <span className="rounded bg-neutral-700/80 px-1.5 py-0.5 text-xs font-bold text-amber-300">
+            D
+          </span>
+        )}
         {isBidWinner && (
           <span className="rounded bg-amber-500/90 px-1.5 py-0.5 text-xs font-semibold text-amber-950">
             Bid
@@ -53,6 +62,9 @@ export function Seat({ seat, position, isHuman, isBidWinner, playable, hideOppon
           <span className="text-xs text-white/70">{seat.hand.length} cards</span>
         )}
       </div>
+      {seat.statusText && (
+        <div className="text-xs text-white/60">{seat.statusText}</div>
+      )}
       {isHuman ? (
         // A single row, not `flex-wrap`: the fanned-overlap look below relies
         // on `first:ml-0` to zero out the leading card's negative margin, which
@@ -88,6 +100,14 @@ export function Seat({ seat, position, isHuman, isBidWinner, playable, hideOppon
               </button>
             )
           })}
+        </div>
+      ) : exposeCards ? (
+        <div className="flex justify-center gap-1 overflow-x-auto">
+          {sortHandForDisplay(seat.hand).map((card, i) => (
+            <div key={i} className="-ml-10 first:ml-0">
+              <PlayingCard suit={card.suit} rank={card.rank} className="w-[60px]" />
+            </div>
+          ))}
         </div>
       ) : hideOpponentHand ? null : (
         <div className="flex overflow-x-auto px-2">

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -1,8 +1,9 @@
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { Scoreboard } from './Scoreboard'
 import { Seat } from './Seat'
 import { seatPosition, type SeatPosition, type TableState } from './tableTypes'
 import { TrickArea } from './TrickArea'
+import { useDraggable } from './useDraggable'
 
 export interface TableProps {
   state: TableState
@@ -23,6 +24,13 @@ export interface TableProps {
    * screen space. UI-only preference, not game state, so it lives here
    * rather than on TableState. */
   hideOpponentCards?: boolean
+  /** 1-based trick number for display (e.g. "Trick 3 of 12"). Omitted outside
+   * trick-play so TrickArea doesn't show a counter during the auction/meld
+   * phases. */
+  trickNumber?: number
+  /** Meld phase: when true, non-human seats render their cards face-up (meld
+   * cards on the table) instead of face-down or hidden. */
+  exposeCards?: boolean
 }
 
 const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
@@ -38,7 +46,21 @@ const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
  * and trick-play controls (separate issues) will mount into this shell,
  * most likely inside/near the human seat and the TrickArea respectively.
  */
-export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards }: TableProps) {
+export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards, trickNumber, exposeCards }: TableProps) {
+  const { onMouseDown, onMouseMove, onMouseUp } = useDraggable()
+
+  useEffect(() => {
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+    document.addEventListener('touchmove', onMouseMove as EventListener, { passive: false })
+    document.addEventListener('touchend', onMouseUp)
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+      document.removeEventListener('touchmove', onMouseMove as EventListener)
+      document.removeEventListener('touchend', onMouseUp)
+    }
+  }, [onMouseMove, onMouseUp])
   const {
     seats,
     humanPlayer,
@@ -50,6 +72,7 @@ export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards 
     teamNames,
     humanPlayable,
     trickWinner,
+    meldPoints,
   } = state
   const bidWinnerSeat = bidWinner === null ? undefined : seats.find((seat) => seat.player === bidWinner)
 
@@ -71,6 +94,7 @@ export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards 
         currentBid={currentBid}
         bidWinnerName={bidWinnerSeat?.name}
         trumpSuit={trumpSuit}
+        meldPoints={meldPoints}
       />
       <div className="grid flex-1 grid-cols-[1fr_2fr_1fr] grid-rows-[1fr_2fr_1fr] items-center justify-items-center gap-4 p-4">
         {seats.map((seat) => (
@@ -83,18 +107,25 @@ export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards 
               position={seatPosition(seat.player, humanPlayer)}
               isHuman={seat.player === humanPlayer}
               isBidWinner={seat.player === bidWinner}
+              isDealer={seat.player === state.dealer}
               playable={seat.player === humanPlayer ? humanPlayable : undefined}
               hideOpponentHand={hideOpponentCards}
+              exposeCards={seat.player !== humanPlayer ? exposeCards : undefined}
             />
           </div>
         ))}
         <div className="col-start-2 row-start-2">
-          <TrickArea trick={trick} humanPlayer={humanPlayer} winningPlayer={trickWinner} />
+          <TrickArea trick={trick} humanPlayer={humanPlayer} winningPlayer={trickWinner} trickNumber={trickNumber} />
         </div>
       </div>
-      {logPanel && <div className="absolute top-16 right-2">{logPanel}</div>}
+      {logPanel && <div className="fixed top-16 right-2 z-30">{logPanel}</div>}
       {overlay && (
-        <div className="fixed inset-0 flex items-center justify-center bg-black/40 p-4">{overlay}</div>
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4" onMouseDown={onMouseDown} onTouchStart={onMouseDown}>
+          <div data-draggable className="inline-block cursor-grab">
+            {overlay}
+          </div>
+        </div>
       )}
     </div>
   )

--- a/web/src/components/TrickArea.tsx
+++ b/web/src/components/TrickArea.tsx
@@ -9,6 +9,9 @@ export interface TrickAreaProps {
    * while it settles, before TrickPlayFlow clears it for the next trick.
    * null/undefined outside that pause (nothing highlighted). */
   winningPlayer?: PlayerIndex | null
+  /** Trick counter display: e.g. 1-based trick number so "Trick 3 of 12"
+   * renders above the trick circle. Omitted outside trick-play. */
+  trickNumber?: number
 }
 
 const POSITION_CLASS: Record<SeatPosition, string> = {
@@ -24,9 +27,13 @@ const POSITION_CLASS: Record<SeatPosition, string> = {
  * until a seat has played, so a trick in progress shows 1-3 cards and a
  * completed-but-not-yet-cleared trick shows all 4.
  */
-export function TrickArea({ trick, humanPlayer, winningPlayer }: TrickAreaProps) {
+export function TrickArea({ trick, humanPlayer, winningPlayer, trickNumber }: TrickAreaProps) {
   return (
-    <div className="grid aspect-square w-full max-w-72 grid-cols-3 grid-rows-3 items-center justify-items-center rounded-full bg-green-950/40">
+    <div className="flex flex-col items-center gap-1">
+      {trickNumber !== undefined && (
+        <span className="text-xs font-semibold text-white/70">Trick {trickNumber} of 12</span>
+      )}
+      <div className="grid aspect-square w-72 max-w-full min-h-[12rem] grid-cols-3 grid-rows-3 items-center justify-items-center rounded-full bg-green-950/40">
       {trick.map((play) => (
         <div
           key={play.player}
@@ -37,6 +44,7 @@ export function TrickArea({ trick, humanPlayer, winningPlayer }: TrickAreaProps)
           <PlayingCard suit={play.card.suit} rank={play.card.rank} />
         </div>
       ))}
+    </div>
     </div>
   )
 }

--- a/web/src/components/TrickPlayFlow.test.tsx
+++ b/web/src/components/TrickPlayFlow.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Card, Deck, Suit } from '../engine/card'
 import type { Hands } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
+import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { AI_PLAY_DELAY_MS, TrickPlayFlow } from './TrickPlayFlow'
 import type { TrickPlayResult } from './trickPlayTypes'
 
@@ -33,10 +34,13 @@ describe('TrickPlayFlow (component)', () => {
         trumpSuit={Suit.Spades}
         bidWinner={1}
         bid={300}
+        meldPointsByTeam={{ 0: 0, 1: 0 }}
         seatNames={SEAT_NAMES}
         humanPlayer={0}
         scoresByTeam={SCORES}
+        dealer={0}
         onComplete={onComplete}
+        options={{ ...DEFAULT_OPTIONS, hideTrickLog: false } as GameOptions}
       />,
     )
 
@@ -82,9 +86,12 @@ describe('TrickPlayFlow (component)', () => {
         trumpSuit={Suit.Spades}
         bidWinner={1}
         bid={300}
+        meldPointsByTeam={{ 0: 0, 1: 0 }}
         seatNames={SEAT_NAMES}
         humanPlayer={0}
         scoresByTeam={SCORES}
+        dealer={0}
+        options={{ ...DEFAULT_OPTIONS, hideTrickLog: false } as GameOptions}
       />,
     )
 
@@ -118,10 +125,13 @@ describe('TrickPlayFlow (component)', () => {
         trumpSuit={Suit.Hearts}
         bidWinner={0}
         bid={300}
+        meldPointsByTeam={{ 0: 0, 1: 0 }}
         seatNames={SEAT_NAMES}
         humanPlayer={0}
         scoresByTeam={SCORES}
+        dealer={0}
         onComplete={onComplete}
+        options={{ ...DEFAULT_OPTIONS, hideTrickLog: false } as GameOptions}
       />,
     )
 

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useMemo, useReducer, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import type { Card, Suit } from '../engine/card'
-import type { Hands, TeamId } from '../engine/round'
+import { teamOf, type Hands, type TeamId } from '../engine/round'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from '../engine/tracker'
 import type { PlayerIndex } from '../engine/trick'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
 import type { TableState } from './tableTypes'
+import { AuctionLog } from './AuctionLog'
 import { TrickLog } from './TrickLog'
 import {
   buildTrick,
@@ -16,6 +17,7 @@ import {
   type TrickPlayState,
 } from './trickPlayReducer'
 import type { TrickPlayResult } from './trickPlayTypes'
+import type { AuctionLogEntry } from './auctionTypes'
 
 export interface TrickPlayFlowProps {
   hands: Hands
@@ -27,11 +29,21 @@ export interface TrickPlayFlowProps {
   seatNames: Record<PlayerIndex, string>
   humanPlayer: PlayerIndex
   scoresByTeam: Record<TeamId, number>
+  /** Meld points per team, computed during the meld phase, used to
+   * detect mathematically impossible contracts for the concede button. */
+  meldPointsByTeam: Record<TeamId, number>
+  /** Full auction/pass event log (#77), kept visible during trick-play so
+   * the human can review every bid, who bid, and the amounts. */
+  auctionLog?: readonly AuctionLogEntry[]
   /** Randomized per-game team display names (#73), threaded straight into
    * the TableState this component builds for Table/Scoreboard. Defaults to
    * scoreTypes.ts's DEFAULT_TEAM_NAMES ("Team A"/"Team B") when omitted —
    * GameFlow.tsx always supplies real per-game names in practice. */
   teamNames?: Record<TeamId, string>
+  /** Dealer seat (#76) — threaded through so the dealer badge shows on the
+   * table during trick-play too. AuctionFlow already tracks it; GameFlow
+   * passes it along. */
+  dealer: PlayerIndex
   /** Local autosave (#54): resume from a saved trick-play checkpoint
    * (GameFlowState.trickPlayCheckpoint) instead of dealing out `hands`
    * fresh via initTrickPlayState. Only ever set by GameFlow.tsx's "Continue"
@@ -83,10 +95,13 @@ export function TrickPlayFlow({
   trumpSuit,
   bidWinner,
   bid,
+  meldPointsByTeam,
+  auctionLog,
   seatNames,
   humanPlayer,
   scoresByTeam,
   teamNames = DEFAULT_TEAM_NAMES,
+  dealer,
   initialState,
   onCheckpoint,
   onOpenMenu,
@@ -115,9 +130,10 @@ export function TrickPlayFlow({
       const hand = state.hands[player]
       const trick = buildTrick(state.trumpSuit, state.currentTrick)
       const legal = trick.legalMoves(hand)
+      const isBidderFirstLead = state.trickNumber === 0 && player === state.bidWinner && state.currentTrick.length === 0
       const card =
         state.currentTrick.length === 0
-          ? chooseLeadCard(hand, state.trumpSuit, trackerRef.current)
+          ? chooseLeadCard(hand, state.trumpSuit, trackerRef.current, isBidderFirstLead)
           : chooseFollowCard(hand, legal, state.currentTrick, state.trumpSuit, teammatesOf(player), trackerRef.current)
       trackerRef.current.record(card)
       dispatch({ type: 'PLAY_CARD', player, card })
@@ -150,10 +166,23 @@ export function TrickPlayFlow({
     onCheckpoint?.(state)
   }, [state, onCheckpoint])
 
+  // Concede/fold (#83): show a fold button when the human won the bid, hide
+  // it after they play their first card or the hand ends.
+  const humanHasPlayedACard = state.log.some(
+    (e) => e.kind === 'card-play' && e.player === humanPlayer,
+  )
+  const canConcede = state.phase !== 'complete' && bidWinner === humanPlayer && !humanHasPlayedACard
+
   const legalMovesForHuman = useMemo(() => {
     if (state.phase !== 'playing' || state.turn !== humanPlayer) return null
     const trick = buildTrick(state.trumpSuit, state.currentTrick)
-    return trick.legalMoves(state.hands[humanPlayer])
+    let moves = trick.legalMoves(state.hands[humanPlayer])
+    // Bidder must lead trump on their first lead (#82)
+    if (state.trickNumber === 0 && state.turn === state.bidWinner && state.currentTrick.length === 0) {
+      const trumpCards = moves.filter((c) => c.suit === state.trumpSuit)
+      if (trumpCards.length > 0) moves = trumpCards
+    }
+    return moves
   }, [state, humanPlayer])
 
   const tableState: TableState = useMemo(() => {
@@ -179,16 +208,40 @@ export function TrickPlayFlow({
       scoresByTeam,
       teamNames,
       humanPlayable,
+      dealer,
+      meldPoints: meldPointsByTeam[teamOf(state.bidWinner)],
       trickWinner: state.phase === 'trick-complete' ? (state.trickWinners.at(-1) ?? null) : null,
     }
-  }, [state, seatNames, humanPlayer, bid, scoresByTeam, teamNames, legalMovesForHuman])
+  }, [state, seatNames, humanPlayer, bid, scoresByTeam, teamNames, meldPointsByTeam, legalMovesForHuman])
+
+  const handleConcede = useCallback(() => {
+    completedRef.current = true
+    onComplete?.({ trickPointsByTeam: state.trickPointsByTeam, trickWinners: state.trickWinners, conceded: true })
+  }, [state, onComplete])
 
   return (
-    <Table
-      state={tableState}
-      logPanel={<TrickLog entries={state.log} />}
-      onOpenMenu={onOpenMenu}
-      hideOpponentCards={options.hideOpponentCards}
-    />
+    <div className="relative">
+      {canConcede && (
+        <button
+          type="button"
+          onClick={handleConcede}
+          className="absolute top-2 right-2 z-20 rounded bg-red-800 px-3 py-1 text-xs font-semibold text-white hover:bg-red-900"
+        >
+          Concede
+        </button>
+      )}
+      <Table
+        state={tableState}
+        logPanel={
+          <div className="flex flex-col gap-2">
+            {auctionLog && auctionLog.length > 0 && <AuctionLog entries={auctionLog} />}
+            {!options.hideTrickLog && <TrickLog entries={state.log} />}
+          </div>
+        }
+        onOpenMenu={onOpenMenu}
+        hideOpponentCards={options.hideOpponentCards}
+        trickNumber={state.trickNumber + 1}
+      />
+    </div>
   )
 }

--- a/web/src/components/auctionReducer.ts
+++ b/web/src/components/auctionReducer.ts
@@ -1,20 +1,6 @@
-// Auction/pass state machine backing AuctionFlow.tsx (#34). Split into its
-// own module (rather than living in AuctionFlow.tsx) so the component file
-// only exports the component — oxlint's react/only-export-components rule
-// flags mixed component+logic exports since it breaks fast refresh.
-//
-// Mirrors pinochle_engine.py's Round._bidding_loop / _passing_phase (frozen
-// Python reference; see round.ts's module docstring — the TS engine
-// doesn't reimplement bidding/passing itself, so this is UI-layer state,
-// not engine state). Turn order rotates clockwise from left of dealer; a
-// player who passes is out for the rest of the auction; the auction ends
-// after 3 passes, or the moment only one active bidder is left once
-// someone has actually bid. If nobody ever bids, the dealer is forced to
-// take it at FORCED_BID (card.ts).
-
 import type { BidRecord } from '../engine/bidding'
 import { FORCED_BID, type Card, type Suit } from '../engine/card'
-import type { Hands, TeamId } from '../engine/round'
+import { partnerOf, type Hands, type TeamId } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
 import type { AuctionLogEntry } from './auctionTypes'
 
@@ -26,16 +12,24 @@ interface BiddingSubstate {
   readonly passes: number
   readonly bidWinner: PlayerIndex | null
   readonly lastBidder: PlayerIndex | null
-  /** Every bid placed this auction, in order — feeds chooseBid's AuctionContext. */
   readonly bidHistory: readonly BidRecord[]
 }
 
 export type AuctionPhase =
   | 'bidding'
   | 'trump'
-  | 'passing-partner-to-bidder'
-  | 'passing-bidder-to-partner'
+  | 'passing'
+  | 'pass-reveal'
   | 'complete'
+
+/** Tracks the 3-card pass state for simultaneous exchange (#80). Both
+ * players choose their cards independently; once both have chosen, the
+ * cards move atomically so neither sees what they will receive before
+ * committing their own selection. */
+interface PassingSubstate {
+  readonly fromBidderCards: readonly Card[] | null
+  readonly fromPartnerCards: readonly Card[] | null
+}
 
 export interface AuctionState {
   readonly hands: Hands
@@ -47,6 +41,7 @@ export interface AuctionState {
   readonly bid: number
   readonly trumpSuit: Suit | null
   readonly phase: AuctionPhase
+  readonly passing: PassingSubstate
   readonly log: readonly AuctionLogEntry[]
 }
 
@@ -54,7 +49,8 @@ export type AuctionAction =
   | { readonly type: 'BID'; readonly player: PlayerIndex; readonly amount: number }
   | { readonly type: 'PASS_BID'; readonly player: PlayerIndex }
   | { readonly type: 'CHOOSE_TRUMP'; readonly player: PlayerIndex; readonly suit: Suit }
-  | { readonly type: 'PASS_CARDS'; readonly from: PlayerIndex; readonly to: PlayerIndex; readonly cards: readonly Card[] }
+  | { readonly type: 'PASS_CARDS'; readonly from: PlayerIndex; readonly cards: readonly Card[] }
+  | { readonly type: 'CONFIRM_PASS_REVEAL' }
 
 export function initAuctionState(
   hands: Hands,
@@ -81,6 +77,7 @@ export function initAuctionState(
     bid: 0,
     trumpSuit: null,
     phase: 'bidding',
+    passing: { fromBidderCards: null, fromPartnerCards: null },
     log: [],
   }
 }
@@ -89,7 +86,6 @@ function isBiddingOver(b: BiddingSubstate): boolean {
   return b.passes >= 3 || (b.everBid && b.active.filter(Boolean).length === 1)
 }
 
-/** Next active seat starting from (and including) `from`, wrapping clockwise. */
 function nextActiveTurn(active: readonly boolean[], from: PlayerIndex): PlayerIndex {
   let idx = from
   for (let i = 0; i < 4; i++) {
@@ -99,10 +95,6 @@ function nextActiveTurn(active: readonly boolean[], from: PlayerIndex): PlayerIn
   return from
 }
 
-/** After a BID/PASS_BID updates `bidding`, checks whether the auction is
- * over and, if so, finalizes the contract (including the forced-bid
- * fallback) and advances to the trump phase; otherwise just hands the
- * turn to the next active seat. */
 function resolveBiddingOutcome(state: AuctionState): AuctionState {
   const { bidding } = state
   if (!isBiddingOver(bidding)) {
@@ -119,16 +111,6 @@ function resolveBiddingOutcome(state: AuctionState): AuctionState {
   return { ...state, phase: 'trump', bidWinner: state.dealer, bid: FORCED_BID, log }
 }
 
-// BID/PASS_BID both require action.player === state.bidding.turn (unlike
-// CHOOSE_TRUMP/PASS_CARDS below, which are adequately guarded by their
-// phase check alone, since only one player can ever act in those phases at
-// a time). Bidding cycles through several players within the same
-// 'bidding' phase, so a phase-only guard would let a stale/duplicate
-// dispatch for a player who isn't up re-apply itself once turn has already
-// moved on — e.g. React StrictMode's dev-mode double effect invocation
-// firing an AI seat's decision twice on mount, which without this guard
-// double-counted that seat's pass and logged it twice. Mirrors
-// trickPlayReducer.ts's PLAY_CARD guard (`action.player !== state.turn`).
 export function auctionReducer(state: AuctionState, action: AuctionAction): AuctionState {
   switch (action.type) {
     case 'BID': {
@@ -170,30 +152,37 @@ export function auctionReducer(state: AuctionState, action: AuctionAction): Auct
         ...state.log,
         { kind: 'trump', player, name: state.seatNames[player], suit },
       ]
-      return { ...state, trumpSuit: suit, phase: 'passing-partner-to-bidder', log }
+      return { ...state, trumpSuit: suit, phase: 'passing', passing: { fromBidderCards: null, fromPartnerCards: null }, log }
     }
     case 'PASS_CARDS': {
-      if (state.phase !== 'passing-partner-to-bidder' && state.phase !== 'passing-bidder-to-partner') return state
-      const { from, to, cards } = action
-      const hands = state.hands.map((h, i) => {
-        if (i === from) return h.filter((c) => !cards.includes(c))
-        if (i === to) return [...h, ...cards]
-        return h
-      }) as Hands
-      const log: AuctionLogEntry[] = [
-        ...state.log,
-        {
-          kind: 'card-pass',
-          fromPlayer: from,
-          fromName: state.seatNames[from],
-          toPlayer: to,
-          toName: state.seatNames[to],
-          count: cards.length,
-        },
-      ]
-      const nextPhase: AuctionPhase =
-        state.phase === 'passing-partner-to-bidder' ? 'passing-bidder-to-partner' : 'complete'
-      return { ...state, hands, log, phase: nextPhase }
+      if (state.phase !== 'passing' || state.bidWinner === null) return state
+      const { from, cards } = action
+      const isBidder = from === state.bidWinner
+      const fromBidderCards = isBidder ? cards : state.passing.fromBidderCards
+      const fromPartnerCards = isBidder ? state.passing.fromPartnerCards : cards
+      const passing: PassingSubstate = { fromBidderCards, fromPartnerCards }
+
+      if (fromBidderCards !== null && fromPartnerCards !== null) {
+        const bidder = state.bidWinner
+        const partner = partnerOf(bidder)
+        const hands = state.hands.map((h, i) => {
+          if (i === bidder) return [...h.filter((c) => !fromBidderCards.includes(c)), ...fromPartnerCards]
+          if (i === partner) return [...h.filter((c) => !fromPartnerCards.includes(c)), ...fromBidderCards]
+          return h
+        }) as Hands
+        const log: AuctionLogEntry[] = [
+          ...state.log,
+          { kind: 'card-pass', fromPlayer: partner, fromName: state.seatNames[partner], toPlayer: bidder, toName: state.seatNames[bidder], count: fromPartnerCards.length },
+          { kind: 'card-pass', fromPlayer: bidder, fromName: state.seatNames[bidder], toPlayer: partner, toName: state.seatNames[partner], count: fromBidderCards.length },
+        ]
+        return { ...state, hands, passing, log, phase: 'pass-reveal' }
+      }
+
+      return { ...state, passing, log: state.log }
+    }
+    case 'CONFIRM_PASS_REVEAL': {
+      if (state.phase !== 'pass-reveal') return state
+      return { ...state, phase: 'complete' }
     }
     default:
       return state

--- a/web/src/components/auctionTypes.ts
+++ b/web/src/components/auctionTypes.ts
@@ -60,13 +60,17 @@ export function formatAuctionLogEntry(entry: AuctionLogEntry): string {
 }
 
 /** Everything a live Round orchestrator needs once the auction and pass
- * phases finish: the post-pass hands, the agreed contract, and who holds
- * it — the inputs `playTrickTakingPhase` (round.ts) expects. */
+ * phases finish: the post-pass hands, the agreed contract, who holds
+ * it, and the full event log — the inputs `playTrickTakingPhase` (round.ts)
+ * expects, plus the auction history for display during later phases. */
 export interface AuctionResult {
   readonly hands: readonly [readonly Card[], readonly Card[], readonly Card[], readonly Card[]]
   readonly trumpSuit: Suit
   readonly bidWinner: PlayerIndex
   readonly bid: number
+  /** Full auction/pass event log, kept visible during meld and trick-play
+   * so the human can review every bid, who bid, and the amounts (#77). */
+  readonly log: readonly AuctionLogEntry[]
 }
 
 /** Fixed team pairing, matches round.ts's `teamOf`. */

--- a/web/src/components/gameFlowReducer.test.ts
+++ b/web/src/components/gameFlowReducer.test.ts
@@ -84,18 +84,36 @@ describe('gameFlowReducer', () => {
   })
 
   describe('AUCTION_COMPLETE', () => {
-    it('stores the auction result and moves to trick-play', () => {
+    it('stores the auction result and moves to the meld phase', () => {
       const state = { ...initGameFlowState(3), phase: 'auction' as const }
-      const result: AuctionResult = { hands: emptyHands(), trumpSuit: Suit.Hearts, bidWinner: 0, bid: 300 }
+      const result: AuctionResult = { hands: emptyHands(), trumpSuit: Suit.Hearts, bidWinner: 0, bid: 300, log: [] }
       const next = gameFlowReducer(state, { type: 'AUCTION_COMPLETE', result })
-      expect(next.phase).toBe('trick-play')
+      expect(next.phase).toBe('meld')
       expect(next.auctionResult).toBe(result)
     })
 
     it('is ignored outside the auction phase', () => {
       const state = initGameFlowState(3)
-      const result: AuctionResult = { hands: emptyHands(), trumpSuit: Suit.Hearts, bidWinner: 0, bid: 300 }
+      const result: AuctionResult = { hands: emptyHands(), trumpSuit: Suit.Hearts, bidWinner: 0, bid: 300, log: [] }
       expect(gameFlowReducer(state, { type: 'AUCTION_COMPLETE', result })).toBe(state)
+    })
+  })
+
+  describe('MELD_COMPLETE', () => {
+    it('stores meld points and moves to trick-play', () => {
+      const state: GameFlowState = {
+        ...initGameFlowState(3),
+        phase: 'meld',
+        auctionResult: { hands: emptyHands(), trumpSuit: Suit.Hearts, bidWinner: 0, bid: 300, log: [] },
+      }
+      const next = gameFlowReducer(state, { type: 'MELD_COMPLETE', meldPointsByTeam: { 0: 190, 1: 0 } })
+      expect(next.phase).toBe('trick-play')
+      expect(next.meldPointsByTeam).toEqual({ 0: 190, 1: 0 })
+    })
+
+    it('is ignored outside the meld phase', () => {
+      const state = initGameFlowState(3)
+      expect(gameFlowReducer(state, { type: 'MELD_COMPLETE', meldPointsByTeam: { 0: 0, 1: 0 } })).toBe(state)
     })
   })
 
@@ -113,7 +131,7 @@ describe('gameFlowReducer', () => {
         new Card(Suit.Hearts, 'J', 1),
       ]
       hands[1] = [new Card(Suit.Spades, '9', 1)]
-      const result: AuctionResult = { hands, trumpSuit: Suit.Hearts, bidWinner: 0, bid: 300, ...overrides }
+      const result: AuctionResult = { hands, trumpSuit: Suit.Hearts, bidWinner: 0, bid: 300, log: [], ...overrides }
       return {
         ...initGameFlowState(3),
         phase: 'trick-play',

--- a/web/src/components/gameFlowReducer.ts
+++ b/web/src/components/gameFlowReducer.ts
@@ -30,6 +30,7 @@ export type GameFlowPhase =
   | 'dealing'
   | 'misdeal-check'
   | 'auction'
+  | 'meld'
   | 'trick-play'
   | 'round-summary'
   | 'game-over'
@@ -45,6 +46,9 @@ export interface GameFlowState {
    * over `self.players` in fixed seat order. */
   readonly misdealCheckIndex: number
   readonly auctionResult: AuctionResult | null
+  /** Meld points per team, computed during the meld phase and carried into
+   * trick-play scoring. null until the meld phase completes. */
+  readonly meldPointsByTeam: Record<TeamId, number> | null
   readonly roundSummary: RoundSummaryData | null
   readonly gameOverData: GameOverData | null
   /** Local autosave (#54): a snapshot of TrickPlayFlow's internal state,
@@ -73,6 +77,7 @@ export type GameFlowAction =
   | { readonly type: 'MISDEAL_ADVANCE' }
   | { readonly type: 'MISDEAL_RESHUFFLE' }
   | { readonly type: 'AUCTION_COMPLETE'; readonly result: AuctionResult }
+  | { readonly type: 'MELD_COMPLETE'; readonly meldPointsByTeam: Record<TeamId, number> }
   | { readonly type: 'TRICK_COMPLETE'; readonly result: TrickPlayResult }
   | { readonly type: 'CONTINUE_ROUND' }
   | { readonly type: 'NEW_GAME'; readonly dealer: PlayerIndex }
@@ -91,6 +96,13 @@ export type GameFlowAction =
 // component+value exports since it breaks fast refresh (same reason these
 // don't live in AuctionFlow.tsx/TrickPlayFlow.tsx either).
 export const HUMAN_PLAYER: PlayerIndex = 0
+/** Random first dealer so each game starts with a different player shuffling.
+ * Seeded off Math.random — not cryptographically random, but good enough to
+ * avoid the same player always dealing first. */
+export function randomDealer(): PlayerIndex {
+  return Math.floor(Math.random() * 4) as PlayerIndex
+}
+
 export const INITIAL_DEALER: PlayerIndex = 3
 
 const TEAM_IDS: readonly TeamId[] = [0, 1]
@@ -117,6 +129,7 @@ export function initGameFlowState(dealer: PlayerIndex): GameFlowState {
     scoresByTeam: { 0: 0, 1: 0 },
     misdealCheckIndex: 0,
     auctionResult: null,
+    meldPointsByTeam: null,
     roundSummary: null,
     gameOverData: null,
     trickPlayCheckpoint: null,
@@ -128,7 +141,7 @@ export function initGameFlowState(dealer: PlayerIndex): GameFlowState {
 /** Melds each hand (post-pass, pre-trick, i.e. still the full 12 cards)
  * under trump, summed per team — the missing ingredient (alongside
  * TrickPlayResult's trick points) `scoreRound` needs. */
-function meldPointsByTeam(
+export function meldPointsByTeam(
   hands: AuctionResult['hands'],
   trumpSuit: AuctionResult['trumpSuit'],
 ): Record<TeamId, number> {
@@ -150,6 +163,7 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         misdealCheckIndex: 0,
         phase: 'misdeal-check',
         auctionResult: null,
+        meldPointsByTeam: null,
         roundSummary: null,
         trickPlayCheckpoint: null,
       }
@@ -168,20 +182,29 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
     }
     case 'AUCTION_COMPLETE': {
       if (state.phase !== 'auction') return state
-      // trickPlayCheckpoint is cleared (not carried over) here: this is a
-      // genuinely fresh trick-play phase driven by a real auction just
-      // finishing, not a resume-from-save — TrickPlayFlow.tsx will mount
-      // and re-checkpoint at trick 0 on its own once it does.
-      return { ...state, phase: 'trick-play', auctionResult: action.result, trickPlayCheckpoint: null }
+      return { ...state, phase: 'meld', auctionResult: action.result, trickPlayCheckpoint: null }
+    }
+    case 'MELD_COMPLETE': {
+      if (state.phase !== 'meld' || state.auctionResult === null) return state
+      return {
+        ...state,
+        phase: 'trick-play',
+        meldPointsByTeam: action.meldPointsByTeam,
+      }
     }
     case 'TRICK_COMPLETE': {
       if (state.phase !== 'trick-play' || state.auctionResult === null) return state
-      const { hands, trumpSuit, bidWinner, bid } = state.auctionResult
-      const meldPoints = meldPointsByTeam(hands, trumpSuit)
+      const { bidWinner, bid } = state.auctionResult
+      const meldPoints = state.meldPointsByTeam ?? meldPointsByTeam(state.auctionResult.hands, state.auctionResult.trumpSuit)
+      // When the bidding team concedes/folds, they forfeit their meld and
+      // lose the bid; opponents keep their meld but get no trick points.
+      const adjustedMeld = action.result.conceded
+        ? { ...meldPoints, [teamOf(bidWinner)]: 0 }
+        : meldPoints
       const bidWinnerTeam = teamOf(bidWinner)
       const roundScoreByTeam = scoreRound({
-        meldPointsByTeam: meldPoints,
-        trickPointsByTeam: action.result.trickPointsByTeam,
+        meldPointsByTeam: adjustedMeld,
+        trickPointsByTeam: action.result.conceded ? { 0: 0, 1: 0 } as Record<TeamId, number> : action.result.trickPointsByTeam,
         bidWinnerTeam,
         bid,
       })
@@ -221,6 +244,7 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         phase: 'dealing',
         dealer: ((state.dealer + 1) % 4) as PlayerIndex,
         auctionResult: null,
+        meldPointsByTeam: null,
         roundSummary: null,
       }
     }
@@ -231,11 +255,10 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         dealer: action.dealer,
         scoresByTeam: { 0: 0, 1: 0 },
         auctionResult: null,
+        meldPointsByTeam: null,
         roundSummary: null,
         gameOverData: null,
         trickPlayCheckpoint: null,
-        // Fresh names per new game (#73) — a brand new game, not a resume,
-        // so opponents/teams should be redrawn rather than carried over.
         seatNames: randomSeatNames(),
         teamNames: randomTeamNames(),
       }

--- a/web/src/components/tableTypes.ts
+++ b/web/src/components/tableTypes.ts
@@ -16,6 +16,9 @@ export interface SeatState {
   readonly player: PlayerIndex
   readonly name: string
   readonly hand: readonly Card[]
+  /** Auction-phase status shown under the player name:
+   * "Pass", "(300)", "(Waiting)" etc. */
+  readonly statusText?: string
 }
 
 export interface TableState {
@@ -42,6 +45,13 @@ export interface TableState {
    * TrickArea while it settles before being cleared for the next trick.
    * null/undefined outside that settle pause. */
   readonly trickWinner?: PlayerIndex | null
+  /** Which seat is the dealer (#76) — shown during the auction phase so the
+   * human knows who has the last bid. Optional because some callers (e.g.
+   * TrickPlayFlow) don't track it. */
+  readonly dealer?: PlayerIndex
+  /** Meld points of the bidding team, shown in the header after meld
+   * declaration. Only meaningful during trick-play; omitted before that. */
+  readonly meldPoints?: number
 }
 
 /** Table position, independent of PlayerIndex — the human seat is always

--- a/web/src/components/trickPlayTypes.ts
+++ b/web/src/components/trickPlayTypes.ts
@@ -55,4 +55,7 @@ export function formatTrickPlayLogEntry(entry: TrickPlayLogEntry): string {
 export interface TrickPlayResult {
   readonly trickPointsByTeam: Record<TeamId, number>
   readonly trickWinners: readonly PlayerIndex[]
+  /** True when the bidding team conceded/folded. The bidding team's meld
+   * is forfeited (they score -bid) and opponents get meld but no tricks. */
+  readonly conceded?: boolean
 }

--- a/web/src/components/useDraggable.ts
+++ b/web/src/components/useDraggable.ts
@@ -1,0 +1,42 @@
+import { useCallback, useRef } from 'react'
+
+export function useDraggable() {
+  const posRef = useRef({ x: 0, y: 0, startX: 0, startY: 0, el: null as HTMLElement | null })
+  const dragging = useRef(false)
+
+  const onMouseDown = useCallback((e: React.MouseEvent | React.TouchEvent) => {
+    const el = (e.target as HTMLElement).closest('[data-draggable]') as HTMLElement | null
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX
+    const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY
+    posRef.current = { x: rect.left, y: rect.top, startX: clientX, startY: clientY, el }
+    dragging.current = true
+    el.style.cursor = 'grabbing'
+    el.style.transition = 'none'
+  }, [])
+
+  const onMouseMove = useCallback((e: MouseEvent | TouchEvent) => {
+    if (!dragging.current || !posRef.current.el) return
+    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX
+    const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY
+    const dx = clientX - posRef.current.startX
+    const dy = clientY - posRef.current.startY
+    posRef.current.el.style.transform = `translate(${posRef.current.x + dx}px, ${posRef.current.y + dy}px)`
+    posRef.current.el.style.position = 'fixed'
+    posRef.current.el.style.left = '0'
+    posRef.current.el.style.top = '0'
+    posRef.current.el.style.margin = '0'
+  }, [])
+
+  const onMouseUp = useCallback(() => {
+    if (!dragging.current) return
+    dragging.current = false
+    if (posRef.current.el) {
+      posRef.current.el.style.cursor = ''
+      posRef.current.el.style.transition = ''
+    }
+  }, [])
+
+  return { onMouseDown, onMouseMove, onMouseUp }
+}

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -72,7 +72,7 @@ describe('computeBaseBid', () => {
       new Card(Suit.Diamonds, 'J', 1),
     ]
     const { breakdown } = computeBaseBid(hand, Suit.Hearts)
-    expect(breakdown['Pinochle/near-double']).toBe(225)
+    expect(breakdown['Pinochle/near-double']).toBe(60)
   })
 
   it('always includes the flat Aces line even at zero', () => {
@@ -212,6 +212,7 @@ describe('chooseBid', () => {
     bidHistory: [],
     dealer: 2,
     scores: { 0: 0, 1: 0 },
+    passedPlayers: [],
     ...overrides,
   })
 
@@ -238,8 +239,10 @@ describe('chooseBid', () => {
       expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context)).toBe(OPENING_BID)
     })
 
-    it('passes when the ceiling does not clear OPENER_THRESHOLD', () => {
-      const context = baseContext({ dealer: 1 })
+    it('passes when the ceiling does not clear OPENER_THRESHOLD and partner has already had a turn', () => {
+      // 4th bidder (passesSoFar=3, dealer): partner (player 2) has already had
+      // their turn, so the "partner hasn't bid" rule doesn't apply.
+      const context = baseContext({ dealer: 0, passesSoFar: 3 })
       expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context)).toBeNull()
     })
 
@@ -249,8 +252,10 @@ describe('chooseBid', () => {
       expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBe(OPENING_BID)
     })
 
-    it('does not trigger dealer-protection when the opponent score is not under 500', () => {
-      const context = baseContext({ dealer: 2, scores: { 0: 850, 1: 500 } })
+    it('passes for a weak-handed 4th bidder when partner has already had a turn', () => {
+      // 4th bidder (passesSoFar=3, dealer=player): partner has had a turn,
+      // and the weak hand's ceiling (130) doesn't clear OPENER_THRESHOLD.
+      const context = baseContext({ dealer: 0, passesSoFar: 3, scores: { 0: 850, 1: 500 } })
       expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBeNull()
     })
 

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -32,8 +32,8 @@ import type { PlayerIndex } from './trick'
 // near-double-pinochle, remaining-card trick-taking potential, partner
 // estimate), not the actual guaranteed meld. ------------------------------
 
-export const NEAR_RUN_VALUE = 120
-export const NEAR_DOUBLE_PINOCHLE_VALUE = 225
+export const NEAR_RUN_VALUE = 60
+export const NEAR_DOUBLE_PINOCHLE_VALUE = 60
 export const ACE_VALUE = 20
 // Proficient AI draws randomly in this range each bid (partner-strength
 // estimate). Not consumed by the pure valuation functions below — ported
@@ -329,6 +329,10 @@ export interface AuctionContext {
   readonly dealer: PlayerIndex
   /** Cumulative game score per team, going into this round. */
   readonly scores: Record<TeamId, number>
+  /** Players who have passed so far this auction. Used to detect when a
+   * partner has passed so the remaining bidder knows to raise the floor to
+   * 320. */
+  readonly passedPlayers: readonly PlayerIndex[]
 }
 
 /**
@@ -378,24 +382,36 @@ export function chooseBid(
   const ceiling = cap === null ? baseBid : Math.min(baseBid, cap)
 
   const partner = partnerOf(player)
-  const partnerIsDealer = partner === context.dealer
+  const partnerPassed = context.passedPlayers.includes(partner)
+
+  // Raise the floor to 320 when partner has already passed this auction
+  // (they declined to bid, so the remaining bidder must cover the gap).
+  const effectiveCeiling = partnerPassed ? Math.max(321, ceiling) : ceiling
+  // The minimum bid amount when partner passed: at least 321 (strictly > 320).
+  const minBidAfterPartnerPass = Math.max(321, currentBid + minIncrement)
 
   if (!context.everBid) {
-    // Dealer-protection.
-    if (partnerIsDealer && myScore >= 850 && oppScore < 500) {
+    // If partner hasn't had their turn yet (first two bidders), always open
+    // to protect against the auction passing out cheaply.
+    if (context.passesSoFar < 2) {
       return OPENING_BID
     }
 
     // 3rd bidder opens cheap.
     if (context.passesSoFar === 2) {
       if (myScore > 800) {
-        return ceiling >= OPENER_THRESHOLD ? OPENING_BID : null
+        return (partnerPassed ? ceiling > 320 : effectiveCeiling >= OPENER_THRESHOLD)
+          ? (partnerPassed ? minBidAfterPartnerPass : OPENING_BID)
+          : null
       }
-      return OPENING_BID
+      return partnerPassed ? (ceiling > 320 ? minBidAfterPartnerPass : null) : OPENING_BID
     }
 
-    // Normal opener threshold.
-    return ceiling >= OPENER_THRESHOLD ? OPENING_BID : null
+    // Normal opener threshold (4th bidder / dealer — partner has already
+    // had their turn, so no pass-out protection needed).
+    return (partnerPassed ? ceiling > 320 : effectiveCeiling >= OPENER_THRESHOLD)
+      ? (partnerPassed ? minBidAfterPartnerPass : OPENING_BID)
+      : null
   }
 
   // Someone has already bid this auction.
@@ -410,7 +426,7 @@ export function chooseBid(
 
     if (lastBidder === partner && myOwnBids.length > 0 && currentBid > myOwnBids[myOwnBids.length - 1]) {
       // partner raised over my own earlier bid
-      return ceiling < 340 ? null : currentBid + minIncrement
+      return effectiveCeiling < 340 ? null : currentBid + minIncrement
     }
 
     return null // our own bid already stands, no need to raise ourselves
@@ -418,13 +434,15 @@ export function chooseBid(
 
   // Opponent currently holds the bid.
   const partnerHasBid = context.bidHistory.some((b) => b.player === partner)
-  let effectiveCeiling = partnerHasBid ? Math.max(ceiling, 330) : ceiling
+  let competitiveCeiling = partnerHasBid ? Math.max(effectiveCeiling, 330) : effectiveCeiling
   if (cap !== null) {
-    effectiveCeiling = Math.min(effectiveCeiling, cap)
+    competitiveCeiling = Math.min(competitiveCeiling, cap)
   }
 
   const nextBid = currentBid + minIncrement
-  return nextBid <= effectiveCeiling ? nextBid : null
+  // When partner passed, the bid must be at least 320 regardless of ceiling.
+  if (partnerPassed && nextBid < 321) return competitiveCeiling >= 321 ? 321 : null
+  return nextBid <= competitiveCeiling ? nextBid : null
 }
 
 /**

--- a/web/src/engine/melds.ts
+++ b/web/src/engine/melds.ts
@@ -34,6 +34,16 @@ export interface MeldResult {
   breakdown: Record<string, number>
 }
 
+function countByKey(hand: readonly Card[]): Map<string, Card[]> {
+  const m = new Map<string, Card[]>()
+  for (const card of hand) {
+    const key = `${card.suit}${card.rank}`
+    if (!m.has(key)) m.set(key, [])
+    m.get(key)!.push(card)
+  }
+  return m
+}
+
 export function scoreMelds(hand: readonly Card[], trumpSuit: Suit): MeldResult {
   const counts = new Map<string, number>()
   for (const card of hand) {
@@ -97,4 +107,133 @@ export function scoreMelds(hand: readonly Card[], trumpSuit: Suit): MeldResult {
 
   const total = Object.values(breakdown).reduce((sum, v) => sum + v, 0)
   return { total, breakdown }
+}
+
+export interface MeldCardsResult {
+  /** Every card that contributes to at least one meld group (deduplicated). */
+  meldCards: Card[]
+  /** Per-group breakdown with the actual cards. A card may appear in multiple groups. */
+  groups: { name: string; points: number; cards: Card[] }[]
+}
+
+/**
+ * Extract the specific cards that form melds in a hand. Used during the
+ * meld-declaration phase to show opponent meld cards face-up on the table.
+ *
+ * In real pinochle, the same card can be used in multiple *different* meld
+ * types simultaneously (e.g. Q♠ counts toward Pinochle, Queens Around, and
+ * a Royal Marriage if spades is trump). The only conflict is Run vs Royal
+ * Marriage in the trump suit — the Run takes precedence since it scores higher.
+ *
+ * This detection therefore does NOT remove cards from a pool as it goes;
+ * instead, each meld type is detected independently, and the same Card object
+ * may appear in several groups' card lists. The returned `meldCards` array
+ * deduplicates across all groups so the table display shows each card once.
+ */
+export function extractMeldCards(hand: readonly Card[], trumpSuit: Suit): MeldCardsResult {
+  const byKey = countByKey(hand)
+  const n = (suit: Suit, rank: Rank) => byKey.get(`${suit}${rank}`)?.length ?? 0
+  const cardAt = (suit: Suit, rank: Rank, index: number): Card | undefined =>
+    byKey.get(`${suit}${rank}`)?.[index]
+
+  const groups: { name: string; points: number; cards: Card[] }[] = []
+  const allCards = new Set<Card>()
+
+  // -- Run / Double Run (trump only) --
+  const runCount = Math.min(...RUN_RANKS.map((r) => n(trumpSuit, r)))
+  let trumpKRunCount = 0
+  let trumpQRunCount = 0
+  if (runCount >= 2) {
+    const cards = RUN_RANKS.flatMap((r) => {
+      const arr = byKey.get(`${trumpSuit}${r}`) ?? []
+      return arr.slice(0, 2)
+    })
+    groups.push({ name: 'Double Run', points: DOUBLE_RUN_VALUE, cards })
+    cards.forEach((c) => allCards.add(c))
+    trumpKRunCount = 2
+    trumpQRunCount = 2
+  } else if (runCount === 1) {
+    const cards = RUN_RANKS.flatMap((r) => {
+      const arr = byKey.get(`${trumpSuit}${r}`) ?? []
+      return arr.slice(0, 1)
+    })
+    groups.push({ name: 'Run', points: RUN_VALUE, cards })
+    cards.forEach((c) => allCards.add(c))
+    trumpKRunCount = 1
+    trumpQRunCount = 1
+  }
+
+  // -- Royal Marriage (skip K/Q pairs already counted in the Run) --
+  const royalK = n(trumpSuit, 'K')
+  const royalQ = n(trumpSuit, 'Q')
+  const royalCount = Math.min(royalK - trumpKRunCount, royalQ - trumpQRunCount)
+  for (let i = 0; i < royalCount; i++) {
+    const k = cardAt(trumpSuit, 'K', trumpKRunCount + i)
+    const q = cardAt(trumpSuit, 'Q', trumpQRunCount + i)
+    const cards = [k!, q!]
+    groups.push({ name: 'Royal Marriage', points: ROYAL_MARRIAGE_VALUE, cards })
+    cards.forEach((c) => allCards.add(c))
+  }
+
+  // -- Common Marriage (non-trump suits) --
+  for (const suit of SUITS) {
+    if (suit === trumpSuit) continue
+    const cm = Math.min(n(suit, 'K'), n(suit, 'Q'))
+    for (let i = 0; i < cm; i++) {
+      const k = cardAt(suit, 'K', i)
+      const q = cardAt(suit, 'Q', i)
+      const cards = [k!, q!]
+      groups.push({ name: `Common Marriage (${suit})`, points: COMMON_MARRIAGE_VALUE, cards })
+      cards.forEach((c) => allCards.add(c))
+    }
+  }
+
+  // -- Dix --
+  const dixCount = n(trumpSuit, '9')
+  for (let i = 0; i < dixCount; i++) {
+    const d = cardAt(trumpSuit, '9', i)!
+    groups.push({ name: 'Dix', points: DIX_VALUE, cards: [d] })
+    allCards.add(d)
+  }
+
+  // -- Pinochle / Double Pinochle --
+  const qs = n(Suit.Spades, 'Q')
+  const jd = n(Suit.Diamonds, 'J')
+  const pinCount = Math.min(qs, jd)
+  if (pinCount >= 2) {
+    const cards = [
+      cardAt(Suit.Spades, 'Q', 0)!,
+      cardAt(Suit.Spades, 'Q', 1)!,
+      cardAt(Suit.Diamonds, 'J', 0)!,
+      cardAt(Suit.Diamonds, 'J', 1)!,
+    ]
+    groups.push({ name: 'Double Pinochle', points: PINOCHLE_DOUBLE_VALUE, cards })
+    cards.forEach((c) => allCards.add(c))
+  } else if (pinCount === 1) {
+    const cards = [cardAt(Suit.Spades, 'Q', 0)!, cardAt(Suit.Diamonds, 'J', 0)!]
+    groups.push({ name: 'Pinochle', points: PINOCHLE_SINGLE_VALUE, cards })
+    cards.forEach((c) => allCards.add(c))
+  }
+
+  // -- Arounds --
+  for (const [rank, baseValue] of Object.entries(AROUND_VALUES) as ['A' | 'K' | 'Q' | 'J', number][]) {
+    const ac = Math.min(...SUITS.map((s) => n(s, rank)))
+    if (ac >= 2) {
+      const cards: Card[] = []
+      for (const s of SUITS) {
+        for (let i = 0; i < 2; i++) cards.push(cardAt(s, rank, i)!)
+      }
+      groups.push({ name: `${rank}s Around (double)`, points: baseValue * AROUND_DOUBLE_MULTIPLIER, cards })
+      cards.forEach((c) => allCards.add(c))
+    } else if (ac === 1) {
+      const cards: Card[] = []
+      for (const s of SUITS) {
+        cards.push(cardAt(s, rank, 0)!)
+      }
+      groups.push({ name: `${rank}s Around`, points: baseValue, cards })
+      cards.forEach((c) => allCards.add(c))
+    }
+  }
+
+  return { meldCards: [...allCards], groups }
 }

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -69,13 +69,29 @@ function isUnsecuredAce(card: Card, hand: readonly Card[], tracker: PlayTracker)
 
 /**
  * Choose what to lead when you have control. Priority:
+ *   0. Bidder's first lead (#82) — must lead trump if any is held
  *   1. Unsecured trump Ace
  *   2. Other unsecured Aces (longest suit first)
  *   3. Safe cards, cascading top-down by rank (longest suit first within a rank)
  *   4. Junk lead (non-point, non-trump) to surrender - shortest suit first
  *   5. Non-point trump as a last resort before giving up a point card
+ *
+ * @param isBidderFirstLead - When true (bidder opening the first trick of the
+ *   round), forces a trump lead if the player has any trump cards remaining.
  */
-export function chooseLeadCard(hand: readonly Card[], trump: Suit, tracker: PlayTracker): Card {
+export function chooseLeadCard(hand: readonly Card[], trump: Suit, tracker: PlayTracker, isBidderFirstLead = false): Card {
+  // Bidder's first lead must be trump if they have any — rule #82
+  if (isBidderFirstLead) {
+    const trumps = hand.filter((c) => c.suit === trump)
+    if (trumps.length > 0) {
+      const unsecuredAce = trumps.find((c) => c.rank === 'A' && isUnsecuredAce(c, hand, tracker))
+      if (unsecuredAce) return unsecuredAce
+      const ace = trumps.find((c) => c.rank === 'A')
+      if (ace) return ace
+      return maxByRank(trumps)
+    }
+  }
+
   const trumpAces = hand.filter((c) => c.suit === trump && c.rank === 'A' && isUnsecuredAce(c, hand, tracker))
   if (trumpAces.length > 0) return trumpAces[0]
 

--- a/web/src/persistence/gameSave.test.ts
+++ b/web/src/persistence/gameSave.test.ts
@@ -57,6 +57,7 @@ describe('game save persistence', () => {
       trumpSuit: Suit.Diamonds,
       bidWinner: 0,
       bid: 320,
+      log: [],
     }
     const state: GameFlowState = { ...initGameFlowState(3), phase: 'trick-play', auctionResult }
     saveGame(state)
@@ -94,7 +95,7 @@ describe('game save persistence', () => {
     const state: GameFlowState = {
       ...initGameFlowState(3),
       phase: 'trick-play',
-      auctionResult: { hands, trumpSuit: Suit.Spades, bidWinner: 1, bid: 300 },
+      auctionResult: { hands, trumpSuit: Suit.Spades, bidWinner: 1, bid: 300, log: [] },
       trickPlayCheckpoint: trickState,
     }
     saveGame(state)

--- a/web/src/persistence/options.test.ts
+++ b/web/src/persistence/options.test.ts
@@ -11,8 +11,8 @@ describe('options persistence', () => {
   })
 
   it('round-trips a saved options value', () => {
-    saveOptions({ hideOpponentCards: true, showBaseBidHint: false })
-    expect(loadOptions()).toEqual({ hideOpponentCards: true, showBaseBidHint: false })
+    saveOptions({ hideOpponentCards: true, showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', showMeldHint: false, hideTrickLog: true })
+    expect(loadOptions()).toEqual({ hideOpponentCards: true, showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', showMeldHint: false, hideTrickLog: true })
   })
 
   it('falls back to DEFAULT_OPTIONS on corrupt JSON', () => {
@@ -22,7 +22,16 @@ describe('options persistence', () => {
 
   it('fills in missing/malformed fields from DEFAULT_OPTIONS rather than failing outright', () => {
     window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ hideOpponentCards: true }))
-    expect(loadOptions()).toEqual({ hideOpponentCards: true, showBaseBidHint: true })
+    const loaded = loadOptions()
+    expect(loaded.hideOpponentCards).toBe(true)
+    expect(loaded.showBaseBidHint).toBe(true)
+    expect(loaded.opponentSkill).toBe('hard')
+    expect(loaded.teammateSkill).toBe('hard')
+    expect(loaded.showMeldHint).toBe(false)
+
+    window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ opponentSkill: 42 }))
+    const loaded2 = loadOptions()
+    expect(loaded2.opponentSkill).toBe('hard')
 
     window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ showBaseBidHint: 'nope' }))
     expect(loadOptions()).toEqual(DEFAULT_OPTIONS)

--- a/web/src/persistence/options.ts
+++ b/web/src/persistence/options.ts
@@ -5,6 +5,11 @@
 
 const OPTIONS_KEY = 'pinochle:options:v1'
 
+/** AI difficulty tiers. `'proficient'` is the current heuristic-based AI.
+ * The other levels will map to GeneralStrategy (Monte Carlo) parameters
+ * once ported from the Python engine (see issue #79). */
+export type SkillLevel = 'easy' | 'medium' | 'hard' | 'proficient' | 'expert'
+
 export interface GameOptions {
   /** Hide the West/Partner/East face-down card fans (Seat.tsx) entirely —
    * just player + board, to save screen space. Off (fans shown) by
@@ -13,32 +18,53 @@ export interface GameOptions {
   /** Show BiddingControls' "Your hand suggests up to N" hint during the
    * human's bidding turn. On by default, matching current behavior. */
   readonly showBaseBidHint: boolean
-  // Deliberately not here yet (#54 scope): an AI-difficulty picker and a
-  // "bid window" hint based on assumed opponent skill. Both depend on AI
-  // difficulty tiers that don't exist in the TS engine yet — bidding.ts
-  // only has the one Proficient strategy. OptionsPanel.tsx leaves layout
-  // room for these; this type just doesn't carry them yet.
+  /** AI skill level for the two opponents (#79). */
+  readonly opponentSkill: SkillLevel
+  /** AI skill level for the human's teammate (#79). */
+  readonly teammateSkill: SkillLevel
+  /** Show the per-card meld breakdown list in MeldFlow. Off by default
+   * (just shows total points) — players who want to verify the AI's meld
+   * detection can turn it on. */
+  readonly showMeldHint: boolean
+  /** Hide the trick-play event log (card plays, trick winners). Default on
+   * (#81) so the table is less cluttered; turn off to see every play logged
+   * in the right-hand panel. The bid/auction history is always shown. */
+  readonly hideTrickLog: boolean
 }
 
 export const DEFAULT_OPTIONS: GameOptions = {
   hideOpponentCards: false,
   showBaseBidHint: true,
+  opponentSkill: 'hard',
+  teammateSkill: 'hard',
+  showMeldHint: false,
+  hideTrickLog: true,
 }
 
 /** Reads saved options from localStorage, falling back to DEFAULT_OPTIONS
  * (whole-object or per-field) if nothing's saved yet or the saved value is
  * corrupt/unrecognized — never throws. */
+const VALID_SKILLS = new Set<SkillLevel>(['easy', 'medium', 'hard', 'proficient', 'expert'])
+
+function parseSkill(raw: unknown, fallback: SkillLevel): SkillLevel {
+  return VALID_SKILLS.has(raw as SkillLevel) ? (raw as SkillLevel) : fallback
+}
+
 export function loadOptions(): GameOptions {
   try {
     const raw = window.localStorage.getItem(OPTIONS_KEY)
     if (!raw) return DEFAULT_OPTIONS
     const parsed: unknown = JSON.parse(raw)
     if (typeof parsed !== 'object' || parsed === null) return DEFAULT_OPTIONS
-    const { hideOpponentCards, showBaseBidHint } = parsed as Partial<GameOptions>
+    const { hideOpponentCards, showBaseBidHint, opponentSkill, teammateSkill, showMeldHint, hideTrickLog } = parsed as Partial<GameOptions>
     return {
       hideOpponentCards:
         typeof hideOpponentCards === 'boolean' ? hideOpponentCards : DEFAULT_OPTIONS.hideOpponentCards,
       showBaseBidHint: typeof showBaseBidHint === 'boolean' ? showBaseBidHint : DEFAULT_OPTIONS.showBaseBidHint,
+      opponentSkill: parseSkill(opponentSkill, DEFAULT_OPTIONS.opponentSkill),
+      teammateSkill: parseSkill(teammateSkill, DEFAULT_OPTIONS.teammateSkill),
+      showMeldHint: typeof showMeldHint === 'boolean' ? showMeldHint : DEFAULT_OPTIONS.showMeldHint,
+      hideTrickLog: typeof hideTrickLog === 'boolean' ? hideTrickLog : DEFAULT_OPTIONS.hideTrickLog,
     }
   } catch {
     return DEFAULT_OPTIONS


### PR DESCRIPTION
Adds a "D" badge next to the dealer's name during the auction phase so the human player can see who bids last.

- **Seat.tsx**: Added `isDealer` prop and renders an amber "D" badge next to the player name when `isDealer` is true
- **Table.tsx**: Threads `isDealer={seat.player === state.dealer}` to `Seat`
- **tableTypes.ts**: Added `dealer?: PlayerIndex` to `TableState`
- **AuctionFlow.tsx**: Sets `dealer: state.dealer` on the `tableState` memo

Closes #76
