### PR TITLE
feat: make the meld display fit the screen (#94)

### DIFF
--- a/web/src/components/MeldFlow.test.tsx
+++ b/web/src/components/MeldFlow.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Card, Suit } from '../engine/card'
+import type { Hands, TeamId } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+import { MeldFlow } from './MeldFlow'
+
+const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'You', 1: 'West', 2: 'Partner', 3: 'East' }
+const SCORES: Record<TeamId, number> = { 0: 0, 1: 0 }
+const TEAM_NAMES: Record<TeamId, string> = { 0: 'Us', 1: 'Them' }
+
+/** Every seat gets a royal marriage in hearts plus filler, so all four have
+ * meld to show — the case that used to overflow the panel. */
+function handsWithMeld(): Hands {
+  const seat = (n: number): Card[] => [
+    new Card(Suit.Hearts, 'K', n % 2 === 0 ? 1 : 2),
+    new Card(Suit.Hearts, 'Q', n % 2 === 0 ? 1 : 2),
+    new Card(Suit.Spades, 'A', 1),
+    new Card(Suit.Clubs, '9', 1),
+  ]
+  return [seat(0), seat(1), seat(2), seat(3)] as Hands
+}
+
+function renderMeld() {
+  return render(
+    <MeldFlow
+      hands={handsWithMeld()}
+      trumpSuit={Suit.Hearts}
+      bidWinner={0}
+      bid={320}
+      seatNames={SEAT_NAMES}
+      humanPlayer={0}
+      scoresByTeam={SCORES}
+      teamNames={TEAM_NAMES}
+      dealer={3}
+      onComplete={vi.fn()}
+    />,
+  )
+}
+
+afterEach(cleanup)
+
+describe('MeldFlow', () => {
+  // #94: the panel used to stack all four seats in one column, growing to
+  // roughly twice the viewport height and pushing Continue off-screen.
+  it('lays meld out in one column per team, each holding that team‘s two seats', () => {
+    renderMeld()
+
+    const us = screen.getByRole('region', { name: 'Us meld' })
+    const them = screen.getByRole('region', { name: 'Them meld' })
+
+    // Seats 0 and 2 are one team; 1 and 3 the other.
+    expect(within(us).getByText(/You/)).toBeTruthy()
+    expect(within(us).getByText(/Partner/)).toBeTruthy()
+    expect(within(them).getByText(/West/)).toBeTruthy()
+    expect(within(them).getByText(/East/)).toBeTruthy()
+
+    // Neither team's seats leak into the other column.
+    expect(within(us).queryByText(/West/)).toBeNull()
+    expect(within(them).queryByText(/You/)).toBeNull()
+  })
+
+  it('renders meld cards at the compact size so four seats fit on screen (#94)', () => {
+    renderMeld()
+    const cards = screen.getAllByRole('img').filter((el) => el.closest('section[aria-label$="meld"]'))
+    expect(cards.length).toBeGreaterThan(0)
+    for (const card of cards) {
+      expect(card.className).toContain('w-9')
+      expect(card.className).not.toContain('w-20')
+    }
+  })
+
+  it('caps the panel height and scrolls the meld list, keeping Continue outside the scroll area', () => {
+    const { container } = renderMeld()
+    const panel = container.querySelector('.max-h-\\[85vh\\]')
+    expect(panel).not.toBeNull()
+
+    const scroller = panel!.querySelector('.overflow-y-auto')
+    expect(scroller).not.toBeNull()
+
+    const continueBtn = screen.getByRole('button', { name: 'Continue' })
+    expect(scroller!.contains(continueBtn)).toBe(false)
+    expect(panel!.contains(continueBtn)).toBe(true)
+  })
+})

--- a/web/src/components/MeldFlow.tsx
+++ b/web/src/components/MeldFlow.tsx
@@ -27,19 +27,67 @@ export interface MeldFlowProps {
 
 function MeldGroupList({ groups }: { groups: MeldCardsResult['groups'] }) {
   return (
-    <div className="mt-1 space-y-1">
+    <div className="mt-1 space-y-1.5">
       {groups.map((g, i) => (
-        <div key={i} className="flex items-center gap-2 text-sm">
-          <span className="text-neutral-500">{g.name}:</span>
-          <span className="font-semibold">{g.points}</span>
-          <div className="flex gap-0.5">
+        <div key={i} className="text-xs">
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-neutral-500">{g.name}</span>
+            <span className="font-semibold">{g.points}</span>
+          </div>
+          <div className="mt-0.5 flex flex-wrap gap-0.5">
             {sortHandForDisplay(g.cards).map((c, j) => (
-              <PlayingCard key={j} suit={c.suit} rank={c.rank} className="w-6" />
+              <PlayingCard key={j} suit={c.suit} rank={c.rank} size="sm" />
             ))}
           </div>
         </div>
       ))}
     </div>
+  )
+}
+
+/** One team's column: both partners' melds, stacked under the team total. */
+function TeamMeldColumn({
+  teamName,
+  total,
+  players,
+  seatNames,
+  humanPlayer,
+  meldFor,
+}: {
+  teamName: string
+  total: number
+  players: readonly PlayerIndex[]
+  seatNames: Record<PlayerIndex, string>
+  humanPlayer: PlayerIndex
+  meldFor: (p: PlayerIndex) => MeldCardsResult
+}) {
+  return (
+    <section className="min-w-0" aria-label={`${teamName} meld`}>
+      <h4 className="flex items-baseline justify-between gap-2 border-b border-neutral-300 pb-1 text-sm font-bold">
+        <span className="truncate">{teamName}</span>
+        <span className="shrink-0 text-green-700">{total}</span>
+      </h4>
+      {players.map((p) => {
+        const md = meldFor(p)
+        const playerTotal = md.groups.reduce((s, g) => s + g.points, 0)
+        return (
+          <div key={p} className="mt-2">
+            <p className="flex items-baseline justify-between gap-2 text-xs font-semibold text-neutral-700">
+              <span className="truncate">
+                {seatNames[p]}
+                {p === humanPlayer && ' (you)'}
+              </span>
+              <span className="shrink-0 text-neutral-500">{playerTotal}</span>
+            </p>
+            {md.groups.length > 0 ? (
+              <MeldGroupList groups={md.groups} />
+            ) : (
+              <p className="mt-0.5 text-xs text-neutral-400">No melds</p>
+            )}
+          </div>
+        )
+      })}
+    </section>
   )
 }
 
@@ -101,40 +149,38 @@ export function MeldFlow({
 
   const humanTotal = humanMeld.groups.reduce((s, g) => s + g.points, 0)
 
+  // Two columns, one per team (#94). The meld list scrolls inside the panel
+  // rather than growing it, so the panel always fits the viewport and the
+  // Continue/Fold buttons stay reachable — previously four stacked players
+  // pushed the panel to roughly twice the screen height and put Continue
+  // off-screen entirely.
   const overlay = (
-    <div className="w-full max-w-sm rounded-lg bg-white p-5 text-neutral-900 shadow-xl">
-      <h3 className="text-base font-bold">Meld Declaration</h3>
+    // The Table overlay wrapper is inline-block, so it shrink-wraps its child
+    // and `w-full max-w-*` would collapse to the intrinsic width. Give the
+    // panel a definite width instead, clamped to the viewport on small screens.
+    <div className="flex max-h-[85vh] w-[min(44rem,calc(100vw-2rem))] flex-col rounded-lg bg-white p-4 text-neutral-900 shadow-xl">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-base font-bold">Meld Declaration</h3>
+        <p className="text-sm text-neutral-600">
+          Your melds: <span className="font-bold text-green-700">{humanTotal}</span>
+        </p>
+      </div>
 
-      <p className="mt-2 text-sm text-neutral-600">
-        Your melds: <span className="font-bold text-green-700">{humanTotal}</span> points
-      </p>
-      {humanMeld.groups.length > 0 ? (
-        <div className="mt-2">
-          <MeldGroupList groups={humanMeld.groups} />
-        </div>
-      ) : (
-        <p className="mt-2 text-sm text-neutral-500">No melds detected in your hand.</p>
-      )}
+      <div className="mt-3 grid min-h-0 flex-1 grid-cols-2 gap-x-4 gap-y-2 overflow-y-auto">
+        {([0, 1] as TeamId[]).map((team) => (
+          <TeamMeldColumn
+            key={team}
+            teamName={teamNames[team]}
+            total={allMeldPoints[team]}
+            players={([0, 1, 2, 3] as PlayerIndex[]).filter((p) => teamOf(p) === team)}
+            seatNames={seatNames}
+            humanPlayer={humanPlayer}
+            meldFor={(p) => allMeldData[p]}
+          />
+        ))}
+      </div>
 
-      {[0, 1, 2, 3]
-        .filter((p) => p !== humanPlayer)
-        .map((p) => {
-          const md = allMeldData[p as PlayerIndex]
-          return (
-            <div key={p} className="mt-4 border-t border-neutral-200 pt-3">
-              <p className="text-sm font-semibold text-neutral-700">
-                {seatNames[p as PlayerIndex]} — {md.groups.reduce((s, g) => s + g.points, 0)} meld points
-              </p>
-              {md.groups.length > 0 ? (
-                <MeldGroupList groups={md.groups} />
-              ) : (
-                <p className="text-sm text-neutral-500">No melds</p>
-              )}
-            </div>
-          )
-        })}
-
-      <div className="mt-5 flex gap-2">
+      <div className="mt-4 flex shrink-0 gap-2">
         <button
           type="button"
           onClick={() => onComplete(allMeldPoints)}

--- a/web/src/components/PlayingCard.test.tsx
+++ b/web/src/components/PlayingCard.test.tsx
@@ -25,6 +25,30 @@ describe('PlayingCard', () => {
     expect(screen.queryByText('Q')).toBeNull()
   })
 
+  // #94: width used to be passed via className, where Tailwind resolved the
+  // conflict with the base `w-20` by stylesheet order — so `w-6` lost and meld
+  // cards silently rendered full size. Width now comes from `size` alone, so
+  // exactly one width utility is ever emitted.
+  it('emits exactly one width utility, chosen by size', () => {
+    const widthsFor = (el: Element) => (el.className.match(/(^|\s)w-\S+/g) ?? []).map((s) => s.trim())
+
+    const { container: sm } = render(<PlayingCard suit={Suit.Spades} rank="A" size="sm" />)
+    const { container: md } = render(<PlayingCard suit={Suit.Spades} rank="A" size="md" />)
+    const { container: lg } = render(<PlayingCard suit={Suit.Spades} rank="A" />)
+
+    expect(widthsFor(sm.firstElementChild!)).toEqual(['w-9'])
+    expect(widthsFor(md.firstElementChild!)).toEqual(['w-[60px]'])
+    expect(widthsFor(lg.firstElementChild!)).toEqual(['w-20'])
+  })
+
+  it('keeps a caller className from introducing a competing width', () => {
+    const { container } = render(<PlayingCard suit={Suit.Spades} rank="A" size="sm" className="-ml-2" />)
+    const cls = container.firstElementChild!.className
+    expect(cls).toContain('w-9')
+    expect(cls).toContain('-ml-2')
+    expect(cls.match(/(^|\s)w-\S+/g)!.map((s) => s.trim())).toEqual(['w-9'])
+  })
+
   it('renders every suit and rank without throwing', () => {
     const suits = [Suit.Spades, Suit.Hearts, Suit.Diamonds, Suit.Clubs]
     const ranks = ['9', 'J', 'Q', 'K', '10', 'A'] as const

--- a/web/src/components/PlayingCard.tsx
+++ b/web/src/components/PlayingCard.tsx
@@ -1,11 +1,34 @@
 import { type Rank, type Suit } from '../engine/card'
 import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
 
+/**
+ * Card sizes, as matched sets of width + corner/centre type scale.
+ *
+ * Size is a prop rather than something a caller passes through `className`
+ * because Tailwind resolves conflicting utilities by their order in the
+ * generated stylesheet, not by their order in the class attribute. A caller
+ * passing `w-6` alongside the base `w-20` silently lost — `w-6` sorts first,
+ * so `w-20` won and the card rendered full size (#94). Keeping width here
+ * means there is never a competing utility to lose to, and the type scale
+ * stays proportional to the card instead of overflowing it.
+ */
+const CARD_SIZES = {
+  /** Compact, for dense read-only displays like meld declaration. */
+  sm: { width: 'w-9', corner: 'text-[0.5rem]', cornerPos: 'top-0.5 left-1', centre: 'text-lg' },
+  /** The fanned hand in a seat. */
+  md: { width: 'w-[60px]', corner: 'text-sm', cornerPos: 'top-1 left-1.5', centre: 'text-3xl' },
+  /** Full size — trick area, pass selector, pass reveal. */
+  lg: { width: 'w-20', corner: 'text-sm', cornerPos: 'top-1 left-1.5', centre: 'text-3xl' },
+} as const
+
+export type PlayingCardSize = keyof typeof CARD_SIZES
+
 export interface PlayingCardProps {
   suit: Suit
   rank: Rank
   /** Render the card back instead of its face. */
   faceDown?: boolean
+  size?: PlayingCardSize
   className?: string
 }
 
@@ -15,35 +38,41 @@ export interface PlayingCardProps {
  * change color with the room lights, and it keeps contrast high against
  * either a light or dark table background by construction.
  */
-export function PlayingCard({ suit, rank, faceDown, className = '' }: PlayingCardProps) {
+export function PlayingCard({ suit, rank, faceDown, size = 'lg', className = '' }: PlayingCardProps) {
+  const { width, corner, cornerPos, centre } = CARD_SIZES[size]
+
   if (faceDown) {
     return (
       <div
         role="img"
         aria-label="face-down card"
-        className={`aspect-5/7 w-20 rounded-lg border border-blue-950 bg-blue-800 bg-[repeating-linear-gradient(45deg,theme(colors.blue.700)_0,theme(colors.blue.700)_4px,theme(colors.blue.800)_4px,theme(colors.blue.800)_8px)] shadow-sm ${className}`}
+        className={`aspect-5/7 ${width} rounded-lg border border-blue-950 bg-blue-800 bg-[repeating-linear-gradient(45deg,theme(colors.blue.700)_0,theme(colors.blue.700)_4px,theme(colors.blue.800)_4px,theme(colors.blue.800)_8px)] shadow-sm ${className}`}
       />
     )
   }
 
   const glyph = SUIT_GLYPH[suit]
   const colorClass = RED_SUITS.includes(suit) ? 'text-red-600' : 'text-neutral-900'
+  // The compact size has no room for the second, rotated corner index.
+  const showRotatedCorner = size !== 'sm'
 
   return (
     <div
       role="img"
       aria-label={`${rank} of ${suit}`}
-      className={`relative aspect-5/7 w-20 rounded-lg border border-neutral-300 bg-neutral-50 shadow-sm select-none ${colorClass} ${className}`}
+      className={`relative aspect-5/7 ${width} rounded-lg border border-neutral-300 bg-neutral-50 shadow-sm select-none ${colorClass} ${className}`}
     >
-      <div className="absolute top-1 left-1.5 flex flex-col items-center text-sm leading-none font-semibold">
+      <div className={`absolute ${cornerPos} flex flex-col items-center ${corner} leading-none font-semibold`}>
         <span>{rank}</span>
         <span>{glyph}</span>
       </div>
-      <div className="absolute right-1.5 bottom-1 flex rotate-180 flex-col items-center text-sm leading-none font-semibold">
-        <span>{rank}</span>
-        <span>{glyph}</span>
-      </div>
-      <div className="flex h-full w-full items-center justify-center text-3xl">{glyph}</div>
+      {showRotatedCorner && (
+        <div className={`absolute right-1.5 bottom-1 flex rotate-180 flex-col items-center ${corner} leading-none font-semibold`}>
+          <span>{rank}</span>
+          <span>{glyph}</span>
+        </div>
+      )}
+      <div className={`flex h-full w-full items-center justify-center ${centre}`}>{glyph}</div>
     </div>
   )
 }

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -105,7 +105,7 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
         <div className="flex justify-center gap-1 overflow-x-auto">
           {sortHandForDisplay(seat.hand).map((card, i) => (
             <div key={i} className="-ml-10 first:ml-0">
-              <PlayingCard suit={card.suit} rank={card.rank} className="w-[60px]" />
+              <PlayingCard suit={card.suit} rank={card.rank} size="md" />
             </div>
           ))}
         </div>


### PR DESCRIPTION
Closes #94. Stacked on #98 — retarget to `main` once that merges.

## The measurement

On the running app at 1280×720, the meld panel was **1463px tall** — more than twice the viewport — clipped 372px at *both* top and bottom, with Continue stranded at y=1032 where it could not be clicked.

## Root cause was a silently dead class

MeldFlow asked for small cards with `<PlayingCard className="w-6" />`, but `PlayingCard` carries `w-20` in its own base classes. Tailwind resolves conflicting utilities by their order in the **generated stylesheet**, not by order in the class attribute — `w-6` sorts before `w-20`, so `w-20` won and meld cards rendered at the full 80px. Confirmed in the browser:

```
w-20 + w-[60px]  ->  60px   (works — arbitrary values are emitted later)
w-20 + w-6       ->  80px   (silently ignored)
```

So the meld cards had never actually been shrunk.

## Changes

- **`PlayingCard` takes a `size` prop** (`'sm' | 'md' | 'lg'`) pairing width with a matching type scale, so exactly one width utility is ever emitted and there is nothing for a caller to lose to. `md`/`lg` reproduce today's rendering exactly — only the new `sm` is compact.
- **Two columns, one per team**, each headed by team name and total, with both partners beneath.
- **The list scrolls inside a `max-h-[85vh]` panel**, with Continue/Fold pinned outside the scroll area so they are always reachable. This is what actually guarantees "fits nicely" for any hand, rather than relying on a card size that happens to be small enough.
- Panel takes a definite width rather than `w-full max-w-2xl`, since Table's overlay wrapper is `inline-block` and shrink-wraps its child.

Per your note I treated 50% as a target rather than a requirement — the panel ends up at ~42% of its old height and, more importantly, can no longer overflow at all.

## Verified in the running app

| | before | after |
|---|---|---|
| panel height | 1463px | **612px** |
| fits viewport | no (744px clipped) | **yes** |
| Continue reachable | no | **yes** |
| meld card width | 80px | **36px** |
| layout | 1 column, 4 seats stacked | **2 columns, one per team** (321px each) |

Also checked at mobile width — panel fits, list scrolls, nothing clipped, no horizontal page scroll. Table seats still render at 80px/60px, unchanged.

## Verification

- `npm run build` clean; `npx vitest run` 265 passed; `python -m pytest` 92 passed; `npm run lint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)