### PR TITLE
feat: auction-constrained determinization, measured and left off (#101)

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -2011,12 +2011,24 @@ GENERAL_STRATEGY_SKILL_PARAMS = {
     # fold_samples: sample count for the concede decision (#100). 0 means the
     #   skill level never folds - it has no rollout budget to judge with, and
     #   a guessed threshold is what #106 exists to remove.
+    # use_auction_evidence: reject determinized deals that contradict what the
+    #   other seats did in the auction (#101). OFF everywhere for now. The
+    #   constraint provably works - a sampled partner's ceiling moves from 276
+    #   to 338 once partner has bid 330 - but A/B'd over 50 paired deals it
+    #   produced no measurable improvement (46-54 on games, margin -1 with a
+    #   95% CI of -109 to +102, make rate 54.4% vs 55.3%) while running about
+    #   4x slower. The likely reason is that the bid decision is a coarse
+    #   argmax over [pass, next_bid], so a sharper model of partner shifts both
+    #   options together and rarely flips the choice. Worth re-measuring once
+    #   #103 makes EV(pass) a real rollout, since that gives the constraint a
+    #   richer comparison to affect; enabling it before then would just be
+    #   paying 4x for nothing.
     # deception: whether choose_expert_follow_card gets a deception_evaluator.
-    1: {"hand_valuation": "meld_only",   "pass_logic": "easy",      "trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "deception": False},
-    2: {"hand_valuation": "base_bid",    "pass_logic": "proficient","trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "deception": False},
-    3: {"hand_valuation": "base_bid",    "pass_logic": "proficient","trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "deception": False},
-    4: {"hand_valuation": "rollout_ev",  "pass_logic": "expert",    "trick_logic": "expert",     "use_rollout": True,  "bid_samples": 20, "pass_samples": 15, "trick_samples": 10, "fold_samples": 20, "deception": False},
-    5: {"hand_valuation": "rollout_ev",  "pass_logic": "expert",    "trick_logic": "expert",     "use_rollout": True,  "bid_samples": 50, "pass_samples": 30, "trick_samples": 25, "fold_samples": 50, "deception": False},
+    1: {"hand_valuation": "meld_only",   "pass_logic": "easy",      "trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "use_auction_evidence": False, "deception": False},
+    2: {"hand_valuation": "base_bid",    "pass_logic": "proficient","trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "use_auction_evidence": False, "deception": False},
+    3: {"hand_valuation": "base_bid",    "pass_logic": "proficient","trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "use_auction_evidence": False, "deception": False},
+    4: {"hand_valuation": "rollout_ev",  "pass_logic": "expert",    "trick_logic": "expert",     "use_rollout": True,  "bid_samples": 20, "pass_samples": 15, "trick_samples": 10, "fold_samples": 20, "use_auction_evidence": False, "deception": False},
+    5: {"hand_valuation": "rollout_ev",  "pass_logic": "expert",    "trick_logic": "expert",     "use_rollout": True,  "bid_samples": 50, "pass_samples": 30, "trick_samples": 25, "fold_samples": 50, "use_auction_evidence": False, "deception": False},
 }
 
 MELD_ONLY_TRICK_ESTIMATE = EASY_FLAT_TRICK_ESTIMATE  # same flat, non-hand-shape-aware stand-in EasyPlayer uses for skill 1's meld-only bidding (doc Section 8) - reused rather than redefined, since it's the same judgment call.
@@ -2104,6 +2116,64 @@ class GeneralStrategy(Player):
             return OPENING_BID if ceiling >= OPENING_BID else None
         return next_bid if next_bid <= ceiling else None
 
+    def _auction_evidence(self, context):
+        """
+        Translate what the other three seats have done this auction into the
+        rollout's seat-key space, so determinized deals that contradict the
+        bidding can be rejected (issue #101).
+
+        Seat keys mirror `estimate_bid_time`'s fixed seating: my partner is
+        "partner", and the two opponents are "opp_left"/"opp_right".
+
+        The two opponents are keyed in the order they first acted, which is
+        not necessarily their true seating relative to me - `context` carries
+        the auction record but no seat indices. Both opponents get constrained
+        by their own bidding either way, so the only thing this can get wrong
+        is which side of the table a given constrained hand sits on. That
+        shifts trick-play order inside the rollout without changing the hand
+        strength being modelled. Worth tightening if seat indices ever reach
+        here; not worth opening a second seating channel for now.
+        """
+        from pinochle_rollout import AuctionEvidence
+
+        if self.team is None:
+            return None
+
+        partner = next((p for p in self.team.players if p is not self), None)
+
+        # Opponents are everyone who has acted this auction and is neither me
+        # nor my partner. Derived from the auction record rather than from the
+        # team objects, so a seat that has not acted yet stays unconstrained.
+        seen = []
+        for player, _amount in context.get("bid_history", []):
+            if player not in seen:
+                seen.append(player)
+        for player, _amount in context.get("pass_history", []):
+            if player not in seen:
+                seen.append(player)
+        opponents = [p for p in seen if p is not self and p is not partner]
+
+        key_for = {}
+        if partner is not None:
+            key_for[id(partner)] = "partner"
+        for opponent, key in zip(opponents, ("opp_left", "opp_right")):
+            key_for[id(opponent)] = key
+
+        highest_bid = {}
+        for player, amount in context.get("bid_history", []):
+            key = key_for.get(id(player))
+            if key is not None:
+                highest_bid[key] = max(highest_bid.get(key, 0), amount)
+
+        declined = {}
+        for player, amount in context.get("pass_history", []):
+            key = key_for.get(id(player))
+            if key is not None:
+                declined[key] = min(declined.get(key, amount), amount)
+
+        evidence = AuctionEvidence(highest_bid=highest_bid, declined=declined)
+        return evidence if evidence else None
+
     def _rollout_ev_bid(self, current_bid, min_increment, context, params):
         """Skill 4-5: replace the static ceiling comparison with simulated
         EV (doc Section 1), via pinochle_rollout.choose_bid_by_ev built on
@@ -2135,6 +2205,7 @@ class GeneralStrategy(Player):
         best_bid, _best_ev, _all_evs = choose_bid_by_ev(
             self.hand, trump, [None, next_bid],
             num_samples=params["bid_samples"], rng=self.rng,
+            evidence=self._auction_evidence(context) if params.get("use_auction_evidence") else None,
         )
         return best_bid
 
@@ -2471,6 +2542,11 @@ class Round:
         passes = 0
         passes_so_far = 0
         bid_history = []  # list of (player, amount)
+        # (player, the minimum bid they declined) - richer than a bare list of
+        # who passed, because "declined to bid 340" bounds a hand from above
+        # while "declined to bid 300" says something much stronger. Issue #101
+        # uses this to reject determinized deals that contradict the auction.
+        pass_history = []
         dealer = self.players[self.dealer_index]
 
         while passes < 3:
@@ -2481,6 +2557,8 @@ class Round:
                     "ever_bid": ever_bid,
                     "passes_so_far": passes_so_far,
                     "bid_history": bid_history,
+                    "pass_history": pass_history,
+                    "passed_players": [p for p, _ in pass_history],
                     "dealer": dealer,
                     "teams": self.teams,
                 }
@@ -2494,6 +2572,7 @@ class Round:
                     active[idx] = False
                     passes += 1
                     passes_so_far += 1
+                    pass_history.append((player, min_bid))
                     if sum(active) == 1 and ever_bid:
                         break
             idx = (idx + 1) % 4

--- a/pinochle_rollout.py
+++ b/pinochle_rollout.py
@@ -50,6 +50,7 @@ import random
 
 from pinochle_engine import (
     Card,
+    best_base_bid,
     PlayTracker,
     Player,
     RANKS,
@@ -189,6 +190,97 @@ def sample_bid_time_deal(my_hand, rng=None):
     return deal_unseen_cards(
         unseen, [("partner", 12), ("opp_left", 12), ("opp_right", 12)], rng=rng,
     )
+
+
+# ---------------------------------------------------------------------------
+# Auction-constrained determinization (issue #101, epic #106).
+#
+# A uniform deal assumes every other seat holds a random hand, even after the
+# auction has said otherwise. If partner opened at 320 they are very unlikely
+# to be sitting on no meld and no aces, but uniform sampling keeps generating
+# exactly that, dragging the estimate toward hands that could not have
+# produced the bidding actually observed.
+#
+# Consistency is judged with `best_base_bid` - the same valuation the bidding
+# AI uses to decide its own bids - so the model of "what a bid means" cannot
+# drift away from what the bidders are actually doing.
+# ---------------------------------------------------------------------------
+
+# How far a sampled hand may fall short of a bid it supposedly made (or exceed
+# a level it declined) before the deal is rejected. Not zero: bidders are
+# speculative, positional rules make them open light, and `best_base_bid` is
+# an estimate rather than the last word - so a hard edge would reject far too
+# much and bias the sample the other way.
+AUCTION_CONSISTENCY_SLACK = 40
+
+
+class AuctionEvidence:
+    """
+    What each unseen seat did in the auction, in the rollout's own seat-key
+    space ("partner" / "opp_left" / "opp_right").
+
+    `highest_bid` maps a seat key to the largest amount that seat actually
+    bid; `declined` maps a seat key to the smallest amount it refused to bid.
+    Either may be absent for a seat that has not acted yet - an unconstrained
+    seat is simply never rejected, which is the honest treatment of "we know
+    nothing about them" rather than a special case.
+    """
+
+    def __init__(self, highest_bid=None, declined=None):
+        self.highest_bid = dict(highest_bid or {})
+        self.declined = dict(declined or {})
+
+    def __bool__(self):
+        return bool(self.highest_bid or self.declined)
+
+    def is_consistent(self, dealt, slack=AUCTION_CONSISTENCY_SLACK):
+        """
+        True if every constrained seat's sampled hand could plausibly have
+        produced that seat's auction behaviour.
+
+        A seat that bid X should hold a hand worth roughly X or better; a seat
+        that declined X should hold one worth less than X. Both are checked
+        with `slack`, for the reasons in the constant's comment above.
+        """
+        for key, amount in self.highest_bid.items():
+            hand = dealt.get(key)
+            if hand is None:
+                continue
+            _trump, ceiling, _breakdown = best_base_bid(hand)
+            if ceiling < amount - slack:
+                return False
+
+        for key, amount in self.declined.items():
+            hand = dealt.get(key)
+            if hand is None:
+                continue
+            _trump, ceiling, _breakdown = best_base_bid(hand)
+            if ceiling >= amount + slack:
+                return False
+
+        return True
+
+
+def sample_consistent_deal(sample_fn, evidence, rng=None, max_attempts=40):
+    """
+    Draw a determinized deal that does not contradict the auction, by
+    rejection sampling on top of any existing sampler.
+
+    Returns `(dealt, attempts, accepted)`. `accepted` is False when
+    `max_attempts` was exhausted, in which case the last draw is returned
+    anyway: a rollout built on a slightly implausible deal is a far smaller
+    error than no rollout at all, and looping until something fits risks
+    hanging on evidence no deal can satisfy. Callers get `accepted` so a
+    constraint that is too tight shows up as a number rather than as
+    mysteriously slow, unexplained behaviour.
+    """
+    rng = rng if rng is not None else random
+    dealt = None
+    for attempt in range(1, max_attempts + 1):
+        dealt = sample_fn(rng)
+        if not evidence or evidence.is_consistent(dealt):
+            return dealt, attempt, True
+    return dealt, max_attempts, False
 
 
 def sample_return_pass_deal(my_hand, partner_known_count=9, rng=None):
@@ -416,7 +508,7 @@ def _build_rollout_players(seat_names, hands):
     return players
 
 
-def estimate_bid_time(hand, trump, bid, num_samples=150, rng=None):
+def estimate_bid_time(hand, trump, bid, num_samples=150, rng=None, evidence=None):
     """
     Bid-time Monte Carlo estimate (Section 0/1). `hand` (12 known cards)
     is seated as the bid winner; partner and both opponents get randomly
@@ -424,14 +516,31 @@ def estimate_bid_time(hand, trump, bid, num_samples=150, rng=None):
     real return pass, and real trick play for every sample, applying the
     Auto-SET guard before any 12-trick rollout.
 
+    `evidence`, if supplied, is an `AuctionEvidence` (issue #101): sampled
+    deals that contradict what the other seats did in the auction are
+    rejected and redrawn. None keeps the uniform sampling this function has
+    always done.
+
     Returns the aggregate dict from `monte_carlo_rollout` (p_make,
     expected_bidding_points, expected_defending_points, auto_set_rate,
-    plus the raw per-sample results).
+    plus the raw per-sample results), plus `evidence_acceptance_rate` and
+    `evidence_attempts_per_sample` when `evidence` was supplied - a
+    constraint too tight to satisfy should be visible as a number, not
+    inferred from the run being slow.
     """
     rng = rng if rng is not None else random
+    rejection_stats = {"attempts": 0, "accepted": 0, "samples": 0}
 
     def sample_fn(active_rng):
-        return sample_bid_time_deal(hand, rng=active_rng)
+        if not evidence:
+            return sample_bid_time_deal(hand, rng=active_rng)
+        dealt, attempts, accepted = sample_consistent_deal(
+            lambda r: sample_bid_time_deal(hand, rng=r), evidence, rng=active_rng,
+        )
+        rejection_stats["attempts"] += attempts
+        rejection_stats["accepted"] += 1 if accepted else 0
+        rejection_stats["samples"] += 1
+        return dealt
 
     def build_fn(dealt):
         players = _build_rollout_players(
@@ -440,10 +549,19 @@ def estimate_bid_time(hand, trump, bid, num_samples=150, rng=None):
         )
         return players, players[0]
 
-    return monte_carlo_rollout(
+    aggregate = monte_carlo_rollout(
         sample_fn, build_fn, trump, bid, num_samples,
         rollout_kwargs={"passing": "both"}, rng=rng,
     )
+
+    if evidence and rejection_stats["samples"]:
+        aggregate["evidence_acceptance_rate"] = (
+            rejection_stats["accepted"] / rejection_stats["samples"]
+        )
+        aggregate["evidence_attempts_per_sample"] = (
+            rejection_stats["attempts"] / rejection_stats["samples"]
+        )
+    return aggregate
 
 
 def estimate_return_pass(hand, trump, bid, num_samples=300, rng=None):
@@ -483,7 +601,7 @@ def estimate_return_pass(hand, trump, bid, num_samples=300, rng=None):
 # as the fast-path prior for those tiers, per the doc).
 # ---------------------------------------------------------------------------
 
-def bid_ev(hand, trump, bid, num_samples=150, rng=None):
+def bid_ev(hand, trump, bid, num_samples=150, rng=None, evidence=None):
     """
     Section 1's formula:
 
@@ -513,7 +631,8 @@ def bid_ev(hand, trump, bid, num_samples=150, rng=None):
     no sample made the bid), so callers/tests can inspect the Monte Carlo
     detail behind the number rather than just the final float.
     """
-    diagnostics = estimate_bid_time(hand, trump, bid, num_samples=num_samples, rng=rng)
+    diagnostics = estimate_bid_time(hand, trump, bid, num_samples=num_samples, rng=rng,
+                                    evidence=evidence)
     p_make = diagnostics["p_make"]
     p_fail = 1.0 - p_make
 
@@ -528,7 +647,7 @@ def bid_ev(hand, trump, bid, num_samples=150, rng=None):
     return ev, diagnostics
 
 
-def choose_bid_by_ev(hand, trump, candidate_bids, num_samples=150, rng=None):
+def choose_bid_by_ev(hand, trump, candidate_bids, num_samples=150, rng=None, evidence=None):
     """
     Section 1: "Choose the bid that maximizes EV ... rather than reading
     off a fixed table." Evaluates `bid_ev` for every level in
@@ -561,7 +680,8 @@ def choose_bid_by_ev(hand, trump, candidate_bids, num_samples=150, rng=None):
         if bid is None:
             all_evs[None] = 0.0
         else:
-            all_evs[bid], _ = bid_ev(hand, trump, bid, num_samples=num_samples, rng=rng)
+            all_evs[bid], _ = bid_ev(hand, trump, bid, num_samples=num_samples, rng=rng,
+                                     evidence=evidence)
 
     best_bid = max(all_evs, key=all_evs.get)
     return best_bid, all_evs[best_bid], all_evs

--- a/test_auction_evidence.py
+++ b/test_auction_evidence.py
@@ -1,0 +1,279 @@
+"""
+Tests for issue #101 (epic #106) - constraining rollout determinization to the
+observed auction. Plain assert-based, pytest-discoverable. Covers:
+
+  1. `AuctionEvidence.is_consistent` accepts and rejects the right hands, with
+     the slack that keeps a speculative bidder from being ruled impossible.
+  2. Rejection sampling actually shifts the distribution: sampled partner
+     hands are measurably stronger after partner bids and weaker after partner
+     passes. This is the behavioural claim the issue makes, and it is the one
+     that would silently stop being true if the constraint were mis-wired -
+     the code would still run, just without effect.
+  3. The escape hatch: an unsatisfiable constraint gives up and reports it
+     rather than looping forever.
+  4. The engine records who passed and at what level, and turns that into
+     evidence with the right seat keys.
+  5. Everything stays backwards compatible - no evidence means the old
+     uniform sampling, unchanged.
+"""
+
+import random
+
+from pinochle_engine import (
+    Card,
+    GeneralStrategy,
+    Player,
+    Round,
+    Suit,
+    Team,
+    best_base_bid,
+)
+from pinochle_rollout import (
+    AuctionEvidence,
+    sample_bid_time_deal,
+    sample_consistent_deal,
+)
+
+
+def _marginal_hand():
+    return [
+        Card(Suit.CLUBS, "A", 1), Card(Suit.CLUBS, "K", 1), Card(Suit.CLUBS, "Q", 1),
+        Card(Suit.CLUBS, "9", 1), Card(Suit.SPADES, "A", 1), Card(Suit.SPADES, "K", 1),
+        Card(Suit.DIAMONDS, "K", 1), Card(Suit.DIAMONDS, "J", 1), Card(Suit.HEARTS, "10", 1),
+        Card(Suit.HEARTS, "J", 1), Card(Suit.HEARTS, "9", 1), Card(Suit.SPADES, "9", 1),
+    ]
+
+
+def _strong_hand():
+    trump = Suit.CLUBS
+    return [
+        Card(trump, "A", 1), Card(trump, "10", 1), Card(trump, "K", 1),
+        Card(trump, "Q", 1), Card(trump, "J", 1),
+        Card(Suit.SPADES, "Q", 1), Card(Suit.SPADES, "Q", 2),
+        Card(Suit.DIAMONDS, "J", 1), Card(Suit.DIAMONDS, "J", 2),
+        Card(Suit.SPADES, "A", 1), Card(Suit.DIAMONDS, "A", 1), Card(Suit.HEARTS, "A", 1),
+    ]
+
+
+def _junk_hand():
+    return [
+        Card(Suit.SPADES, "9", 1), Card(Suit.SPADES, "J", 1), Card(Suit.DIAMONDS, "9", 1),
+        Card(Suit.DIAMONDS, "J", 1), Card(Suit.HEARTS, "9", 1), Card(Suit.HEARTS, "J", 1),
+        Card(Suit.CLUBS, "9", 1), Card(Suit.CLUBS, "J", 1), Card(Suit.SPADES, "9", 2),
+        Card(Suit.DIAMONDS, "9", 2), Card(Suit.HEARTS, "9", 2), Card(Suit.CLUBS, "9", 2),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. Consistency rules.
+# ---------------------------------------------------------------------------
+
+def test_empty_evidence_is_falsy_and_accepts_everything():
+    evidence = AuctionEvidence()
+    assert not evidence
+    assert evidence.is_consistent({"partner": _junk_hand()}) is True
+
+
+def test_a_junk_hand_is_inconsistent_with_having_bid_high():
+    evidence = AuctionEvidence(highest_bid={"partner": 400})
+    assert evidence.is_consistent({"partner": _junk_hand()}) is False
+
+
+def test_a_strong_hand_is_consistent_with_having_bid_high():
+    evidence = AuctionEvidence(highest_bid={"partner": 400})
+    assert evidence.is_consistent({"partner": _strong_hand()}) is True
+
+
+def test_a_strong_hand_is_inconsistent_with_having_passed_cheaply():
+    evidence = AuctionEvidence(declined={"partner": 300})
+    assert evidence.is_consistent({"partner": _strong_hand()}) is False
+
+
+def test_a_junk_hand_is_consistent_with_having_passed():
+    evidence = AuctionEvidence(declined={"partner": 300})
+    assert evidence.is_consistent({"partner": _junk_hand()}) is True
+
+
+def test_slack_tolerates_a_bidder_stretching_slightly():
+    """
+    Bidders open light for positional reasons and `best_base_bid` is an
+    estimate, so a hard edge would reject plausible hands and bias the sample
+    the other way. A hand just under its bid must survive.
+    """
+    hand = _marginal_hand()
+    ceiling = best_base_bid(hand)[1]
+    just_over = AuctionEvidence(highest_bid={"partner": ceiling + 20})
+    far_over = AuctionEvidence(highest_bid={"partner": ceiling + 200})
+    assert just_over.is_consistent({"partner": hand}) is True
+    assert far_over.is_consistent({"partner": hand}) is False
+
+
+def test_a_seat_with_no_evidence_is_never_rejected():
+    evidence = AuctionEvidence(highest_bid={"partner": 400})
+    # opp_left is unconstrained, so its junk hand cannot cause a rejection.
+    assert evidence.is_consistent(
+        {"partner": _strong_hand(), "opp_left": _junk_hand()}
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# 2. The distribution actually moves. The point of the issue.
+# ---------------------------------------------------------------------------
+
+def _avg_partner_ceiling(evidence, samples=200, seed=1):
+    rng = random.Random(seed)
+    hand = _marginal_hand()
+    total = 0
+    accepted = 0
+    for _ in range(samples):
+        dealt, _attempts, ok = sample_consistent_deal(
+            lambda r: sample_bid_time_deal(hand, rng=r), evidence, rng=rng,
+        )
+        total += best_base_bid(dealt["partner"])[1]
+        accepted += 1 if ok else 0
+    return total / samples, accepted / samples
+
+
+def test_sampled_partner_is_stronger_after_partner_bids():
+    uniform, _ = _avg_partner_ceiling(AuctionEvidence())
+    after_bid, acceptance = _avg_partner_ceiling(
+        AuctionEvidence(highest_bid={"partner": 330})
+    )
+    assert after_bid > uniform + 25
+    assert acceptance > 0.9
+
+
+def test_sampled_partner_is_weaker_after_partner_passes():
+    uniform, _ = _avg_partner_ceiling(AuctionEvidence())
+    after_pass, acceptance = _avg_partner_ceiling(
+        AuctionEvidence(declined={"partner": 300})
+    )
+    assert after_pass < uniform
+    assert acceptance > 0.9
+
+
+# ---------------------------------------------------------------------------
+# 3. Escape hatch.
+# ---------------------------------------------------------------------------
+
+def test_an_unsatisfiable_constraint_gives_up_and_says_so():
+    """
+    No 12-card hand clears a 5000 bid, so this can never be satisfied. The
+    sampler must return a usable deal and report `accepted=False` rather than
+    loop forever - a slightly implausible rollout beats no rollout, but the
+    caller has to be able to see it happened.
+    """
+    hand = _marginal_hand()
+    impossible = AuctionEvidence(highest_bid={"partner": 5000})
+    dealt, attempts, accepted = sample_consistent_deal(
+        lambda r: sample_bid_time_deal(hand, rng=r), impossible,
+        rng=random.Random(3), max_attempts=5,
+    )
+    assert accepted is False
+    assert attempts == 5
+    assert len(dealt["partner"]) == 12  # still a usable deal
+
+
+def test_acceptance_rate_is_reported_in_bid_time_diagnostics():
+    from pinochle_rollout import estimate_bid_time
+
+    diagnostics = estimate_bid_time(
+        _marginal_hand(), Suit.CLUBS, 300, num_samples=4,
+        rng=random.Random(4), evidence=AuctionEvidence(highest_bid={"partner": 330}),
+    )
+    assert 0.0 <= diagnostics["evidence_acceptance_rate"] <= 1.0
+    assert diagnostics["evidence_attempts_per_sample"] >= 1.0
+
+
+def test_no_evidence_leaves_the_old_uniform_sampling_alone():
+    from pinochle_rollout import estimate_bid_time
+
+    diagnostics = estimate_bid_time(
+        _marginal_hand(), Suit.CLUBS, 300, num_samples=4, rng=random.Random(5),
+    )
+    assert "evidence_acceptance_rate" not in diagnostics
+
+
+# ---------------------------------------------------------------------------
+# 4. The engine records the auction, and translates it into evidence.
+# ---------------------------------------------------------------------------
+
+def _round_of(players):
+    team_a = Team("A", [players[0], players[2]])
+    team_b = Team("B", [players[1], players[3]])
+    players[0].team = players[2].team = team_a
+    players[1].team = players[3].team = team_b
+    return Round(players, [team_a, team_b], dealer_index=3)
+
+
+def test_bidding_records_who_passed_and_at_what_level():
+    seen = {}
+
+    class Recorder(Player):
+        def choose_bid(self, current_bid, min_increment, context=None):
+            seen["pass_history"] = list(context["pass_history"])
+            seen["passed_players"] = list(context["passed_players"])
+            return None  # everyone passes
+
+    players = [Recorder(f"P{i}", None) for i in range(4)]
+    rnd = _round_of(players)
+    rnd._deal()
+    rnd._bidding_loop()
+
+    # The last player asked saw the two seats that passed before it.
+    assert len(seen["pass_history"]) == 2
+    assert seen["passed_players"] == [p for p, _ in seen["pass_history"]]
+    for _player, level in seen["pass_history"]:
+        assert level > 0
+
+
+def test_evidence_maps_partner_and_opponents_to_rollout_seat_keys():
+    players = [GeneralStrategy(f"P{i}", None, skill_level=5, rng=random.Random(i)) for i in range(4)]
+    _round_of(players)
+    me, partner = players[0], players[2]
+    opp_left, opp_right = players[1], players[3]
+
+    context = {
+        "bid_history": [(opp_left, 300), (partner, 320), (partner, 340)],
+        "pass_history": [(opp_right, 350)],
+    }
+    evidence = me._auction_evidence(context)
+
+    assert evidence.highest_bid["partner"] == 340  # highest, not latest-seen
+    assert evidence.highest_bid["opp_left"] == 300
+    assert evidence.declined["opp_right"] == 350
+    assert "me" not in evidence.highest_bid
+
+
+def test_no_auction_activity_yields_no_evidence():
+    players = [GeneralStrategy(f"P{i}", None, skill_level=5, rng=random.Random(i)) for i in range(4)]
+    _round_of(players)
+    assert players[0]._auction_evidence({"bid_history": [], "pass_history": []}) is None
+
+
+def test_auction_evidence_is_off_by_default_at_every_skill_level():
+    """
+    The constraint demonstrably works (see the distribution tests above) but
+    A/B'd over 50 paired deals it produced no measurable improvement while
+    running about 4x slower, so it ships off. This test exists so re-enabling
+    it is a deliberate act with a measurement behind it, not something that
+    drifts back on unnoticed.
+    """
+    from pinochle_engine import GENERAL_STRATEGY_SKILL_PARAMS
+
+    for skill in range(1, 6):
+        assert GENERAL_STRATEGY_SKILL_PARAMS[skill]["use_auction_evidence"] is False
+
+
+def test_evidence_still_reaches_the_rollout_when_switched_on():
+    """The wiring must stay live, since #103 is expected to re-test it."""
+    from pinochle_engine import GENERAL_STRATEGY_SKILL_PARAMS
+
+    ai = GeneralStrategy("me", None, skill_level=5, rng=random.Random(1))
+    players = [ai] + [GeneralStrategy(f"P{i}", None, skill_level=5, rng=random.Random(i))
+                      for i in range(1, 4)]
+    _round_of(players)
+    context = {"bid_history": [(players[2], 340)], "pass_history": []}
+
+    assert ai._auction_evidence(context).highest_bid == {"partner": 340}
+    assert "use_auction_evidence" in GENERAL_STRATEGY_SKILL_PARAMS[5]


### PR DESCRIPTION
Closes #101. A negative result, shipped as such.

## The constraint works

Rejection-samples determinized deals that contradict what the other seats did in the auction, judged with `best_base_bid` — the same valuation the bidding AI uses, so the model of "what a bid means" can't drift from what the bidders actually do.

Average sampled partner ceiling over 200 draws:

| evidence | partner's sampled ceiling |
|---|---|
| uniform (none) | 276 |
| partner **bid 330** | **338** |
| partner **passed**, declined 300 | **247** |

100% acceptance, ~2 draws per accepted sample. The distribution moves exactly as #101 predicted it would.

## It doesn't help

A/B'd with #105's harness — skill 5 with the constraint vs skill 5 without, 50 paired deals:

| | auction-aware | uniform |
|---|---|---|
| games won | 46 | 54 |
| **margin per deal** | **−1 (95% CI −109 to +102)** | |
| make rate | 54.4% | 55.3% |
| avg bid | 342 | 342 |

No established difference. And it costs roughly **4× the runtime** (6492 vs ~1540 ms/game on comparable skill-5 runs), because every candidate deal is valued across four trump suits for three seats.

## So it ships off

`use_auction_evidence` is `False` at every skill level, with these numbers recorded in the skill-params table and a test asserting it stays off — re-enabling should be a deliberate act with a measurement behind it, not something that drifts back on.

**Best explanation for the null result:** the bid decision is a coarse argmax over `[pass, next_bid]`. Sharpening the model of partner moves both options' EV in the same direction, so it rarely flips the choice. Worth re-testing after **#103** makes `EV(pass)` a real rollout instead of a flat `0.0` — that gives the constraint a genuinely richer comparison to act on. The wiring stays live and tested for exactly that.

I'd rather land this measured-and-disabled than either delete the work or quietly enable something that costs 4× for nothing.

## Also

Adds `pass_history` / `passed_players` to the Python bidding context. The engine recorded who *bid* but never who *passed* — the same gap #93 fixed on the TS side. The level is recorded too, since "declined to bid 340" bounds a hand from above while "declined to bid 300" says something much stronger.

## Verification

`python -m pytest` — 143 passed, 17 new in `test_auction_evidence.py`, covering the consistency rules, the distribution shift, the give-up path for unsatisfiable constraints, and the engine's new auction record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)