### PR TITLE
feat: add AI skill-level options (1-5) (#79)

### DIFF
--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -2,8 +2,9 @@ import { useEffect, useMemo, useReducer, useRef } from 'react'
 import { bestBaseBid, chooseBid, chooseTrump, type AuctionContext } from '../engine/bidding'
 import { OPENING_BID } from '../engine/card'
 import { PASS_COUNT, choosePassCards } from '../engine/passing'
-import { teamOf, type Hands, type TeamId } from '../engine/round'
+import { partnerOf, teamOf, type Hands, type TeamId } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
+import type { SkillLevel } from '../persistence/options'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { auctionReducer, initAuctionState } from './auctionReducer'
 import type { AuctionResult } from './auctionTypes'
@@ -19,6 +20,11 @@ import { TrumpSelector } from './TrumpSelector'
 export const AI_BID_DELAY_MS = 600
 
 const MIN_INCREMENT = 10
+
+/** Returns the SkillLevel to use for a given AI player, based on options. */
+function skillForPlayer(player: PlayerIndex, humanPlayer: PlayerIndex, options: GameOptions): SkillLevel {
+  return partnerOf(player) === humanPlayer ? options.teammateSkill : options.opponentSkill
+}
 
 export interface AuctionFlowProps {
   initialHands: Hands
@@ -64,7 +70,8 @@ export function AuctionFlow({
           (_, i) => !state.bidding.active[i],
         ),
       }
-      const decision = chooseBid(turn, state.hands[turn], state.bidding.currentBid, MIN_INCREMENT, context)
+      const skill = skillForPlayer(turn, humanPlayer, options)
+      const decision = chooseBid(turn, state.hands[turn], state.bidding.currentBid, MIN_INCREMENT, context, skill)
       const timer = setTimeout(() => {
         if (decision === null) dispatch({ type: 'PASS_BID', player: turn })
         else dispatch({ type: 'BID', player: turn, amount: decision })
@@ -75,7 +82,8 @@ export function AuctionFlow({
     if (state.phase === 'trump') {
       if (state.bidWinner === null || state.bidWinner === humanPlayer) return
       const bidWinner = state.bidWinner
-      const suit = chooseTrump(state.hands[bidWinner])
+      const skill = skillForPlayer(bidWinner, humanPlayer, options)
+      const suit = chooseTrump(state.hands[bidWinner], skill)
       const timer = setTimeout(() => {
         dispatch({ type: 'CHOOSE_TRUMP', player: bidWinner, suit })
       }, AI_BID_DELAY_MS)
@@ -103,11 +111,13 @@ export function AuctionFlow({
 
       const timer = setTimeout(() => {
         if (bidder !== humanPlayer && !bidderReady) {
-          const cards = choosePassCards(state.hands[bidder], PASS_COUNT, state.trumpSuit!, true)
+          const skill = skillForPlayer(bidder, humanPlayer, options)
+          const cards = choosePassCards(state.hands[bidder], PASS_COUNT, state.trumpSuit!, true, skill)
           dispatch({ type: 'PASS_CARDS', from: bidder, cards })
         }
         if (partner !== humanPlayer && !partnerReady) {
-          const cards = choosePassCards(state.hands[partner], PASS_COUNT, state.trumpSuit!, false)
+          const skill = skillForPlayer(partner, humanPlayer, options)
+          const cards = choosePassCards(state.hands[partner], PASS_COUNT, state.trumpSuit!, false, skill)
           dispatch({ type: 'PASS_CARDS', from: partner, cards })
         }
       }, AI_BID_DELAY_MS)

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type { Card, Suit } from '../engine/card'
-import { teamOf, type Hands, type TeamId } from '../engine/round'
+import { partnerOf, teamOf, type Hands, type TeamId } from '../engine/round'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from '../engine/tracker'
 import type { PlayerIndex } from '../engine/trick'
+import type { SkillLevel } from '../persistence/options'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
@@ -74,6 +75,11 @@ export interface TrickPlayFlowProps {
 export const AI_PLAY_DELAY_MS = 700
 export const TRICK_SETTLE_MS = 1200
 
+/** Returns the SkillLevel to use for a given AI player, based on options. */
+function skillForPlayer(player: PlayerIndex, humanPlayer: PlayerIndex, options: GameOptions): SkillLevel {
+  return partnerOf(player) === humanPlayer ? options.teammateSkill : options.opponentSkill
+}
+
 /**
  * Drives the trick-taking phase (#35): legal-move highlighting on the
  * human's hand, playing a card into the center trick area, settling a
@@ -133,10 +139,11 @@ export function TrickPlayFlow({
       const trick = buildTrick(state.trumpSuit, state.currentTrick)
       const legal = trick.legalMoves(hand)
       const isBidderFirstLead = state.trickNumber === 0 && player === state.bidWinner && state.currentTrick.length === 0
+      const skill = skillForPlayer(player, humanPlayer, options)
       const card =
         state.currentTrick.length === 0
-          ? chooseLeadCard(hand, state.trumpSuit, trackerRef.current, isBidderFirstLead)
-          : chooseFollowCard(hand, legal, state.currentTrick, state.trumpSuit, teammatesOf(player), trackerRef.current)
+          ? chooseLeadCard(hand, state.trumpSuit, trackerRef.current, isBidderFirstLead, skill)
+          : chooseFollowCard(hand, legal, state.currentTrick, state.trumpSuit, teammatesOf(player), trackerRef.current, skill)
       trackerRef.current.record(card)
       dispatch({ type: 'PLAY_CARD', player, card })
     }, AI_PLAY_DELAY_MS)

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -336,9 +336,35 @@ export interface AuctionContext {
 }
 
 /**
+ * Meld-only bid valuation for skill 1 (easy). Mirrors EasyPlayer's
+ * approach from Python: uses actual `scoreMelds` (not speculative Base
+ * Bid), adds a flat trick-point constant plus uniform noise, then applies
+ * the minimal positional filter. No dealer-protection, no partner-bid-count
+ * tracking, no score-differential awareness — pure "meld value + guess".
+ */
+function meldOnlyBid(
+  hand: readonly Card[],
+  currentBid: number,
+  minIncrement: number,
+  context: AuctionContext,
+): number | null {
+  const bestMeldValue = Math.max(...SUITS.map((t) => scoreMelds(hand, t).total))
+  const noise = (Math.random() * 2 - 1) * MELD_ONLY_BID_NOISE
+  const ceiling = bestMeldValue + MELD_ONLY_TRICK_ESTIMATE + noise
+  const nextBid = currentBid + minIncrement
+  if (!context.everBid) {
+    return ceiling >= OPENING_BID ? OPENING_BID : null
+  }
+  return nextBid <= ceiling ? nextBid : null
+}
+
+/**
  * Proficient bidding logic, built on Base Bid plus positional and
  * score-context rules. Falls back to the old coin-flip placeholder if
  * called without a context (keeps old call sites/tests working).
+ *
+ * @param skill Skill level from options — controls hand-valuation formula.
+ *   Defaults to 'hard' (base_bid, the current Proficient behavior).
  *
  * Decision tiers:
  *   - No one has bid yet this auction:
@@ -367,9 +393,14 @@ export function chooseBid(
   currentBid: number,
   minIncrement: number,
   context?: AuctionContext,
+  skill: SkillLevel = 'hard',
 ): number | null {
   if (context === undefined) {
     return Math.random() < 0.6 ? null : currentBid + minIncrement
+  }
+
+  if (SKILL_PARAMS[skill].handValuation === 'meld_only') {
+    return meldOnlyBid(hand, currentBid, minIncrement, context)
   }
 
   const myTeam = teamOf(player)
@@ -448,9 +479,24 @@ export function chooseBid(
 /**
  * Uses the same per-suit Base Bid comparison as chooseBid, so trump
  * selection reflects real speculative hand strength rather than raw card
- * count.
+ * count. For skill 1 (easy), picks the suit with the highest actual meld.
+ *
+ * @param skill Skill level — controls trump selection formula. Defaults
+ *   to 'hard' (base_bid, current Proficient behavior).
  */
-export function chooseTrump(hand: readonly Card[]): Suit {
+export function chooseTrump(hand: readonly Card[], skill: SkillLevel = 'hard'): Suit {
+  if (SKILL_PARAMS[skill].handValuation === 'meld_only') {
+    let best: Suit = Suit.Spades
+    let bestValue = -1
+    for (const t of SUITS) {
+      const { total } = scoreMelds(hand, t)
+      if (total > bestValue) {
+        best = t
+        bestValue = total
+      }
+    }
+    return best
+  }
   const { trump } = bestBaseBid(hand)
   return trump
 }

--- a/web/src/engine/passing.ts
+++ b/web/src/engine/passing.ts
@@ -5,8 +5,10 @@
 // is the entry point; bidderPassSelection / partnerPassSelection hold
 // the tiered priority logic for each role.
 
+import type { SkillLevel } from '../persistence/options'
 import { type Card, type Rank, Suit, SUITS } from './card'
 import { scoreMelds } from './melds'
+import { SKILL_PARAMS } from './skills'
 
 export type PassCategory = 'DS' | 'HC'
 
@@ -259,20 +261,54 @@ function sampleRandom(pool: readonly Card[], count: number): Card[] {
   return result
 }
 
+/** Cheap per-card "keep value" for skill 1's simplified passing logic,
+ *  matching Python's `_easy_card_worth`. */
+function easyCardWorth(card: Card, trump: Suit): number {
+  let worth = 0
+  if (card.suit === trump) worth += 5
+  if (card.rank === 'A' || card.rank === '10' || card.rank === 'K') worth += 2
+  if (card.rank === 'Q' || card.rank === 'J') worth += 1
+  return worth
+}
+
 /**
  * Skill-level-proficient passing strategy, split by trump category
  * (Diamonds/Spades vs Hearts/Clubs) and role (bidder vs partner). Falls
  * back to random selection if trumpSuit/isBidWinner aren't supplied
  * (keeps the function usable in isolation / old call sites).
+ *
+ * @param skill Skill level — skill 1 (easy) uses simplified
+ *   meld-only passing logic; 2-5 use the full Proficient tiers.
  */
 export function choosePassCards(
   hand: readonly Card[],
   count: number,
   trumpSuit?: Suit,
   isBidWinner?: boolean,
+  skill: SkillLevel = 'hard',
 ): Card[] {
   if (trumpSuit === undefined || isBidWinner === undefined) {
     return sampleRandom(hand, count)
+  }
+
+  // Skill 1 (easy): simplified meld-only passing logic matching Python's EasyPlayer
+  if (SKILL_PARAMS[skill].handValuation === 'meld_only') {
+    if (!isBidWinner) {
+      const ranked = [...hand].sort((a, b) => easyCardWorth(a, trumpSuit!) - easyCardWorth(b, trumpSuit!))
+      return ranked.slice(0, count)
+    }
+    // Bidder: ship non-trump 10s first, then lowest-worth filler
+    const pool = [...hand]
+    const chosen = pool.filter((c) => c.suit !== trumpSuit && c.rank === '10').slice(0, count)
+    for (const c of chosen) {
+      const idx = pool.indexOf(c)
+      if (idx !== -1) pool.splice(idx, 1)
+    }
+    if (chosen.length < count) {
+      const filler = [...pool].sort((a, b) => easyCardWorth(a, trumpSuit!) - easyCardWorth(b, trumpSuit!))
+      chosen.push(...filler.slice(0, count - chosen.length))
+    }
+    return chosen
   }
 
   const category: PassCategory = trumpSuit === Suit.Spades || trumpSuit === Suit.Diamonds ? 'DS' : 'HC'

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -1,0 +1,24 @@
+import type { SkillLevel } from '../persistence/options'
+
+/** Ported from Python's GENERAL_STRATEGY_SKILL_PARAMS (pinochle_engine.py:1917).
+ *  Controls which hand-valuation formula the AI uses in bidding. */
+export type HandValuation = 'meld_only' | 'base_bid'
+
+export interface SkillParams {
+  readonly handValuation: HandValuation
+}
+
+export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
+  easy: { handValuation: 'meld_only' },
+  medium: { handValuation: 'base_bid' },
+  hard: { handValuation: 'base_bid' },
+  proficient: { handValuation: 'base_bid' },
+  expert: { handValuation: 'base_bid' },
+}
+
+/** Flat trick-point estimate for meld-only bidding (skill 1), matching
+ *  Python's `MELD_ONLY_TRICK_ESTIMATE` / `EASY_FLAT_TRICK_ESTIMATE`. */
+export const MELD_ONLY_TRICK_ESTIMATE = 60
+
+/** Uniform noise range +/- for meld-only bidding ceiling. */
+export const MELD_ONLY_BID_NOISE = 30

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -7,8 +7,10 @@
 // tracker instance. Its public shape is kept deliberately small -
 // `record` / `playedCount` are all either strategy currently needs.
 
+import type { SkillLevel } from '../persistence/options'
 import { type Card, RANK_VALUE, RANKS, type Rank, type Suit } from './card'
 import type { PlayerIndex, TrickPlay } from './trick'
+import { SKILL_PARAMS } from './skills'
 
 const POINT_RANKS = new Set(['A', '10', 'K'])
 
@@ -78,8 +80,17 @@ function isUnsecuredAce(card: Card, hand: readonly Card[], tracker: PlayTracker)
  *
  * @param isBidderFirstLead - When true (bidder opening the first trick of the
  *   round), forces a trump lead if the player has any trump cards remaining.
+ * @param skill - Skill level. Skill 1 (easy) uses simplified logic: prefers
+ *   low non-trump non-count cards. Defaults to 'hard' (full Proficient cascade).
  */
-export function chooseLeadCard(hand: readonly Card[], trump: Suit, tracker: PlayTracker, isBidderFirstLead = false): Card {
+export function chooseLeadCard(hand: readonly Card[], trump: Suit, tracker: PlayTracker, isBidderFirstLead = false, skill: SkillLevel = 'hard'): Card {
+  // Skill 1 (easy): simplified leading — prefer low non-trump non-count cards
+  if (SKILL_PARAMS[skill].handValuation === 'meld_only') {
+    const safeLeads = hand.filter((c) => c.suit !== trump && c.rank !== 'A' && c.rank !== '10' && c.rank !== 'K')
+    const pool = safeLeads.length > 0 ? safeLeads : hand
+    return pool.reduce((lowest, c) => (c.rankValue < lowest.rankValue ? c : lowest))
+  }
+
   // Bidder's first lead must be trump if they have any — rule #82
   if (isBidderFirstLead) {
     const trumps = hand.filter((c) => c.suit === trump)
@@ -176,6 +187,9 @@ function currentWinner(trickPlays: readonly TrickPlay[], trump: Suit): TrickPlay
  *   - Sluff (void in both lead suit and trump): free choice across
  *     suits - work toward voiding the shortest suit, lowest rank within
  *     it.
+ *
+ * @param skill Skill level. Skill 1 (easy) plays the lowest legal card.
+ *   Defaults to 'hard' (full Proficient tiered logic).
  */
 export function chooseFollowCard(
   hand: readonly Card[],
@@ -184,8 +198,14 @@ export function chooseFollowCard(
   trump: Suit,
   myTeamPlayers: readonly PlayerIndex[],
   tracker?: PlayTracker,
+  skill: SkillLevel = 'hard',
 ): Card {
   if (legalMoves.length === 1) return legalMoves[0]
+
+  // Skill 1 (easy): always play the lowest legal card
+  if (SKILL_PARAMS[skill].handValuation === 'meld_only') {
+    return legalMoves.reduce((lowest, c) => (c.rankValue < lowest.rankValue ? c : lowest))
+  }
 
   const leadSuit = trickPlays.length > 0 ? trickPlays[0].card.suit : undefined
   const winner = trickPlays.length > 0 ? currentWinner(trickPlays, trump) : undefined


### PR DESCRIPTION
Adds AI skill-level options (1-5 mapping to easy/medium/hard/proficient/expert) for opponents and teammate in the web UI.

- **New file:** skills.ts — ported GENERAL_STRATEGY_SKILL_PARAMS table from Python, defining handValuation (meld_only vs ase_bid) per skill level
- **bidding.ts:** chooseBid/chooseTrump accept optional skill param; skill 1 uses meld-only valuation (matching Python's EasyPlayer)
- **passing.ts:** choosePassCards accepts optional skill param; skill 1 uses simplified pass logic
- **tracker.ts:** chooseLeadCard/chooseFollowCard accept optional skill param; skill 1 uses simplified trick-play
- **AuctionFlow.tsx:** passes per-player skill (teammate vs opponent) to AI bidding/trump/passing calls
- **TrickPlayFlow.tsx:** passes per-player skill to AI lead/follow calls

The existing Proficient-tier behavior is preserved as the default for skills 2-5 (ase_bid).