### PR TITLE
feat: show full auction history (#77)

### DIFF
--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { auctionReducer, initAuctionState } from './auctionReducer'
 import type { AuctionResult } from './auctionTypes'
 import { partnerOf } from './auctionTypes'
+import { AuctionLog } from './AuctionLog'
 import { BiddingControls } from './BiddingControls'
 import { PassRevealDialog } from './PassRevealDialog'
 import { PassSelector } from './PassSelector'
@@ -220,10 +221,24 @@ export function AuctionFlow({
     return null
   }, [state, humanPlayer, options.showBaseBidHint])
 
+  const logPanel = useMemo(() => {
+    const bidWinner = state.bidding.bidWinner
+    return (
+      <AuctionLog
+        entries={state.log}
+        currentBid={state.bid || state.bidding.currentBid}
+        bidWinner={bidWinner ?? undefined}
+        bidWinnerName={bidWinner !== null ? state.seatNames[bidWinner] : undefined}
+        dealerName={state.seatNames[state.dealer]}
+      />
+    )
+  }, [state.log, state.bid, state.bidding.currentBid, state.bidding.bidWinner, state.seatNames, state.dealer])
+
   return (
     <Table
       state={tableState}
       overlay={overlay}
+      logPanel={logPanel}
       onOpenMenu={onOpenMenu}
       hideOpponentCards={options.hideOpponentCards}
     />

--- a/web/src/components/AuctionLog.tsx
+++ b/web/src/components/AuctionLog.tsx
@@ -1,8 +1,17 @@
 import { type AuctionLogEntry, formatAuctionLogEntry } from './auctionTypes'
+import type { PlayerIndex } from '../engine/trick'
 
 export interface AuctionLogProps {
   /** Oldest-first; rendered newest-first so the latest event is always visible without scrolling. */
   entries: readonly AuctionLogEntry[]
+  /** The current high bid in the auction. */
+  currentBid?: number
+  /** The player index of the current highest bidder. */
+  bidWinner?: PlayerIndex
+  /** The display name of the current highest bidder. */
+  bidWinnerName?: string
+  /** The display name of the dealer. */
+  dealerName?: string
 }
 
 /**
@@ -11,20 +20,33 @@ export interface AuctionLogProps {
  * a human player can follow the auction instead of just watching table
  * state change silently underneath them.
  */
-export function AuctionLog({ entries }: AuctionLogProps) {
-  if (entries.length === 0) return null
-
+export function AuctionLog({ entries, currentBid, bidWinner, bidWinnerName, dealerName }: AuctionLogProps) {
   const newestFirst = [...entries].reverse()
 
   return (
     <div className="pointer-events-none w-full max-w-xs">
-      <ol className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded-lg bg-black/60 p-3 text-xs text-white shadow-lg">
-        {newestFirst.map((entry, i) => (
-          <li key={newestFirst.length - i} className={i === 0 ? 'font-semibold' : 'text-white/70'}>
-            {formatAuctionLogEntry(entry)}
-          </li>
-        ))}
-      </ol>
+      <div className="flex flex-col gap-1 rounded-lg bg-black/60 p-3 text-xs text-white shadow-lg">
+        {(currentBid !== undefined || dealerName) && (
+          <div className="flex flex-wrap gap-x-3 gap-y-0.5 border-b border-white/20 pb-1.5 font-semibold">
+            {currentBid !== undefined && currentBid > 0 && bidWinnerName && (
+              <span className="text-amber-300">High: {currentBid} ({bidWinnerName})</span>
+            )}
+            {currentBid !== undefined && currentBid === 0 && (
+              <span className="text-white/60">No bids yet</span>
+            )}
+            {dealerName && <span className="text-white/50">Dealer: {dealerName}</span>}
+          </div>
+        )}
+        {entries.length > 0 && (
+          <ol className="flex max-h-44 flex-col gap-1 overflow-y-auto">
+            {newestFirst.map((entry, i) => (
+              <li key={newestFirst.length - i} className={i === 0 ? 'font-semibold' : 'text-white/70'}>
+                {formatAuctionLogEntry(entry)}
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

The auction phase was too opaque — the human saw no intermediate state, just the final result. The engine already tracked the full bid history in the reducer; this was purely a display gap where the logPanel prop was never passed to \Table\.

## Changes

- **AuctionFlow.tsx**: Import and mount \AuctionLog\ as the \logPanel\ prop on \Table\, feeding it the full \state.log\ array plus current high-bid info and the dealer name
- **AuctionLog.tsx**: Add a summary header row showing the current high bid (with bidder name) and the dealer; keep the existing newest-first event feed below

## Testing

- The log panel appears in the top-right corner during bidding and persists through trump selection and passing phases
- Every bid, pass, forced bid, trump call, and card-pass event renders instantly via the existing reducer log entries
- Current high bid is highlighted in amber with the bidder's name; dealer is shown in muted white