### PR TITLE
feat: strengthen defensive bidding AI (#78)

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -196,6 +196,12 @@ PARTNER_ESTIMATE_RANGE = (50, 100)  # Proficient draws randomly in this range ea
 MAX_BID_DEFAULT = 400
 MAX_BID_MELD_THRESHOLD = 300
 OPENER_THRESHOLD = 320  # minimum Base Bid to justify opening at all
+# Minimum ceiling to justify a defensive push against an opening bid of 300.
+# Hands at or above this floor should almost always raise a 300 opener,
+# since even moderate hands can contribute toward making 300 with partner's
+# help, and pushing deprives the opponent of a cheap contract. "Truly
+# hopeless" hands (no meld, no aces — ceiling ~130) fall below this floor.
+DEFENSIVE_PUSH_FLOOR = 200
 
 
 def compute_base_bid(hand, trump):
@@ -1686,6 +1692,14 @@ class Player:
             effective_ceiling = min(effective_ceiling, cap)
 
         next_bid = current_bid + min_increment
+
+        # Defensive push (#78): when opponent opened at the minimum (300),
+        # respond unless the hand is truly hopeless (ceiling below
+        # DEFENSIVE_PUSH_FLOOR). In real Pinochle, 300 is the absolute floor
+        # and is almost always raised.
+        if current_bid <= OPENING_BID and ceiling >= DEFENSIVE_PUSH_FLOOR:
+            return next_bid
+
         return next_bid if next_bid <= effective_ceiling else None
 
     def choose_trump(self):

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -329,9 +329,14 @@ describe('chooseBid', () => {
       expect(chooseBid(0, strongHand, 300, 10, context)).toBe(310)
     })
 
-    it('passes when the next bid exceeds my ceiling', () => {
+    it('defensively pushes against an opening bid of 300 unless the hand is truly hopeless', () => {
+      // runOnlyHand has ceiling 300 (Run 150 + Ace 20 + baseline adj 130) >= DEFENSIVE_PUSH_FLOOR (200)
       const context = baseContext({ everBid: true, bidHistory: [{ player: 1, amount: 300 }] })
-      expect(chooseBid(0, runOnlyHand, 300, 10, context)).toBeNull()
+      expect(chooseBid(0, runOnlyHand, 300, 10, context)).toBe(310)
+
+      // weakHand has ceiling 130 (no meld, no aces) < DEFENSIVE_PUSH_FLOOR (200) — truly hopeless
+      const hopelessContext = baseContext({ everBid: true, bidHistory: [{ player: 1, amount: 300 }] })
+      expect(chooseBid(0, weakHand, 300, 10, hopelessContext)).toBeNull()
     })
 
     it('relaxes the ceiling to at least 330 once my partner has bid', () => {

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -43,6 +43,12 @@ export const MAX_BID_DEFAULT = 400
 export const MAX_BID_MELD_THRESHOLD = 300
 // Minimum Base Bid to justify opening at all.
 export const OPENER_THRESHOLD = 320
+// Minimum ceiling to justify a defensive push against an opening bid of 300.
+// Hands at or above this floor should almost always raise a 300 opener,
+// since even moderate hands can contribute toward making 300 with partner's
+// help, and pushing deprives the opponent of a cheap contract. "Truly
+// hopeless" hands (no meld, no aces — ceiling ~130) fall below this floor.
+export const DEFENSIVE_PUSH_FLOOR = 200
 
 function handCount(hand: readonly Card[], suit: Suit, rank: Rank): number {
   return hand.reduce((count, c) => count + (c.suit === suit && c.rank === rank ? 1 : 0), 0)
@@ -440,6 +446,17 @@ export function chooseBid(
   }
 
   const nextBid = currentBid + minIncrement
+
+  // Defensive push (#78): when opponent opened at the minimum (300), respond
+  // unless the hand is truly hopeless (ceiling below DEFENSIVE_PUSH_FLOOR).
+  // In real Pinochle, 300 is the absolute floor and is almost always raised.
+  // Even a moderate hand (~200+ ceiling) can contribute toward making 300
+  // with partner's help, and pushing deprives the opponent of a cheap contract.
+  if (currentBid <= OPENING_BID && ceiling >= DEFENSIVE_PUSH_FLOOR) {
+    if (partnerPassed) return Math.max(nextBid, 321)
+    return nextBid
+  }
+
   // When partner passed, the bid must be at least 320 regardless of ceiling.
   if (partnerPassed && nextBid < 321) return competitiveCeiling >= 321 ? 321 : null
   return nextBid <= competitiveCeiling ? nextBid : null


### PR DESCRIPTION
## Summary

Strengthens the AI's defensive bidding response to low opening bids. Currently, the AI frequently passes when the opponent opens at 300 (the minimum), even with moderate hands that could contribute toward making the contract.

## Changes

### New constant: DEFENSIVE_PUSH_FLOOR = 200
Added to both bidding.ts and pinochle_engine.py. This is the minimum ceiling that justifies pushing back against a 300 opening bid. Hands below this floor (no meld, no aces -- ceiling ~130) are truly hopeless and still pass.

### Updated opponent-bid branch in both implementations
When the opponent holds the bid and the current bid is at OPENING_BID (300), the AI now checks if its ceiling is at or above DEFENSIVE_PUSH_FLOOR (200). If so, it responds with currentBid + minIncrement (310, or 321 if partner passed).

Previously, a moderate hand (e.g., Royal Marriage + 2 aces, ceiling 210) would pass because 310 > 210. Now it pushes back, since even moderate hands can contribute toward making 300 with partner's help, and pushing denies the opponent a cheap contract.

### Tests
- Updated the old "passes when next bid exceeds ceiling" test -- runOnlyHand at 300 opener now expects 310
- Added test for "truly hopeless" hand (weakHand at 300 opener) -- still passes correctly

### GeneralStrategy flow
- Skill 2-3 calls super().choose_bid() directly, benefitting automatically
- Skill 4-5 (_rollout_ev_bid) uses the strengthened static bid as input, then does EV comparison between None and nextBid
