### PR TITLE
fix: make 3-card pass simultaneous (#80)

### DIFF
--- a/human_play.py
+++ b/human_play.py
@@ -285,21 +285,26 @@ class InteractiveRound(Round):
         if not hasattr(self, "_pass_stage"):
             self._pass_stage = 0
             self._pass_partner = next(p for p in self.bid_winner.team.players if p is not self.bid_winner)
+            self._pass_to_bidder = None
+            self._pass_to_partner = None
 
         partner = self._pass_partner
 
         if self._pass_stage == 0:
-            to_bidder = partner.choose_pass_cards(PASS_COUNT, self.trump_suit, is_bid_winner=False)
-            for c in to_bidder:
-                partner.hand.remove(c)
-            self.bid_winner.hand.extend(to_bidder)
-            self._pass_stage = 1
+            if self._pass_to_bidder is None:
+                self._pass_to_bidder = partner.choose_pass_cards(
+                    PASS_COUNT, self.trump_suit, is_bid_winner=False)
+            if self._pass_to_partner is None:
+                self._pass_to_partner = self.bid_winner.choose_pass_cards(
+                    PASS_COUNT, self.trump_suit, is_bid_winner=True)
 
-        if self._pass_stage == 1:
-            back_to_partner = self.bid_winner.choose_pass_cards(PASS_COUNT, self.trump_suit, is_bid_winner=True)
-            for c in back_to_partner:
+            # Both choices obtained; exchange atomically (#80).
+            for c in self._pass_to_bidder:
+                partner.hand.remove(c)
+            self.bid_winner.hand.extend(self._pass_to_bidder)
+            for c in self._pass_to_partner:
                 self.bid_winner.hand.remove(c)
-            partner.hand.extend(back_to_partner)
+            partner.hand.extend(self._pass_to_partner)
             self._pass_stage = 2
 
     def _trick_taking_loop(self):

--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -600,6 +600,21 @@ def run_return_pass(bid_winner, partner, trump_suit):
     partner.hand.extend(back_to_partner)
 
 
+def run_simultaneous_pass(bid_winner, partner, trump_suit):
+    """Simultaneous PASS_COUNT exchange (#80): both players choose their
+    cards independently; once both selections are made the cards move
+    atomically so neither sees what they will receive before committing
+    their own selection. Mutates both players' hands in place."""
+    to_bidder = partner.choose_pass_cards(PASS_COUNT, trump_suit, is_bid_winner=False)
+    back_to_partner = bid_winner.choose_pass_cards(PASS_COUNT, trump_suit, is_bid_winner=True)
+    for c in to_bidder:
+        partner.hand.remove(c)
+    bid_winner.hand.extend(to_bidder)
+    for c in back_to_partner:
+        bid_winner.hand.remove(c)
+    partner.hand.extend(back_to_partner)
+
+
 def play_tricks(players, trump, leader_index, tracker, num_tricks=12, trick_num_offset=0,
                  forced_lead_card=None):
     """
@@ -2390,8 +2405,7 @@ class Round:
 
     def _passing_phase(self):
         partner = next(p for p in self.bid_winner.team.players if p is not self.bid_winner)
-        run_forward_pass(self.bid_winner, partner, self.trump_suit)
-        run_return_pass(self.bid_winner, partner, self.trump_suit)
+        run_simultaneous_pass(self.bid_winner, partner, self.trump_suit)
 
     def _meld_phase(self):
         for team in self.teams:


### PR DESCRIPTION
**Bug**: the 3-card pass was sequential — partner passed to bidder first, then the bidder passed back — giving the second passer an unfair information advantage.

**Fix**: 
- Both passers now choose their cards independently (human via PassSelector, AI via choosePassCards in one setTimeout)
- Cards exchange atomically once both selections are made
- PassRevealDialog shows what was received after the atomic swap
- AuctionLog still records both card-pass entries

**Changes**:
- \pinochle_engine.py\: Added \un_simultaneous_pass\ which calls both \choose_pass_cards\ calls independently then exchanges atomically; updated \Round._passing_phase\ to use it
- \human_play.py\: Rewrote \InteractiveRound._passing_phase\ as a single resumable stage — both players pick independently via stored state, then exchange happens atomically

Note: the TypeScript/web side was already correctly implemented for simultaneous passing (in \uctionReducer.ts\ with \PassingSubstate\ tracking both sides independently, and \AuctionFlow.tsx\ dispatching both AI passes in one \setTimeout\).