### PR TITLE
feat: add quick-fail/concede hand (#83)

### DIFF
--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -2,6 +2,10 @@ export interface ConfirmDialogProps {
   message: string
   onConfirm: () => void
   onCancel: () => void
+  /** Label for the confirm button. Defaults to "Confirm". */
+  confirmLabel?: string
+  /** Label for the cancel button. Defaults to "Cancel". */
+  cancelLabel?: string
 }
 
 /**
@@ -10,7 +14,13 @@ export interface ConfirmDialogProps {
  * page (and looks like a bare browser alert, not part of the app) rather
  * than rendering as one of this app's own modals.
  */
-export function ConfirmDialog({ message, onConfirm, onCancel }: ConfirmDialogProps) {
+export function ConfirmDialog({
+  message,
+  onConfirm,
+  onCancel,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+}: ConfirmDialogProps) {
   return (
     <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/70 p-4">
       <div className="w-full max-w-xs rounded-lg bg-white p-6 text-center text-neutral-900 shadow-xl">
@@ -21,14 +31,14 @@ export function ConfirmDialog({ message, onConfirm, onCancel }: ConfirmDialogPro
             onClick={onConfirm}
             className="w-full rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900"
           >
-            Start new game
+            {confirmLabel}
           </button>
           <button
             type="button"
             onClick={onCancel}
             className="w-full rounded bg-neutral-200 px-4 py-2 font-semibold text-neutral-900 hover:bg-neutral-300"
           >
-            Cancel
+            {cancelLabel}
           </button>
         </div>
       </div>

--- a/web/src/components/GameShell.test.tsx
+++ b/web/src/components/GameShell.test.tsx
@@ -123,7 +123,7 @@ describe('GameShell', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
     fireEvent.click(screen.getByRole('button', { name: 'New Game' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Start new game' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
     await waitFor(() => expect(screen.getByRole('button', { name: 'Bid' })).not.toBeNull())
     expect(Deck.prototype.deal).toHaveBeenCalledTimes(2)
   })

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type { Card, Suit } from '../engine/card'
 import { teamOf, type Hands, type TeamId } from '../engine/round'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from '../engine/tracker'
@@ -8,6 +8,7 @@ import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
 import type { TableState } from './tableTypes'
 import { AuctionLog } from './AuctionLog'
+import { ConfirmDialog } from './ConfirmDialog'
 import { TrickLog } from './TrickLog'
 import {
   buildTrick,
@@ -119,6 +120,7 @@ export function TrickPlayFlow({
   // strategy input the AI reads, not something any render needs back.
   const trackerRef = useRef(new PlayTracker())
   const completedRef = useRef(false)
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false)
 
   // Resolve AI turns automatically, after a brief delay so the play reads
   // as a real decision rather than an instant jump. Runs after every state
@@ -149,11 +151,16 @@ export function TrickPlayFlow({
     return () => clearTimeout(timer)
   }, [state.phase, state.trickWinners.length])
 
-  // Fire onComplete exactly once, when all 12 tricks are done.
+  // Fire onComplete exactly once, when all 12 tricks are done (or human conceded).
   useEffect(() => {
     if (state.phase !== 'complete' || completedRef.current) return
     completedRef.current = true
-    onComplete?.({ trickPointsByTeam: state.trickPointsByTeam, trickWinners: state.trickWinners })
+    const result: TrickPlayResult = {
+      trickPointsByTeam: state.trickPointsByTeam,
+      trickWinners: state.trickWinners,
+    }
+    if (state.conceded) result.conceded = true
+    onComplete?.(result)
   }, [state, onComplete])
 
   // Local autosave (#54): checkpoint after each completed trick — i.e.
@@ -215,20 +222,30 @@ export function TrickPlayFlow({
   }, [state, seatNames, humanPlayer, bid, scoresByTeam, teamNames, meldPointsByTeam, legalMovesForHuman])
 
   const handleConcede = useCallback(() => {
-    completedRef.current = true
-    onComplete?.({ trickPointsByTeam: state.trickPointsByTeam, trickWinners: state.trickWinners, conceded: true })
-  }, [state, onComplete])
+    dispatch({ type: 'CONCEDE' })
+    setShowConfirmDialog(false)
+  }, [])
 
   return (
     <div className="relative">
       {canConcede && (
-        <button
-          type="button"
-          onClick={handleConcede}
-          className="absolute top-2 right-2 z-20 rounded bg-red-800 px-3 py-1 text-xs font-semibold text-white hover:bg-red-900"
-        >
-          Concede
-        </button>
+        <>
+          <button
+            type="button"
+            onClick={() => setShowConfirmDialog(true)}
+            className="absolute top-2 right-2 z-20 rounded bg-red-800 px-3 py-1 text-xs font-semibold text-white hover:bg-red-900"
+          >
+            Concede hand
+          </button>
+          {showConfirmDialog && (
+            <ConfirmDialog
+              message={`Are you sure? Your team will score -${bid} points`}
+              confirmLabel="Concede"
+              onConfirm={handleConcede}
+              onCancel={() => setShowConfirmDialog(false)}
+            />
+          )}
+        </>
       )}
       <Table
         state={tableState}

--- a/web/src/components/trickPlayReducer.ts
+++ b/web/src/components/trickPlayReducer.ts
@@ -42,11 +42,14 @@ export interface TrickPlayState {
   readonly trickPointsByTeam: Record<TeamId, number>
   readonly phase: TrickPlayPhase
   readonly log: readonly TrickPlayLogEntry[]
+  /** True when the human has conceded the hand (#83). */
+  readonly conceded: boolean
 }
 
 export type TrickPlayAction =
   | { readonly type: 'PLAY_CARD'; readonly player: PlayerIndex; readonly card: Card }
   | { readonly type: 'CLEAR_TRICK' }
+  | { readonly type: 'CONCEDE' }
 
 export function initTrickPlayState(
   hands: Hands,
@@ -67,6 +70,7 @@ export function initTrickPlayState(
     trickPointsByTeam: { 0: 0, 1: 0 },
     phase: 'playing',
     log: [],
+    conceded: false,
   }
 }
 
@@ -153,6 +157,10 @@ export function trickPlayReducer(state: TrickPlayState, action: TrickPlayAction)
         turn: winner,
         trickNumber: nextTrickNumber,
       }
+    }
+    case 'CONCEDE': {
+      if (state.phase !== 'playing') return state
+      return { ...state, phase: 'complete', conceded: true }
     }
     default:
       return state


### PR DESCRIPTION
Add quick-fail/concede hand when bid is mathematically impossible (BID - MELD > 250) [auto-detect] or when the human player chooses to concede during trick-play.

- Concede button with ConfirmDialog (confirms -BID penalty)
- CONCEDE action in trickPlayReducer
- Auto-detect: when meld + 250 < bid, skip trick-play entirely
- Scoring: bidding team scores -bid, opponents keep meld only
- AI never concedes

Closes #83