### PR TITLE
feat: win probability as the rollout objective, measured and left off (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ level at creation) are implemented — see the strategy doc below.
   currently-unseen cards for a decision point (bidding / return-pass /
   trick-play), rolls a sample out to completion via the real pass/
   trick-play logic, and aggregates P(make)/E[points] across samples.
+  Carries three objectives over the same rollouts, in increasing order of
+  what they can see: own points (`bid_ev`, #60), score differential
+  (`bid_ev_differential` / `defend_ev` / `fold_ev`, #100/#103), and
+  probability of winning the game (`*_win_probability`, #102) — the last
+  being the only one the game score is an input to.
+- [`win_probability.py`](win_probability.py) — P(win the game | score
+  state), the objective the rollout AI can maximize instead of points
+  (issue #102). A coarse 20×20 lookup table over both teams' scores in
+  100-point buckets, tabulated from Proficient self-play and smoothed
+  toward a race-model prior, plus exact resolution of already-decided
+  states (bust before target; a round carrying both sides past 1000 goes
+  to the bidding team). Also the generator that built it —
+  `python win_probability.py --games 6000 --seed 7` reprints the table
+  literal. Consumed by `pinochle_rollout.py`'s
+  `bid_ev_win_probability` / `defend_ev_win_probability` /
+  `fold_ev_win_probability`, which are gated behind the
+  `use_win_probability` skill parameter.
 - [`human_play.py`](human_play.py) — resumable interactive play layer
   (`HumanPlayer`, `InteractiveRound`) built for chat-session play, where
   a script can't block on `input()` between messages: decisions raise
@@ -85,6 +102,9 @@ level at creation) are implemented — see the strategy doc below.
 python pinochle_engine.py   # rules engine self-checks + full-game sanity runs
 python play_local.py        # play a full interactive game in the terminal
 python tournament_sim.py --games 300   # Proficient-vs-Proficient sanity check (~50/50)
+python ab_harness.py --pairs 100       # A/B harness self-test (a config against itself)
+python win_probability.py --games 6000 --seed 7   # regenerate the win-probability table
+python -m pytest -q                    # full test suite
 ```
 
 ## Architecture

--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -2038,12 +2038,39 @@ GENERAL_STRATEGY_SKILL_PARAMS = {
     #   letting a flawed bidder overreach. Re-measure against a stronger
     #   bidder before treating +233 as universal. 20 samples is the value
     #   measured; the count itself was not separately tuned.
+    # use_win_probability: score every rollout sample as P(win the game) from
+    #   the resulting score state (win_probability.py), instead of as a score
+    #   differential (#102). Uses the same rollouts and the same sample budget
+    #   as defence_samples - only the function applied to each sample changes -
+    #   and requires defence_samples > 0, since the objective compares two
+    #   futures. OFF everywhere, following #101's precedent.
+    #   It does what the issue asks: the same hand at the same bid passes at
+    #   950-300 and bids at 890-950, with no score branch anywhere. But A/B'd
+    #   against the differential objective at skill 5 over 120 paired deals it
+    #   did not win more games (122-118, 30 decisive pairs, p=0.86) and was
+    #   slightly WORSE on margin (-92 per deal, 95% CI -170 to -13). Two
+    #   40-pair replicates agreed on "no effect" (41-39, margin -29 with a 95%
+    #   CI of -159 to +109; 44-36, margin -46 with a 95% CI of -158 to +69).
+    #   Games and margin pointed opposite ways in every run - the exact
+    #   divergence #102 warned about - and neither points at enabling this.
+    #   The likely reason is measured rather than guessed: the self-play table
+    #   is nearly flat in game stage (a 100-point lead is worth ~0.58 at 100-0
+    #   and ~0.56 at 700-600), because a Pinochle round swings ~259 points with
+    #   a ~406-point spread, so no lead is safe until a side can actually cross
+    #   1000. Over 18 sampled hands the two objectives chose identically at 0-0
+    #   and at 500-500 and differed only near the finish (2/18 at 890-950,
+    #   10/18 at 950-300). An objective that only bites in the last round or
+    #   two cannot move a whole-game A/B much, and what it does change here
+    #   (758 contracts taken vs 581, make rate 59.6% vs 64.4%, conceded 20.4%
+    #   vs 16.5%) is not paying for itself. Do not re-run this A/B without a
+    #   new hypothesis; the promising direction is the endgame decisions
+    #   specifically, not the objective across the board.
     # deception: whether choose_expert_follow_card gets a deception_evaluator.
-    1: {"hand_valuation": "meld_only",   "pass_logic": "easy",      "trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "use_auction_evidence": False, "defence_samples": 0,  "deception": False},
-    2: {"hand_valuation": "base_bid",    "pass_logic": "proficient","trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "use_auction_evidence": False, "defence_samples": 0,  "deception": False},
-    3: {"hand_valuation": "base_bid",    "pass_logic": "proficient","trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "use_auction_evidence": False, "defence_samples": 0,  "deception": False},
-    4: {"hand_valuation": "rollout_ev",  "pass_logic": "expert",    "trick_logic": "expert",     "use_rollout": True,  "bid_samples": 20, "pass_samples": 15, "trick_samples": 10, "fold_samples": 20, "use_auction_evidence": False, "defence_samples": 20, "deception": False},
-    5: {"hand_valuation": "rollout_ev",  "pass_logic": "expert",    "trick_logic": "expert",     "use_rollout": True,  "bid_samples": 50, "pass_samples": 30, "trick_samples": 25, "fold_samples": 50, "use_auction_evidence": False, "defence_samples": 20, "deception": False},
+    1: {"hand_valuation": "meld_only",   "pass_logic": "easy",      "trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "use_auction_evidence": False, "defence_samples": 0,  "use_win_probability": False, "deception": False},
+    2: {"hand_valuation": "base_bid",    "pass_logic": "proficient","trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "use_auction_evidence": False, "defence_samples": 0,  "use_win_probability": False, "deception": False},
+    3: {"hand_valuation": "base_bid",    "pass_logic": "proficient","trick_logic": "proficient", "use_rollout": False, "bid_samples": 0,  "pass_samples": 0,  "trick_samples": 0,  "fold_samples": 0,  "use_auction_evidence": False, "defence_samples": 0,  "use_win_probability": False, "deception": False},
+    4: {"hand_valuation": "rollout_ev",  "pass_logic": "expert",    "trick_logic": "expert",     "use_rollout": True,  "bid_samples": 20, "pass_samples": 15, "trick_samples": 10, "fold_samples": 20, "use_auction_evidence": False, "defence_samples": 20, "use_win_probability": False, "deception": False},
+    5: {"hand_valuation": "rollout_ev",  "pass_logic": "expert",    "trick_logic": "expert",     "use_rollout": True,  "bid_samples": 50, "pass_samples": 30, "trick_samples": 25, "fold_samples": 50, "use_auction_evidence": False, "defence_samples": 20, "use_win_probability": False, "deception": False},
 }
 
 MELD_ONLY_TRICK_ESTIMATE = EASY_FLAT_TRICK_ESTIMATE  # same flat, non-hand-shape-aware stand-in EasyPlayer uses for skill 1's meld-only bidding (doc Section 8) - reused rather than redefined, since it's the same judgment call.
@@ -2221,6 +2248,19 @@ class GeneralStrategy(Player):
 
         defence_samples = params.get("defence_samples", 0)
         if defence_samples > 0:
+            if params.get("use_win_probability"):
+                # Same two futures and the same rollouts as #103's comparison,
+                # scored as P(win the game) from the resulting score state
+                # instead of as a score differential (#102). The score reaches
+                # the decision by moving the objective, not via a branch.
+                from pinochle_rollout import choose_bid_by_win_probability
+
+                best_bid, _best_ev, _all_evs = choose_bid_by_win_probability(
+                    self.hand, trump, [None, next_bid], my_score, opp_score,
+                    num_samples=defence_samples, rng=self.rng, evidence=evidence,
+                )
+                return best_bid
+
             # Compare taking the contract against defending it, both as score
             # differentials (#103), instead of scoring a pass as a flat 0.0.
             from pinochle_rollout import choose_bid_vs_defence
@@ -2254,9 +2294,21 @@ class GeneralStrategy(Player):
         if num_samples <= 0:
             return False
 
+        # Under the win-probability objective (#102) the concede decision gets
+        # the game score too, so "we are 60 behind with one round left" can
+        # reach it. Scores are only passed when both sides are actually known -
+        # a hand-built Team in a test has no opponent wired up, and guessing 0
+        # there would silently model the wrong game state.
+        our_score = their_score = None
+        if params.get("use_win_probability") and self.team is not None:
+            opponent = self.team.opponent
+            if opponent is not None:
+                our_score, their_score = self.team.score, opponent.score
+
         fold, _diagnostics = should_fold(
             self.hand, trump, bid, bidding_meld, defending_meld,
             num_samples=num_samples, rng=self.rng,
+            our_score=our_score, their_score=their_score,
         )
         return fold
 

--- a/pinochle_rollout.py
+++ b/pinochle_rollout.py
@@ -39,6 +39,14 @@ machinery that wiring calls:
     the Expert-tier replacement for the static Base-Bid formula, at the
     top of the skill range only. `Player`/`EasyPlayer.choose_bid` are
     untouched; a higher-skill strategy calls this instead (issue #63).
+  - Objectives (what gets averaged across samples). Three of them share the
+    rollouts above rather than each having their own simulator: own points
+    (`bid_ev`, #60), score differential (`bid_ev_differential` / `defend_ev` /
+    `fold_ev`, #100/#103), and probability of winning the game
+    (`bid_ev_win_probability` / `defend_ev_win_probability` /
+    `fold_ev_win_probability`, #102 - the only one the game score is an input
+    to). They coexist deliberately: swapping the objective is the change being
+    measured, so the one it replaces has to stay runnable next to it.
 
 Sample counts are always a caller-supplied parameter (never hardcoded) -
 the doc suggests ~100-150 for bid-time and ~300+ for the one-time
@@ -62,6 +70,10 @@ from pinochle_engine import (
     run_return_pass,
     score_melds,
 )
+# win_probability imports pinochle_engine too, but nothing imports back into
+# this module at import time, so this is a plain top-level import rather than
+# one of the lazy in-method imports GeneralStrategy needs for the real cycle.
+from win_probability import win_probability
 
 
 # ---------------------------------------------------------------------------
@@ -707,7 +719,8 @@ def choose_bid_by_ev(hand, trump, candidate_bids, num_samples=150, rng=None, evi
 # taking the contract and defending one distribute points differently between
 # the teams, and only the difference is common to both. This matches the
 # convention `fold_ev` already uses. Differential remains a proxy for winning
-# the game; #102 replaces it with win probability.
+# the game; `choose_bid_by_win_probability` below (#102) is the same
+# comparison with P(win) as the objective instead.
 # ---------------------------------------------------------------------------
 
 def _differential_when_we_bid(sample, bid):
@@ -951,9 +964,10 @@ def fold_ev(hand, trump, bid, bidding_meld, defending_meld,
 
     Differential is still only a proxy for what actually matters, which is
     winning the game - at 900-100 our own points matter far more than denying
-    theirs, and at 400-900 the reverse. #102 replaces this objective with win
-    probability; until then the score itself is deliberately not an input
-    here, rather than being folded in via some invented weighting.
+    theirs, and at 400-900 the reverse. `fold_ev_win_probability` (#102) is
+    this same comparison with P(win) as the objective and the score as a real
+    input; this function keeps the score deliberately out of it rather than
+    folding it in via some invented weighting.
 
     Returns (ev_play_on, ev_fold, diagnostics). `diagnostics` is the
     `estimate_play_on` aggregate (or a synthetic equivalent when the auto-set
@@ -1008,7 +1022,7 @@ def fold_ev(hand, trump, bid, bidding_meld, defending_meld,
 
 
 def should_fold(hand, trump, bid, bidding_meld, defending_meld,
-                 num_samples=150, rng=None):
+                 num_samples=150, rng=None, our_score=None, their_score=None):
     """
     True when conceding beats playing the contract out, by the comparison in
     `fold_ev`. There is no threshold, no margin and no tunable constant here
@@ -1024,8 +1038,23 @@ def should_fold(hand, trump, bid, bidding_meld, defending_meld,
     only an upper bound on playing on there, so the flag decides instead of
     the (deliberately tied) numbers.
 
+    Supplying both `our_score` and `their_score` switches the objective from
+    score differential to win probability (issue #102) via
+    `fold_ev_win_probability`. Omitting them keeps the differential behaviour
+    this function has always had, per CODING_STANDARDS' "default to None and
+    branch on its absence" convention for widening a contract.
+
     Returns (fold, diagnostics).
     """
+    if our_score is not None and their_score is not None:
+        p_play_on, p_fold, diagnostics = fold_ev_win_probability(
+            hand, trump, bid, bidding_meld, defending_meld,
+            our_score, their_score, num_samples=num_samples, rng=rng,
+        )
+        if diagnostics["auto_set_shortcut"]:
+            return True, diagnostics
+        return p_play_on < p_fold, diagnostics
+
     ev_play_on, ev_fold, diagnostics = fold_ev(
         hand, trump, bid, bidding_meld, defending_meld,
         num_samples=num_samples, rng=rng,
@@ -1033,3 +1062,188 @@ def should_fold(hand, trump, bid, bidding_meld, defending_meld,
     if diagnostics["auto_set_shortcut"]:
         return True, diagnostics
     return ev_play_on < ev_fold, diagnostics
+
+
+# ---------------------------------------------------------------------------
+# Win probability as the objective (issue #102, epic #106).
+#
+# Everything above is denominated in points - `bid_ev` in our own points, and
+# `bid_ev_differential` / `defend_ev` / `fold_ev` in score differential. Both
+# are proxies for the thing that decides a game, and both stop tracking it near
+# the end: at 890-950 a differential of +40 is worthless if we never take the
+# contract, and at 200-180 a differential of +300 bought with a 40% chance of
+# being set is a bad trade. The score is not even an input to any of them.
+#
+# The fix is not to bolt a score term onto the point EVs. It is to change what
+# is averaged. A rollout already produces a full round result; applying it to
+# the current game score gives a *game state*, and `win_probability.py` turns a
+# game state into P(win). Average that instead of points and score-awareness
+# stops being a special case anybody hand-codes - it falls out of the objective.
+#
+# The functions here mirror the differential ones one-for-one rather than
+# replacing them: the differential path is what skill 4-5 ships with today, and
+# a swap of objective has to be A/B-able against it, not assumed better.
+# ---------------------------------------------------------------------------
+
+def _win_prob_when_we_bid(sample, bid, our_score, their_score):
+    """
+    P(win) after a sample where WE hold the contract, applied to the current
+    score. Failing scores us exactly -bid with no partial credit, while the
+    defenders keep meld + tricks either way - the same asymmetry
+    `_differential_when_we_bid` encodes, just resolved into a probability.
+    """
+    ours = sample["bidding_total"] if sample["made"] else -bid
+    theirs = sample["defending_total"]
+    return win_probability(our_score + ours, their_score + theirs, we_bid=True)
+
+
+def _win_prob_when_they_bid(sample, bid, our_score, their_score):
+    """
+    P(win) after a sample where THEY hold the contract - so `rollout_deal`'s
+    "bidding" side is the opponents and its "defending" side is us.
+    """
+    theirs = sample["bidding_total"] if sample["made"] else -bid
+    ours = sample["defending_total"]
+    return win_probability(our_score + ours, their_score + theirs, we_bid=False)
+
+
+def bid_ev_win_probability(hand, trump, bid, our_score, their_score,
+                            num_samples=150, rng=None, evidence=None):
+    """
+    P(win the game) from taking the contract at `bid`, averaged over the same
+    rollout `bid_ev_differential` uses. Returns (p_win, diagnostics).
+
+    Note what changes and what does not: the rollout is identical, the samples
+    are identical, only the function applied to each sample's result differs.
+    That is deliberate - it makes the A/B against the differential objective a
+    clean comparison of objectives rather than of two different simulators.
+    """
+    diagnostics = estimate_bid_time(
+        hand, trump, bid, num_samples=num_samples, rng=rng, evidence=evidence,
+    )
+    probabilities = [
+        _win_prob_when_we_bid(sample, bid, our_score, their_score)
+        for sample in diagnostics["samples"]
+    ]
+    p_win = sum(probabilities) / len(probabilities)
+    diagnostics["p_win_bid"] = p_win
+    return p_win, diagnostics
+
+
+def defend_ev_win_probability(hand, bid, our_score, their_score,
+                               num_samples=150, rng=None, evidence=None):
+    """
+    P(win the game) from passing and defending a contract of `bid`, averaged
+    over `estimate_defence`'s rollout. Returns (p_win, diagnostics).
+    """
+    diagnostics = estimate_defence(
+        hand, bid, num_samples=num_samples, rng=rng, evidence=evidence,
+    )
+    probabilities = [
+        _win_prob_when_they_bid(sample, bid, our_score, their_score)
+        for sample in diagnostics["samples"]
+    ]
+    p_win = sum(probabilities) / len(probabilities)
+    diagnostics["p_win_defend"] = p_win
+    return p_win, diagnostics
+
+
+def choose_bid_by_win_probability(hand, trump, candidate_bids, our_score, their_score,
+                                   num_samples=150, rng=None, evidence=None,
+                                   defence_bid=None):
+    """
+    `choose_bid_vs_defence` with win probability as the objective (#102).
+
+    Same two futures, same rollouts, same return shape `(best_bid, best_ev,
+    all_evs)` - so a caller swaps between the two by swapping the function.
+    The only difference is that every candidate is scored as P(win the game
+    from the resulting state) instead of as a score differential.
+
+    This is what makes the *same hand at the same bid* decide differently at
+    200-180 and at 890-950, with no score branch anywhere: at 200-180 a set
+    costs a modest slice of win probability and there are many rounds left to
+    recover, while at 890-950 passing hands them a contract that ends the
+    game, so almost any chance of making one beats near-certain defeat.
+    """
+    if not candidate_bids:
+        raise ValueError("candidate_bids must be non-empty")
+
+    real_bids = [b for b in candidate_bids if b is not None]
+    if defence_bid is None:
+        defence_bid = min(real_bids) if real_bids else OPENING_BID
+
+    all_evs = {}
+    for bid in candidate_bids:
+        if bid is None:
+            all_evs[None], _ = defend_ev_win_probability(
+                hand, defence_bid, our_score, their_score,
+                num_samples=num_samples, rng=rng, evidence=evidence,
+            )
+        else:
+            all_evs[bid], _ = bid_ev_win_probability(
+                hand, trump, bid, our_score, their_score,
+                num_samples=num_samples, rng=rng, evidence=evidence,
+            )
+
+    best_bid = max(all_evs, key=all_evs.get)
+    return best_bid, all_evs[best_bid], all_evs
+
+
+def fold_ev_win_probability(hand, trump, bid, bidding_meld, defending_meld,
+                             our_score, their_score, num_samples=150, rng=None):
+    """
+    `fold_ev` with win probability as the objective (#102).
+
+    Folding's score is still exact - we take -bid and forfeit our meld, they
+    keep `defending_meld` and take no tricks - so P(win | fold) needs no
+    rollout either, just the conversion of that one known state.
+
+    The auto-set fast path survives the change of objective intact, and for
+    the same dominance reason: playing on cannot make the contract, so we
+    score -bid whichever way it goes, while the opponents end at
+    `defending_meld + T` for some T >= 0 that conceding denies them. Win
+    probability is non-increasing in the opponents' score, so P(play on) <=
+    P(fold) for every T. That the argument still holds is worth stating
+    rather than assuming - a change of objective is exactly the kind of change
+    that quietly invalidates a shortcut taken under the old one.
+
+    Returns (p_play_on, p_fold, diagnostics).
+    """
+    p_fold = win_probability(our_score - bid, their_score + defending_meld, we_bid=True)
+
+    if is_auto_set(bidding_meld, bid):
+        diagnostics = {
+            "samples": [],
+            "p_make": 0.0,
+            "expected_bidding_points": float(bidding_meld),
+            "expected_defending_points": float(defending_meld),
+            "auto_set_rate": 1.0,
+            "auto_set_shortcut": True,
+            "ev_play_on": p_fold,
+            "ev_play_on_is_upper_bound": True,
+            "ev_fold": p_fold,
+            "p_play_on": p_fold,
+            "p_fold": p_fold,
+        }
+        return p_fold, p_fold, diagnostics
+
+    diagnostics = estimate_play_on(
+        hand, trump, bid, bidding_meld, defending_meld,
+        num_samples=num_samples, rng=rng,
+    )
+
+    probabilities = [
+        _win_prob_when_we_bid(sample, bid, our_score, their_score)
+        for sample in diagnostics["samples"]
+    ]
+    p_play_on = sum(probabilities) / len(probabilities)
+
+    diagnostics["auto_set_shortcut"] = False
+    diagnostics["ev_play_on_is_upper_bound"] = False
+    # Both key sets are populated so a caller (or `should_fold`) can read the
+    # diagnostics without first knowing which objective produced them.
+    diagnostics["ev_play_on"] = p_play_on
+    diagnostics["ev_fold"] = p_fold
+    diagnostics["p_play_on"] = p_play_on
+    diagnostics["p_fold"] = p_fold
+    return p_play_on, p_fold, diagnostics

--- a/test_win_probability.py
+++ b/test_win_probability.py
@@ -1,0 +1,552 @@
+"""
+Tests for issue #102 (epic #106) - making the rollout objective the
+probability of winning the game instead of points or score differential.
+Plain assert-based, pytest-discoverable, matching test_defence_ev.py /
+test_fold_ev.py's convention. Covers:
+
+  1. The measured table's structural guarantees. Its *values* come from
+     self-play and would change on regeneration, so the assertions here are
+     about the properties the construction is supposed to guarantee
+     (antisymmetry, a 0.5 diagonal, direction) rather than about any
+     particular number - a test pinned to a generated float would fail on
+     every regeneration for no reason.
+  2. End-of-game resolution, which is arithmetic and must be exact rather
+     than estimated. The endgame is the whole reason this objective exists,
+     so this is the part that cannot be a little bit wrong: bust is checked
+     before the 1000 target, and a round that carries both sides over goes to
+     the bidding team.
+  3. The prior's shape - the same lead being worth more with fewer rounds
+     left is what makes it a usable fallback for cells self-play never
+     reaches, rather than a constant with a plausible story attached.
+  4. The per-sample objective helpers, against synthetic samples where the
+     right answer is arithmetic rather than a simulation result.
+  5. The acceptance criterion from the issue: the same hand at the same bid
+     decides differently at 200-180 and at 890-950, with no score branch
+     anywhere in the code - and the differential objective it replaces does
+     not, because the score is not an input to it at all.
+  6. The fold decision under the new objective, including that the auto-set
+     dominance shortcut survives the change.
+  7. Nothing is enabled by default, and the flag reaches the decision.
+
+Real pass and trick-play logic are deterministic given the dealt hands, so a
+seeded `random.Random` makes the rollout-backed cases reproducible at modest
+sample counts.
+"""
+
+import random
+
+from pinochle_engine import Card, Suit
+from pinochle_rollout import (
+    _win_prob_when_they_bid,
+    _win_prob_when_we_bid,
+    bid_ev_win_probability,
+    choose_bid_by_win_probability,
+    choose_bid_vs_defence,
+    defend_ev_win_probability,
+    fold_ev_win_probability,
+    should_fold,
+)
+from win_probability import (
+    BUCKET_COUNT,
+    GAME_LOSE_SCORE,
+    GAME_WIN_SCORE,
+    WIN_PROBABILITY_TABLE,
+    bucket_midpoint,
+    generate_table,
+    prior_win_probability,
+    resolve_game_winner,
+    score_bucket,
+    table_win_probability,
+    win_probability,
+)
+
+
+def _marginal_hand():
+    """
+    The same borderline hand test_defence_ev.py uses: one weak trump suit, a
+    scattering of side-suit strength, no meld to speak of. Deliberately not a
+    powerhouse - a hand that is obviously worth bidding would take the
+    contract at every score, and could not show that the *score* moved the
+    decision.
+    """
+    return [
+        Card(Suit.CLUBS, "A", 1), Card(Suit.CLUBS, "K", 1), Card(Suit.CLUBS, "Q", 1),
+        Card(Suit.CLUBS, "9", 1), Card(Suit.SPADES, "A", 1), Card(Suit.SPADES, "K", 1),
+        Card(Suit.DIAMONDS, "K", 1), Card(Suit.DIAMONDS, "J", 1), Card(Suit.HEARTS, "10", 1),
+        Card(Suit.HEARTS, "J", 1), Card(Suit.HEARTS, "9", 1), Card(Suit.SPADES, "9", 1),
+    ]
+
+
+def _powerhouse_hand():
+    trump = Suit.CLUBS
+    return [
+        Card(trump, "A", 1), Card(trump, "A", 2), Card(trump, "10", 1), Card(trump, "10", 2),
+        Card(trump, "K", 1), Card(trump, "Q", 1), Card(trump, "J", 1),
+        Card(Suit.SPADES, "A", 1), Card(Suit.SPADES, "A", 2),
+        Card(Suit.DIAMONDS, "A", 1), Card(Suit.DIAMONDS, "A", 2), Card(Suit.HEARTS, "A", 1),
+    ], trump
+
+
+# ---------------------------------------------------------------------------
+# 1. The table's structural guarantees.
+# ---------------------------------------------------------------------------
+
+def test_table_covers_the_whole_score_range():
+    assert len(WIN_PROBABILITY_TABLE) == BUCKET_COUNT
+    assert all(len(row) == BUCKET_COUNT for row in WIN_PROBABILITY_TABLE)
+    assert all(0.0 <= v <= 1.0 for row in WIN_PROBABILITY_TABLE for v in row)
+
+
+def test_buckets_span_the_playable_range_without_gaps():
+    """Every legal in-progress score has to land in a cell - a lookup that can
+    raise IndexError on a real game state would be a crash mid-decision."""
+    for score in range(GAME_LOSE_SCORE, GAME_WIN_SCORE, 25):
+        assert 0 <= score_bucket(score) < BUCKET_COUNT
+    # Out-of-range scores clamp rather than raise; `win_probability` resolves
+    # them exactly before ever reaching the table anyway.
+    assert score_bucket(-5000) == 0
+    assert score_bucket(5000) == BUCKET_COUNT - 1
+
+
+def test_the_table_is_antisymmetric():
+    """
+    P(a beats b) + P(b beats a) must be 1: the same game, read from the two
+    sides. This is guaranteed by entering every self-play observation twice
+    (once mirrored) rather than hoped for, and it matters because a
+    bid-vs-defend comparison reads cells on opposite sides of the diagonal -
+    cells that disagreed would make the comparison partly an artifact of which
+    side of the table got more games.
+    """
+    for i in range(BUCKET_COUNT):
+        for j in range(BUCKET_COUNT):
+            pair = WIN_PROBABILITY_TABLE[i][j] + WIN_PROBABILITY_TABLE[j][i]
+            assert abs(pair - 1.0) < 0.005, (i, j, pair)  # 0.005 covers 3-dp rounding
+
+
+def test_a_tied_score_is_a_coin_flip():
+    for i in range(BUCKET_COUNT):
+        assert WIN_PROBABILITY_TABLE[i][i] == 0.5
+
+
+def test_a_large_lead_beats_a_large_deficit():
+    """
+    Direction, checked across wide gaps rather than between adjacent cells.
+    Adjacent cells differ by less than the sampling noise in the cells that
+    were only visited a few hundred times, so asserting strict cell-by-cell
+    monotonicity would be asserting that the noise happens to be small - a
+    test that fails on regeneration without anything being wrong.
+    """
+    assert table_win_probability(700, 100) > 0.75
+    assert table_win_probability(100, 700) < 0.25
+    assert table_win_probability(500, 100) > table_win_probability(300, 100)
+    assert table_win_probability(300, 100) > table_win_probability(300, 500)
+
+
+# ---------------------------------------------------------------------------
+# 2. End-of-game resolution - exact, not estimated.
+# ---------------------------------------------------------------------------
+
+def test_an_undecided_game_is_left_to_the_table():
+    assert resolve_game_winner(400, 300, we_bid=True) is None
+    assert win_probability(400, 300) == table_win_probability(400, 300)
+
+
+def test_reaching_the_target_wins_outright():
+    assert win_probability(1000, 400) == 1.0
+    assert win_probability(400, 1010) == 0.0
+
+
+def test_busting_is_checked_before_the_target():
+    """
+    `Game.play` tests the -1000 bust before the +1000 target, so a team that
+    busts loses even against a side nowhere near winning. Getting this
+    backwards would make the objective *reward* a catastrophic set in a game
+    the opponents were also losing.
+    """
+    assert win_probability(-500, GAME_LOSE_SCORE) == 1.0
+    assert win_probability(GAME_LOSE_SCORE - 50, 200) == 0.0
+
+
+def test_a_round_that_carries_both_sides_over_goes_to_the_bidder():
+    """
+    The rule that makes bidding correct at 890-950 rather than merely
+    defensible: if the round puts both teams past 1000, the bidding team wins
+    it. An objective that split this 50/50, or handed it to the higher score,
+    would miss the single most important endgame decision in the game.
+    """
+    assert win_probability(1100, 1200, we_bid=True) == 1.0
+    assert win_probability(1200, 1100, we_bid=False) == 0.0
+
+
+def test_defenders_still_score_which_is_why_950_is_nearly_decisive():
+    """
+    Records a rules consequence the issue's motivating example gets backwards.
+    Defenders keep meld + trick points whether or not the contract is made, so
+    a side sitting at 950 crosses 1000 in *any* round it defends. Trailing far
+    behind them, taking the contract cannot help - we would go over only if we
+    were within one round of 1000 ourselves.
+    """
+    # We take the contract at 300 and make it handsomely; they defend and pick
+    # up a modest 60 of meld. They still cross first from 950.
+    made_well = {"made": True, "bidding_total": 400, "defending_total": 60}
+    assert _win_prob_when_we_bid(made_well, 300, our_score=300, their_score=950) == 0.0
+    # From 890 the same round carries us over too - and the tie goes to us.
+    assert _win_prob_when_we_bid(made_well, 300, our_score=890, their_score=950) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 3. The prior's shape.
+# ---------------------------------------------------------------------------
+
+def test_the_same_lead_is_worth_more_later_in_the_game():
+    """
+    The one property the prior exists to supply, and the reason a flat
+    logistic on score difference would not do: a 60-point lead is nearly
+    meaningless with six rounds left and close to decisive with one, because
+    what changes is how much variance is still to come.
+    """
+    early = prior_win_probability(200, 140)
+    late = prior_win_probability(950, 890)
+    assert late > early
+    assert early < 0.6  # early on, 60 points is barely a nudge
+
+
+def test_the_prior_is_symmetric():
+    for ours, theirs in [(0, 0), (300, 100), (900, 400), (-200, 500)]:
+        assert abs(prior_win_probability(ours, theirs)
+                   + prior_win_probability(theirs, ours) - 1.0) < 1e-9
+
+
+def test_a_dead_even_score_is_a_coin_flip_under_the_prior():
+    for score in (-500, 0, 400, 900):
+        assert abs(prior_win_probability(score, score) - 0.5) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 4. Per-sample objective helpers - arithmetic, not simulation.
+# ---------------------------------------------------------------------------
+
+def test_a_failed_contract_scores_minus_bid_not_the_total_it_reached():
+    """
+    Same no-partial-credit rule the differential helpers encode, resolved into
+    a probability instead. A sample that reached 310 against a 320 contract
+    must move the score by -320, not by +310 - and from 900 that is the
+    difference between winning the game and dropping to 580.
+    """
+    missed = {"made": False, "bidding_total": 310, "defending_total": 100}
+    assert _win_prob_when_we_bid(missed, 320, our_score=900, their_score=100) == \
+        win_probability(900 - 320, 100 + 100, we_bid=True)
+
+
+def test_setting_them_is_read_from_our_side_of_the_table():
+    """`estimate_defence`'s "bidding" side is the opponents, so the sample's
+    defending_total is ours. A sign error here would have the AI treating a
+    set it inflicted as a set it suffered."""
+    they_failed = {"made": False, "bidding_total": 300, "defending_total": 150}
+    assert _win_prob_when_they_bid(they_failed, 320, our_score=400, their_score=400) == \
+        win_probability(400 + 150, 400 - 320, we_bid=False)
+
+
+def test_the_objective_is_a_probability():
+    hand = _marginal_hand()
+    p, diagnostics = bid_ev_win_probability(
+        hand, Suit.CLUBS, 300, 400, 400, num_samples=8, rng=random.Random(1),
+    )
+    assert 0.0 <= p <= 1.0
+    assert diagnostics["p_win_bid"] == p
+    assert len(diagnostics["samples"]) == 8
+
+
+def test_defending_from_a_hopeless_deficit_still_beats_bidding_into_it():
+    """
+    At 300-950 the opponents cross 1000 in any round they merely defend, so
+    taking a small contract cannot win the game however well it goes - the
+    only live path is that they bid and we set them. The objective finds that
+    without a rule, and this is the case the issue's own worked example gets
+    backwards (see the rules note above).
+    """
+    hand = _marginal_hand()
+    bidding, _ = bid_ev_win_probability(
+        hand, Suit.CLUBS, 300, 300, 950, num_samples=10, rng=random.Random(2),
+    )
+    defending, _ = defend_ev_win_probability(
+        hand, 300, 300, 950, num_samples=10, rng=random.Random(2),
+    )
+    assert bidding == 0.0
+    assert defending > bidding
+
+
+# ---------------------------------------------------------------------------
+# 5. The acceptance criterion: the score moves the decision.
+# ---------------------------------------------------------------------------
+
+def test_the_same_hand_and_bid_decide_differently_at_different_scores():
+    """
+    The issue's headline acceptance criterion: one hand, one contract level,
+    one rollout budget, one seed - only the game score differs, and the verdict
+    flips. Nothing in the code path branches on the score; it reaches the
+    decision by changing what each rolled-out round is worth.
+
+    Two late-game states rather than the issue's 200-180 / 890-950 pair,
+    because those two differ *reliably in preference but not always in verdict*
+    for a marginal hand (see the next test) - and a criterion demonstrated on a
+    coin-flip is not demonstrated. These two are decided by the rules rather
+    than by sampling luck:
+
+      950-300 - we cross 1000 on defensive meld alone in any round we defend,
+      so taking a contract we might be set on is a pure downside. Protecting a
+      lead, with no rule saying so.
+
+      890-950 - defending hands them the round that ends the game, and only
+      the *bidding* team wins a round that carries both sides over. Bidding is
+      the only path, on a hand whose points-EV says otherwise.
+    """
+    hand = _marginal_hand()
+    ahead, _ev_ahead, _all_ahead = choose_bid_by_win_probability(
+        hand, Suit.CLUBS, [None, 300], 950, 300, num_samples=20, rng=random.Random(3),
+    )
+    behind, _ev_behind, _all_behind = choose_bid_by_win_probability(
+        hand, Suit.CLUBS, [None, 300], 890, 950, num_samples=20, rng=random.Random(3),
+    )
+    assert ahead is None       # sit on the lead
+    assert behind == 300       # take the contract or lose
+
+
+def test_bidding_gets_more_attractive_as_the_endgame_closes_in():
+    """
+    The issue's own 200-180 vs 890-950 example, asserted as the effect that is
+    actually there rather than as a guaranteed flip of the verdict. On a hand
+    this marginal the two options sit within a couple of points of each other
+    at 200-180, so which one wins the argmax is decided by rollout noise - but
+    the *size and sign* of the preference for bidding moves the same way on
+    every seed tried, which is the claim the issue is really making.
+    """
+    hand = _marginal_hand()
+    for seed in (0, 3):
+        _b, _e, early = choose_bid_by_win_probability(
+            hand, Suit.CLUBS, [None, 300], 200, 180, num_samples=20, rng=random.Random(seed),
+        )
+        _b2, _e2, late = choose_bid_by_win_probability(
+            hand, Suit.CLUBS, [None, 300], 890, 950, num_samples=20, rng=random.Random(seed),
+        )
+        assert late[300] - late[None] > early[300] - early[None], seed
+
+
+def test_the_differential_objective_cannot_tell_those_apart():
+    """
+    The other half of the same claim, and the reason this issue exists: the
+    function being replaced has no score parameter at all, so it necessarily
+    returns the same verdict in both situations. Asserting the *old* behaviour
+    is what stops the test above from being a tautology about a function that
+    happens to take two extra arguments.
+    """
+    hand = _marginal_hand()
+    verdict, _ev, _all = choose_bid_vs_defence(
+        hand, Suit.CLUBS, [None, 300], num_samples=15, rng=random.Random(3),
+    )
+    assert verdict is None    # one answer, for every score state there is
+
+
+def test_the_chooser_keeps_the_existing_return_shape():
+    """Swapping objectives has to be a function swap at the call site, not a
+    rewrite of it - so the triple must match `choose_bid_vs_defence`'s."""
+    hand = _marginal_hand()
+    best, ev, all_evs = choose_bid_by_win_probability(
+        hand, Suit.CLUBS, [None, 300], 400, 400, num_samples=6, rng=random.Random(4),
+    )
+    assert set(all_evs) == {None, 300}
+    assert all_evs[best] == ev
+    assert all(0.0 <= v <= 1.0 for v in all_evs.values())
+
+
+def test_empty_candidates_still_raises():
+    try:
+        choose_bid_by_win_probability(
+            _marginal_hand(), Suit.CLUBS, [], 0, 0, num_samples=4, rng=random.Random(5),
+        )
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for empty candidate_bids")
+
+
+# ---------------------------------------------------------------------------
+# 6. Folding under the new objective.
+# ---------------------------------------------------------------------------
+
+def test_fold_returns_two_probabilities():
+    hand, trump = _powerhouse_hand()
+    p_play_on, p_fold, diagnostics = fold_ev_win_probability(
+        hand, trump, 300, 100, 40, 400, 400, num_samples=8, rng=random.Random(6),
+    )
+    assert 0.0 <= p_play_on <= 1.0
+    assert 0.0 <= p_fold <= 1.0
+    assert diagnostics["auto_set_shortcut"] is False
+    assert diagnostics["p_play_on"] == p_play_on
+    assert diagnostics["p_fold"] == p_fold
+
+
+def test_the_auto_set_shortcut_survives_the_change_of_objective():
+    """
+    A contract that cannot be reached even taking all 250 trick points still
+    folds by dominance: we score -bid either way, and playing on can only add
+    to the opponents' total, which win probability is non-increasing in. The
+    shortcut is re-justified rather than inherited - a change of objective is
+    exactly what invalidates a shortcut argued under the old one.
+    """
+    hand, trump = _powerhouse_hand()
+    p_play_on, p_fold, diagnostics = fold_ev_win_probability(
+        hand, trump, 5000, 40, 40, 400, 400, num_samples=8, rng=random.Random(7),
+    )
+    assert diagnostics["auto_set_shortcut"] is True
+    assert diagnostics["samples"] == []          # no 12-trick rollout was run
+    assert p_play_on == p_fold                   # dominance, not a strict EV gap
+
+    folds, _ = should_fold(hand, trump, 5000, 40, 40, num_samples=8,
+                            rng=random.Random(7), our_score=400, their_score=400)
+    assert folds is True
+
+
+def test_conceding_is_evaluated_against_the_actual_game_score():
+    """
+    Folding gives the opponents `defending_meld` and gives us -bid. Whether
+    that is survivable is a question about the score, and under the old
+    differential objective it could not be asked at all. Near the bust floor
+    the same concede is far more costly than it is at 0-0.
+    """
+    hand, trump = _powerhouse_hand()
+    _play_on_safe, fold_safe, _d = fold_ev_win_probability(
+        hand, trump, 300, 100, 40, 0, 0, num_samples=4, rng=random.Random(8),
+    )
+    _play_on_edge, fold_edge, _d2 = fold_ev_win_probability(
+        hand, trump, 300, 100, 40, -800, 400, num_samples=4, rng=random.Random(8),
+    )
+    assert fold_edge < fold_safe
+
+
+def test_should_fold_keeps_the_differential_path_when_no_score_is_given():
+    """
+    CODING_STANDARDS' widening convention: omitting the new optional arguments
+    has to preserve the old behaviour exactly, because every existing caller
+    and every skill level with the flag off still goes down that path.
+    """
+    hand, trump = _powerhouse_hand()
+    _folds, diagnostics = should_fold(
+        hand, trump, 300, 100, 40, num_samples=6, rng=random.Random(9),
+    )
+    assert "p_fold" not in diagnostics          # the differential path ran
+    assert diagnostics["ev_fold"] == -300 - 40  # ...and its exact fold value
+
+
+# ---------------------------------------------------------------------------
+# 7. Nothing changes unless asked.
+# ---------------------------------------------------------------------------
+
+def test_the_win_probability_objective_is_off_at_every_skill_level():
+    """
+    Shipped disabled, following #101's precedent: over 120 paired deals at
+    skill 5 it neither won more games (122-118, p=0.86) nor gained margin
+    (-92 per deal, 95% CI -170 to -13). See the flag's comment in
+    GENERAL_STRATEGY_SKILL_PARAMS for the full numbers and the measured
+    explanation - this test exists so that turning it on is a deliberate edit
+    with a measurement behind it, not something that drifts in.
+    """
+    from pinochle_engine import GENERAL_STRATEGY_SKILL_PARAMS
+
+    for skill in (1, 2, 3, 4, 5):
+        assert GENERAL_STRATEGY_SKILL_PARAMS[skill]["use_win_probability"] is False
+
+
+def test_the_flag_needs_a_defence_budget_to_mean_anything():
+    """The objective compares two futures, so it needs the rollout budget that
+    scores a pass. A level with the flag on and no defence samples would
+    silently fall through to the flat-zero path."""
+    from pinochle_engine import GENERAL_STRATEGY_SKILL_PARAMS
+
+    for skill, params in GENERAL_STRATEGY_SKILL_PARAMS.items():
+        if params["use_win_probability"]:
+            assert params["defence_samples"] > 0, skill
+
+
+def test_the_flag_reaches_the_bidding_decision():
+    """
+    The flag has to change which chooser runs, not just sit in a dict. Flipped
+    on for one constructed decision and checked by capturing the call, rather
+    than by inferring it from a bid that could have come out the same way by
+    chance.
+
+    Uses the powerhouse hand deliberately. `_rollout_ev_bid` prunes any hand
+    whose static `best_base_bid` ceiling is below FORCED_BID (250) *before*
+    reaching any rollout, so the marginal hand never gets this far - which is
+    itself worth knowing: that surviving threshold caps how aggressive the
+    win-probability objective can be when behind late, and #106 has not
+    removed it yet.
+    """
+    import pinochle_engine as engine
+    import pinochle_rollout as rollout
+
+    calls = []
+    original = rollout.choose_bid_by_win_probability
+
+    def recording(hand, trump, candidates, our_score, their_score, **kwargs):
+        calls.append((our_score, their_score))
+        return original(hand, trump, candidates, our_score, their_score, **kwargs)
+
+    original_params = dict(engine.GENERAL_STRATEGY_SKILL_PARAMS[5])
+    rollout.choose_bid_by_win_probability = recording
+    engine.GENERAL_STRATEGY_SKILL_PARAMS[5] = dict(original_params, use_win_probability=True,
+                                                    defence_samples=4)
+    try:
+        ai = engine.GeneralStrategy("me", None, skill_level=5, rng=random.Random(1))
+        partner = engine.Player("partner", None)
+        opp_a, opp_b = engine.Player("oppA", None), engine.Player("oppB", None)
+        mine = engine.Team("A", [ai, partner])
+        theirs = engine.Team("B", [opp_a, opp_b])
+        ai.team = partner.team = mine
+        opp_a.team = opp_b.team = theirs
+        mine.score, theirs.score = 890, 950
+        ai.hand, _trump = _powerhouse_hand()
+        ai.choose_bid(0, 10, {
+            "ever_bid": False, "passes_so_far": 0, "bid_history": [],
+            "pass_history": [], "passed_players": [], "dealer": ai,
+            "teams": [mine, theirs],
+        })
+    finally:
+        rollout.choose_bid_by_win_probability = original
+        engine.GENERAL_STRATEGY_SKILL_PARAMS[5] = original_params
+
+    assert calls == [(890, 950)]
+
+
+# ---------------------------------------------------------------------------
+# 8. The generator itself.
+# ---------------------------------------------------------------------------
+
+def test_generation_mirrors_every_observation():
+    """
+    The mirroring is what makes antisymmetry exact rather than approximate, so
+    it is checked on a freshly generated (tiny, deliberately under-powered)
+    table rather than only on the baked-in one - the baked table would keep
+    passing the antisymmetry test above even if the generator stopped
+    mirroring, since it was built when the generator still did.
+    """
+    table, stats = generate_table(6, seed=11)
+    assert stats["n_mirrored"] == 2 * stats["n_observations"]
+    for i in range(BUCKET_COUNT):
+        for j in range(BUCKET_COUNT):
+            assert abs(table[i][j] + table[j][i] - 1.0) < 0.005, (i, j)
+
+
+def test_generation_measures_its_own_prior_constants():
+    """The prior's round-gain/spread are measured from the same run that
+    builds the table, not carried over from whatever the module currently has
+    baked in - otherwise a regeneration would shrink new data toward a stale
+    model of the game."""
+    _table, stats = generate_table(6, seed=12)
+    assert stats["round_gain"] > 0
+    assert stats["round_spread"] > 0
+    assert stats["populated_cells"] > 0
+
+
+def test_bucket_midpoints_land_inside_their_bucket():
+    for index in range(BUCKET_COUNT):
+        assert score_bucket(bucket_midpoint(index)) == index

--- a/win_probability.py
+++ b/win_probability.py
@@ -1,0 +1,417 @@
+"""
+P(win the game | score state) - the objective the rollout AI maximizes
+(issue #102, epic #106).
+
+Every EV in `pinochle_rollout.py` up to now has been denominated in *points*:
+`bid_ev` in our own points, `defend_ev` / `bid_ev_differential` / `fold_ev` in
+score differential. Points are a proxy. What a player actually wants is to
+reach 1000 before the other side does, and the two come apart exactly where it
+matters most - at 890-950 a cautious pass is losing, because you cannot win by
+defending; at 200-180 the identical hand should play safe. A points objective
+cannot tell those apart, and the score is not even an input to it.
+
+This module supplies the missing conversion: a game state -> a probability.
+Once the objective is win probability, score-awareness stops being a special
+case anybody hand-codes.
+
+Why a lookup table and not a model
+----------------------------------
+The issue asks for the cheapest thing that works: "a coarse lookup table is a
+fine first version; it does not need to be a model." It is also the *honest*
+first version - the table is measured from self-play rather than asserted, so
+its errors are sampling error rather than modelling assumptions nobody checked.
+
+The table is 100-point buckets on each side's score, 20 x 20 = 400 cells over
+[-1000, 1000). It is consulted thousands of times per bid decision (once per
+rollout sample), so runtime has to be a list index, not a simulation.
+
+Three things keep it well-behaved where the data is thin:
+
+  Mirroring. Every observed round contributes twice - once as (ours, theirs)
+  and once as (theirs, ours) with the outcome flipped. That doubles the data
+  and makes `P(a, b) == 1 - P(b, a)` hold by construction rather than
+  approximately, which matters because the two sides of a bid-vs-defend
+  comparison read cells on opposite sides of the diagonal.
+
+  A smooth prior. Games walk up the diagonal from 0-0, so cells like
+  (-900, -900) are never visited and cells far off-diagonal are visited
+  rarely. Unvisited cells fall back to `prior_win_probability` below - a
+  race model, not a guess: a lead is worth more when fewer rounds remain,
+  because there is less variance left to overturn it.
+
+  Shrinkage. A cell seen 3 times is not evidence; it is noise that would show
+  up as a non-monotonic dent in the table. Each cell is blended toward the
+  prior with weight `SHRINK_STRENGTH / (n + SHRINK_STRENGTH)`, so a
+  well-observed cell is essentially its own empirical rate and a barely-seen
+  one is essentially the prior.
+
+What the measured table turned out to say
+----------------------------------------
+Worth recording, because it is not what the prior predicts and it explains a
+lot about how much this objective can be worth. The table is nearly *flat in
+game stage*: a 100-point lead is worth about 0.55-0.58 whether the score is
+100-0 or 700-600, and a 300-point lead about 0.64-0.71 across the same span.
+The race model expects a lead to be worth steadily more as the finish
+approaches; self-play says it barely is.
+
+The reason is the size of a Pinochle round. A scoring round is worth ~259
+points on average with a ~406-point spread between the teams, so even at
+700-600 there is more than a full round of variance still to come and a
+100-point lead is nearly noise. Leads only become decisive once a side can
+actually cross 1000 - which is the terminal case below, resolved exactly.
+
+So the practical leverage of a win-probability objective lives in the last
+round or two, not spread across the score range. That is a real result about
+the game, not a defect in the table.
+
+Terminal states are NOT looked up. `win_probability` resolves them exactly,
+mirroring `Game.play`'s own end-of-game rules (bust at -1000 checked before
+the 1000 target; the bidding team wins a round that carries both sides over).
+An estimate there would be strictly worse than the arithmetic, and the endgame
+is the whole reason this objective exists.
+
+Regenerating the table
+----------------------
+    python win_probability.py --games 6000 --seed 7
+
+prints the constants below, ready to paste. Do that after any change that
+moves how rounds score, and record the run's parameters in the constant's
+comment - a table generated from an AI nobody can identify later is a number
+with no provenance.
+"""
+
+import argparse
+import math
+import random
+from collections import defaultdict
+
+from pinochle_engine import GAME_LOSE_SCORE, GAME_WIN_SCORE, Game, Player
+
+
+# ---------------------------------------------------------------------------
+# Bucketing - the table's resolution.
+# ---------------------------------------------------------------------------
+
+BUCKET_SIZE = 100          # points per bucket; 100 keeps 890 and 950 in different rows
+BUCKET_MIN = GAME_LOSE_SCORE   # -1000, the bust floor
+BUCKET_COUNT = (GAME_WIN_SCORE - GAME_LOSE_SCORE) // BUCKET_SIZE  # 20
+
+
+def score_bucket(score):
+    """
+    Which row/column of the table a score falls in. Scores outside
+    [-1000, 1000) are clamped rather than rejected: a caller that hands us an
+    already-terminal score is asking the wrong question, but clamping keeps
+    the lookup total and the exact answer comes from `win_probability`'s
+    terminal check anyway.
+    """
+    index = int((score - BUCKET_MIN) // BUCKET_SIZE)
+    return max(0, min(BUCKET_COUNT - 1, index))
+
+
+def bucket_midpoint(index):
+    """Representative score for a bucket, used when the prior needs a number
+    rather than a range."""
+    return BUCKET_MIN + index * BUCKET_SIZE + BUCKET_SIZE // 2
+
+
+# ---------------------------------------------------------------------------
+# The prior - a race model, used for unobserved cells and as the shrinkage
+# target. Both constants are MEASURED by the generator below, not chosen.
+# ---------------------------------------------------------------------------
+
+# How fast the race runs. `TYPICAL_ROUND_GAIN` is the mean score a team takes
+# in a round it scores at all (set rounds subtract rather than advance, so
+# averaging them in would understate how quickly 1000 arrives);
+# `TYPICAL_ROUND_SPREAD` is the standard deviation of the per-round score
+# differential between the two teams. Both MEASURED over 6000 self-play games
+# (Proficient vs Proficient, seed 7) by `generate_table`, not chosen - see the
+# module docstring for how to regenerate.
+TYPICAL_ROUND_GAIN = 258.6
+TYPICAL_ROUND_SPREAD = 405.8
+
+# How many observations a cell needs before it mostly speaks for itself.
+# 40 is roughly "one cell's worth of a few hundred games" - large enough that
+# a 3-observation cell cannot dent the table, small enough that the
+# heavily-travelled cells near the diagonal are dominated by their own data.
+SHRINK_STRENGTH = 40
+
+
+def _normal_cdf(x):
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def prior_win_probability(our_score, their_score,
+                          round_gain=TYPICAL_ROUND_GAIN,
+                          round_spread=TYPICAL_ROUND_SPREAD):
+    """
+    P(win) under a simple race model: both sides are climbing toward 1000, the
+    per-round differential is noise with standard deviation `round_spread`,
+    and roughly `min(distance to go) / round_gain` rounds remain for that
+    noise to accumulate in.
+
+    The point of the model is not its precision, it is its *shape*: the same
+    60-point lead is nearly meaningless at 200-140 (many rounds left, plenty
+    of variance to come) and close to decisive at 950-890 (one round left, one
+    round of variance). That is the behaviour the issue is asking the AI to
+    learn, and it is what makes this a usable fallback for cells self-play
+    never visits.
+
+    Symmetric by construction: `prior(a, b) == 1 - prior(b, a)`, because the
+    remaining-rounds term depends only on the *smaller* distance to go.
+    """
+    ours_to_go = max(GAME_WIN_SCORE - our_score, 1.0)
+    theirs_to_go = max(GAME_WIN_SCORE - their_score, 1.0)
+    rounds_left = max(min(ours_to_go, theirs_to_go) / round_gain, 0.5)
+    sigma = round_spread * math.sqrt(rounds_left)
+    return _normal_cdf((our_score - their_score) / sigma)
+
+
+# ---------------------------------------------------------------------------
+# The measured table. Rows are OUR score bucket, columns THEIRS, both from
+# -1000 (index 0) to +900 (index 19) in 100-point steps. Value is P(we win).
+#
+# Generated by `python win_probability.py --games 6000 --seed 7` against
+# Proficient (`Player`) self-play - the AI the epic measures its changes
+# against. 30,210 round-states (60,420 after mirroring) filling 356 of the 400
+# cells; the 44 empty ones are deep in the both-sides-badly-negative corner
+# that real play never reaches, and fall back to `prior_win_probability`.
+# Every cell is shrunk toward that prior as described in the module docstring.
+# ---------------------------------------------------------------------------
+
+WIN_PROBABILITY_TABLE = [
+    [0.500, 0.463, 0.425, 0.385, 0.344, 0.301, 0.259, 0.216, 0.175, 0.136, 0.097, 0.090, 0.060, 0.034, 0.033, 0.002, 0.019, 0.000, 0.000, 0.000],
+    [0.537, 0.500, 0.462, 0.423, 0.381, 0.339, 0.295, 0.251, 0.202, 0.160, 0.129, 0.091, 0.048, 0.065, 0.037, 0.004, 0.001, 0.000, 0.000, 0.000],
+    [0.575, 0.538, 0.500, 0.461, 0.420, 0.377, 0.325, 0.274, 0.220, 0.206, 0.157, 0.137, 0.094, 0.032, 0.050, 0.038, 0.001, 0.018, 0.016, 0.000],
+    [0.615, 0.577, 0.539, 0.500, 0.460, 0.418, 0.364, 0.304, 0.287, 0.262, 0.199, 0.172, 0.173, 0.104, 0.095, 0.045, 0.035, 0.000, 0.017, 0.000],
+    [0.656, 0.619, 0.580, 0.540, 0.500, 0.461, 0.395, 0.380, 0.316, 0.384, 0.224, 0.175, 0.166, 0.111, 0.053, 0.079, 0.064, 0.041, 0.034, 0.011],
+    [0.699, 0.661, 0.623, 0.582, 0.539, 0.500, 0.467, 0.417, 0.379, 0.368, 0.252, 0.233, 0.194, 0.141, 0.102, 0.056, 0.026, 0.065, 0.010, 0.000],
+    [0.741, 0.705, 0.675, 0.636, 0.605, 0.533, 0.500, 0.466, 0.379, 0.401, 0.346, 0.298, 0.262, 0.145, 0.157, 0.122, 0.093, 0.035, 0.012, 0.000],
+    [0.784, 0.749, 0.726, 0.696, 0.620, 0.583, 0.534, 0.500, 0.471, 0.364, 0.344, 0.267, 0.244, 0.167, 0.153, 0.150, 0.148, 0.044, 0.048, 0.019],
+    [0.825, 0.798, 0.780, 0.713, 0.684, 0.621, 0.621, 0.529, 0.500, 0.439, 0.392, 0.403, 0.366, 0.274, 0.207, 0.156, 0.149, 0.084, 0.064, 0.005],
+    [0.864, 0.840, 0.794, 0.738, 0.616, 0.632, 0.599, 0.636, 0.561, 0.500, 0.467, 0.343, 0.355, 0.296, 0.195, 0.175, 0.201, 0.087, 0.071, 0.021],
+    [0.903, 0.871, 0.843, 0.801, 0.776, 0.748, 0.654, 0.656, 0.608, 0.533, 0.500, 0.424, 0.391, 0.364, 0.286, 0.250, 0.216, 0.129, 0.061, 0.046],
+    [0.910, 0.909, 0.863, 0.828, 0.825, 0.767, 0.702, 0.733, 0.597, 0.657, 0.576, 0.500, 0.453, 0.406, 0.342, 0.294, 0.245, 0.178, 0.137, 0.041],
+    [0.940, 0.952, 0.906, 0.827, 0.834, 0.806, 0.738, 0.756, 0.634, 0.645, 0.609, 0.547, 0.500, 0.466, 0.378, 0.286, 0.232, 0.215, 0.113, 0.051],
+    [0.966, 0.935, 0.968, 0.896, 0.889, 0.859, 0.855, 0.833, 0.726, 0.704, 0.636, 0.594, 0.534, 0.500, 0.399, 0.382, 0.295, 0.233, 0.226, 0.099],
+    [0.967, 0.963, 0.950, 0.905, 0.947, 0.898, 0.843, 0.847, 0.793, 0.805, 0.714, 0.658, 0.622, 0.601, 0.500, 0.422, 0.371, 0.314, 0.190, 0.121],
+    [0.998, 0.996, 0.962, 0.955, 0.921, 0.944, 0.878, 0.850, 0.844, 0.825, 0.750, 0.706, 0.714, 0.618, 0.578, 0.500, 0.440, 0.412, 0.294, 0.233],
+    [0.981, 0.999, 0.999, 0.965, 0.936, 0.974, 0.907, 0.852, 0.851, 0.799, 0.784, 0.755, 0.768, 0.705, 0.629, 0.560, 0.500, 0.458, 0.357, 0.296],
+    [1.000, 1.000, 0.982, 1.000, 0.959, 0.935, 0.965, 0.956, 0.916, 0.913, 0.871, 0.822, 0.785, 0.767, 0.686, 0.588, 0.542, 0.500, 0.438, 0.393],
+    [1.000, 1.000, 0.984, 0.983, 0.966, 0.990, 0.988, 0.952, 0.936, 0.929, 0.939, 0.863, 0.887, 0.774, 0.810, 0.706, 0.643, 0.562, 0.500, 0.505],
+    [1.000, 1.000, 1.000, 1.000, 0.989, 1.000, 1.000, 0.981, 0.995, 0.979, 0.954, 0.959, 0.949, 0.901, 0.879, 0.767, 0.704, 0.607, 0.495, 0.500],
+]
+
+
+def table_win_probability(our_score, their_score):
+    """
+    The raw table lookup, with no end-of-game handling. Public so tests and
+    tuning scripts can inspect the estimate itself; game code should call
+    `win_probability`, which resolves decided games exactly instead of
+    estimating them.
+    """
+    return WIN_PROBABILITY_TABLE[score_bucket(our_score)][score_bucket(their_score)]
+
+
+def resolve_game_winner(our_score, their_score, we_bid):
+    """
+    Who has already won, if anyone: True (us), False (them), or None if the
+    game continues.
+
+    Mirrors `Game.play`'s end conditions exactly rather than approximating
+    them, because this is the half of the objective that has to be *right*:
+
+      - Busting at -1000 is checked first and hands the game to the other
+        side, even if that side is nowhere near 1000.
+      - Otherwise a side at or past 1000 wins; if both crossed in the same
+        round, the *bidding* team takes it. `we_bid` is which side that was.
+
+    Only one team can bust in a given round (the defenders always score their
+    meld, which is never negative), so a double bust cannot arise from real
+    play; it is treated as undecided rather than given an invented winner.
+    """
+    we_busted = our_score <= GAME_LOSE_SCORE
+    they_busted = their_score <= GAME_LOSE_SCORE
+    if we_busted and they_busted:
+        return None
+    if we_busted:
+        return False
+    if they_busted:
+        return True
+
+    we_are_over = our_score >= GAME_WIN_SCORE
+    they_are_over = their_score >= GAME_WIN_SCORE
+    if we_are_over and they_are_over:
+        return bool(we_bid)
+    if we_are_over:
+        return True
+    if they_are_over:
+        return False
+    return None
+
+
+def win_probability(our_score, their_score, we_bid=False):
+    """
+    P(we win the game) from this score state - 1.0 / 0.0 when the game is
+    already over, the measured table otherwise.
+
+    `we_bid` only matters for the one ambiguous terminal state (both sides
+    past 1000 in the same round), where the rules give it to the bidding team.
+    It is a keyword with a default because most callers are asking about a
+    state that is plainly still in progress.
+    """
+    decided = resolve_game_winner(our_score, their_score, we_bid)
+    if decided is not None:
+        return 1.0 if decided else 0.0
+    return table_win_probability(our_score, their_score)
+
+
+# ---------------------------------------------------------------------------
+# Generation from self-play. Dev tooling - not imported by game code.
+# ---------------------------------------------------------------------------
+
+def collect_self_play_states(n_games, seed=None, player_class=Player, player_kwargs=None):
+    """
+    Play `n_games` full games and record, for every round, the score state the
+    round *started* from plus who eventually won.
+
+    `Game.play`'s `on_round` hook fires after the round is scored but before
+    the scores are applied, so `team.score` at that moment is exactly the
+    pre-round state - which is the state a bid decision is actually made in.
+
+    Returns `(observations, deltas)`: observations is a list of
+    `(our_score, their_score, we_won)` from team A's point of view, deltas is
+    the flat list of per-round (team A delta - team B delta) differentials the
+    prior's spread constant is measured from.
+    """
+    player_kwargs = player_kwargs or {}
+    rng = random.Random(seed)
+    observations = []
+    deltas = []
+    gains = []
+
+    for _ in range(n_games):
+        game_seed = rng.randrange(2 ** 63)
+        random.seed(game_seed)
+        players = [player_class(f"P{i}", None, **player_kwargs) for i in range(4)]
+        game = Game.from_players(players)
+        team_a, team_b = game.teams
+
+        states = []
+
+        def on_round(round_, round_scores, states=states, team_a=team_a, team_b=team_b):
+            states.append((team_a.score, team_b.score))
+            deltas.append(round_scores[team_a] - round_scores[team_b])
+            gains.append(round_scores[team_a])
+            gains.append(round_scores[team_b])
+
+        winner = game.play(deal_seed=game_seed, on_round=on_round)
+        a_won = winner is team_a
+        for our_score, their_score in states:
+            observations.append((our_score, their_score, a_won))
+
+    return observations, deltas, gains
+
+
+def _mean(values):
+    return sum(values) / len(values) if values else 0.0
+
+
+def _stdev(values):
+    if len(values) < 2:
+        return 0.0
+    mean = _mean(values)
+    return math.sqrt(sum((v - mean) ** 2 for v in values) / (len(values) - 1))
+
+
+def generate_table(n_games, seed=None, player_class=Player, player_kwargs=None,
+                   shrink_strength=SHRINK_STRENGTH):
+    """
+    Tabulate self-play outcomes into the 20 x 20 win-probability table.
+
+    Every observation is entered twice - once as itself and once mirrored
+    across the diagonal with the outcome flipped - so the table satisfies
+    `P(a, b) == 1 - P(b, a)` exactly. Without that, a bid-vs-defend comparison
+    could read two cells that disagree about the same situation purely because
+    one side of the diagonal happened to get more games.
+
+    Returns `(table, stats)`. `stats` carries the measured `round_gain` /
+    `round_spread` (which the prior needs, and which are re-measured here
+    rather than assumed) plus the per-cell observation counts, so a
+    regeneration can be sanity-checked instead of trusted.
+    """
+    observations, deltas, gains = collect_self_play_states(
+        n_games, seed=seed, player_class=player_class, player_kwargs=player_kwargs,
+    )
+
+    round_gain = _mean([g for g in gains if g > 0]) or TYPICAL_ROUND_GAIN
+    round_spread = _stdev(deltas) or TYPICAL_ROUND_SPREAD
+
+    wins = defaultdict(float)
+    counts = defaultdict(int)
+    for our_score, their_score, we_won in observations:
+        i, j = score_bucket(our_score), score_bucket(their_score)
+        counts[(i, j)] += 1
+        wins[(i, j)] += 1.0 if we_won else 0.0
+        # Mirrored copy: the same round seen from the other side of the table.
+        counts[(j, i)] += 1
+        wins[(j, i)] += 0.0 if we_won else 1.0
+
+    table = []
+    for i in range(BUCKET_COUNT):
+        row = []
+        for j in range(BUCKET_COUNT):
+            prior = prior_win_probability(
+                bucket_midpoint(i), bucket_midpoint(j),
+                round_gain=round_gain, round_spread=round_spread,
+            )
+            n = counts[(i, j)]
+            if n:
+                empirical = wins[(i, j)] / n
+                value = (n * empirical + shrink_strength * prior) / (n + shrink_strength)
+            else:
+                value = prior
+            row.append(round(value, 3))
+        table.append(row)
+
+    stats = {
+        "n_games": n_games,
+        "n_observations": len(observations),
+        "n_mirrored": 2 * len(observations),
+        "round_gain": round_gain,
+        "round_spread": round_spread,
+        "counts": dict(counts),
+        "populated_cells": sum(1 for v in counts.values() if v > 0),
+    }
+    return table, stats
+
+
+def format_table_literal(table):
+    """Render a generated table as the Python literal to paste into this
+    module - regeneration should be copy-paste, not hand transcription."""
+    lines = ["WIN_PROBABILITY_TABLE = ["]
+    for row in table:
+        lines.append("    [" + ", ".join(f"{v:.3f}" for v in row) + "],")
+    lines.append("]")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Regenerate the win-probability table from self-play (#102)",
+    )
+    parser.add_argument("--games", type=int, default=4000,
+                        help="self-play games to tabulate (default: 4000)")
+    parser.add_argument("--seed", type=int, default=7, help="seed for the self-play run")
+    args = parser.parse_args()
+
+    table, stats = generate_table(args.games, seed=args.seed)
+    print(f"# {stats['n_games']} games, {stats['n_observations']} round-states "
+          f"({stats['n_mirrored']} mirrored), {stats['populated_cells']}/400 cells populated")
+    print(f"TYPICAL_ROUND_GAIN = {stats['round_gain']:.1f}")
+    print(f"TYPICAL_ROUND_SPREAD = {stats['round_spread']:.1f}")
+    print(format_table_literal(table))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #102. Part of epic #106.

Replaces the rollout's points/differential objective with **probability of winning the game**: roll the round out exactly as before, apply the result to the current game score, convert that game state to `P(win from here)`, and average *that* instead of points.

**Measured and shipped disabled.** It does what the issue asks for behaviourally, but it does not win more games, so `use_win_probability` defaults `False` at every skill level — #101's precedent rather than #103's.

## What landed

- **`win_probability.py`** (new) — `P(win | our score, their score)`.
  - A coarse **20×20 lookup table**, 100-point buckets per side over `[-1000, 1000)`, tabulated from **6000 Proficient self-play games** (`python win_probability.py --games 6000 --seed 7` regenerates and reprints it). 30,210 round-states, 356/400 cells populated.
  - Every observation is entered **twice, mirrored**, so `P(a,b) = 1 − P(b,a)` holds exactly — the bid-vs-defend comparison reads cells on opposite sides of the diagonal, and cells that disagreed would make the comparison partly an artifact of which side got more games.
  - Thin cells are **shrunk toward a race-model prior** whose two constants (`TYPICAL_ROUND_GAIN`, `TYPICAL_ROUND_SPREAD`) are measured by the same run, not chosen.
  - **Terminal states are resolved exactly, not estimated**, mirroring `Game.play`: bust at −1000 is checked before the +1000 target, and a round carrying *both* sides over goes to the **bidding** team. The endgame is the whole point of this objective, so it is the one part that cannot be a little bit wrong.
- **`pinochle_rollout.py`** — `bid_ev_win_probability`, `defend_ev_win_probability`, `choose_bid_by_win_probability`, `fold_ev_win_probability`, plus optional `our_score`/`their_score` on `should_fold`. These reuse the *same* rollouts as the differential functions and change only the function applied to each sample, so the A/B compares objectives rather than two simulators. The differential path stays runnable next to them.
- **`pinochle_engine.py`** — `use_win_probability` in `GENERAL_STRATEGY_SKILL_PARAMS` (off everywhere), wired into `_rollout_ev_bid` and `decide_fold`.
- **`test_win_probability.py`** (new, 32 tests) — full suite **194 passed** (was 162).

## A/B (`ab_harness.py`, skill 5, win-probability objective vs the shipped differential one)

Headline run, **120 paired deals** (240 games, seed 424242):

|                        | WinProb | Differential |
|---|---|---|
| games won              | 122 (50.8%) | 118 (49.2%) |
| decisive pairs         | 16 | 14 |
| exact binomial p       | **0.8555** — not significant | |
| **margin per deal**    | **−92**, 95% CI **−170 to −13** | (CI excludes zero, *against* WinProb) |
| contracts won          | 758 | 581 |
| made / set / conceded  | 59.6% / 19.9% / 20.4% | 64.4% / 19.1% / 16.5% |
| avg bid                | 301 | 294 |

Two 40-pair replicates, both null:

- seed 20260730: games 41–39, margin **−29**, 95% CI **−159 to +109**, p = 1.00
- seed 991: games 44–36, margin **−46**, 95% CI **−158 to +69**, p = 0.42

**On the games-won vs margin tension.** The issue asks to be judged on games won *because* the two can diverge, and they did — in all three runs games leaned very slightly toward WinProb while margin leaned toward the differential objective. But games won is null at every sample size tried (p = 0.86 on the largest), and margin — the more sensitive statistic — is *negative* with a CI excluding zero on the 120-pair run. Neither statistic argues for enabling it, so the tension does not have to be adjudicated. Reporting both rather than quoting the friendlier one.

## Why it is null — measured, not guessed

The behaviour the issue asks for is present and is covered by tests. The same hand at the same bid **passes at 950-300 and bids at 890-950**, with no score branch anywhere in the code path.

What is missing is *leverage*. Two measurements:

1. **The self-play table is nearly flat in game stage.** A 100-point lead is worth ~0.58 at 100-0 and ~0.56 at 700-600; a 300-point lead ~0.64 to ~0.70 across the same span. A Pinochle round swings ~259 points with a ~406-point spread between the teams, so at 700-600 there is still more than a full round of variance to come and a lead is nearly noise. Leads become decisive only when a side can actually cross 1000 — which the exact terminal resolution already handles.
2. **The two objectives mostly agree.** Over 18 sampled hands at a fixed 300 candidate, they chose identically at 0-0 (0/18 differ) and at 500-500 (0/18), and differed only near the finish: 2/18 at 890-950 and 10/18 at 950-300.

An objective that only bites in the last round or two cannot move a whole-game A/B much. The follow-up worth trying is the endgame decisions specifically, not the objective across the board — recorded in the flag's comment so nobody re-runs this A/B without a new hypothesis.

## Things I found that contradict the issue's assumptions

1. **The 890-950 example is right, but not for the stated reason.** The issue says "you cannot win by defending, so you must bid aggressively". Under this engine's rules the defenders **always** score their meld and trick points, made contract or not — so a side sitting at 950 crosses 1000 in *any* round it merely defends. Bidding at 890-950 is correct because a round that carries **both** sides over goes to the **bidding team**, not because defending scores nothing. The distinction matters: at **300-950** the same reasoning inverts and bidding is worth exactly `P(win) = 0`, because we cannot cross with it while they cross regardless. The only live path there is that *they* bid and we set them — i.e. pass. Both cases are covered by tests.
2. **A surviving threshold caps the aggression this can express.** `_rollout_ev_bid` prunes any hand whose static `best_base_bid` ceiling is below `FORCED_BID` (250) *before* any rollout runs. So the "bid aggressively on a hand whose points-EV says otherwise" case is blocked outright for genuinely weak hands, however desperate the score. That prune is exactly the kind of constant #106 exists to remove; I left it alone rather than change two things at once in a PR whose job is to measure one of them.
3. **`computeCompetitiveAdjustment` / the >800 branch are not yet redundant.** The issue expects them to become deletable. They cannot go here: the flag defaults off, the static path is still the fallback (and still supplies trump choice and the floor above), and `best_base_bid(hand, my_score, opp_score)` is on the shared skill 1-3 path. Deleting them would have changed behaviour the A/B was not measuring. That deletion belongs with whatever ends up enabled.
4. **A coarse table really was enough.** The measured flatness in point 1 means extra resolution would not have bought anything — the estimate is not what is limiting this.

## Not done

Not merged, per convention. `use_win_probability` is off; enabling it needs a measurement that does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
