### PR TITLE
Fit and evaluate a cheap evaluator on the rollout data (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ level at creation) are implemented — see the strategy doc below.
   `--config` prints it. Output is `rollout_dataset.csv`; the committed
   file is a reproducible 2000-row prefix of a longer run, not a
   hand-edited artifact.
+- [`fit_evaluator.py`](fit_evaluator.py) — fits the cheap evaluator epic
+  #104 wants to ship to that dataset (issue #113), and reports how often
+  it reaches the rollout's *decision* rather than how close it gets to
+  `p_make`. Two separate logistic models, because a bid row (auction
+  running, melds unknown) and a fold row (auction over, both melds face
+  up) are different problems sharing one table. Held out the last 25% of
+  rows in capture order — a shuffled split would scatter one deal's rows
+  across the boundary. Held-out decision agreement is 85.5% on bid rows
+  against 74.3% for the shipped `ceiling >= OPENER_THRESHOLD` rule, and
+  92.0% on fold rows against 81.6% for never conceding; disagreements sit
+  almost entirely where the rollout's own two EVs are within sampling
+  noise of each other, not on any hand class. Nothing heavier than
+  logistic regression was warranted: a 150-tree gradient-boosted ensemble
+  on the same features scored 86.7% five-fold against the linear model's
+  86.3% ± 1.9%. Output is `rollout_evaluator.json`, the artifact #114
+  exports to TypeScript.
 - [`human_play.py`](human_play.py) — resumable interactive play layer
   (`HumanPlayer`, `InteractiveRound`) built for chat-session play, where
   a script can't block on `input()` between messages: decisions raise
@@ -119,6 +135,9 @@ python win_probability.py --games 6000 --seed 7   # regenerate the win-probabili
 python generate_rollout_dataset.py --config       # print the config the labels describe
 python generate_rollout_dataset.py --games 100 --samples 150 --seed 112 --max-rows 2000
                                        # regenerate the committed rollout dataset (~15 min)
+python fit_evaluator.py --compare --disagreements
+                                       # refit the cheap evaluator, with the baselines it
+                                       # has to beat and where it disagrees (~15 s)
 python -m pytest -q                    # full test suite
 ```
 

--- a/fit_evaluator.py
+++ b/fit_evaluator.py
@@ -1,0 +1,840 @@
+"""
+A cheap evaluator fitted to the rollout data (issue #113, epic #104).
+
+#112 measured what the skill-5 rollout AI decides in 2000 real decision points
+and wrote them to `rollout_dataset.csv`. This module fits a small predictor to
+those rows and reports how often it reaches the *same decision*, so #114 can
+replace `bidding.ts`'s `OPENER_THRESHOLD = 320` with something fitted to
+measured outcomes instead of guessed.
+
+Two models, not one. `decision_point` splits the dataset into `bid` rows (1655)
+and `fold` rows (345), and they are not the same problem wearing two hats:
+
+  * A bid row asks "does taking this contract beat defending it", from a
+    12-card hand with both melds unknown and an auction still running.
+  * A fold row asks "does playing this contract out beat conceding it", from a
+    *different* 12-card hand - post-pass - with both melds face up and the
+    auction over.
+
+The fold row's extra columns (`bidding_meld`, `defending_meld`) are blank on a
+bid row because no such measurement exists there, not because they are zero.
+One model over the union would have to invent values for them.
+
+Why logistic regression and nothing heavier. The decision each model has to
+reproduce is a threshold on a difference of two EVs, and the numbers below say a
+linear model in log-odds already sits within noise of a 150-tree gradient-boosted
+ensemble on the same features (86.3% vs 86.7% five-fold, against a fold-to-fold
+spread of +-1.6%). A weight vector is inspectable, exports to TypeScript as a dot
+product and a comparison, and costs microseconds in a React render; an ensemble
+buys none of that back for four tenths of a point. `--compare` prints the
+baselines that argument rests on rather than asking anyone to take it on trust.
+
+The one feature that is not a CSV column. `base_bid_ceiling` is recomputed here
+from the row's `hand` column via `compute_max_bid`/`capped_bid`. That is not a
+label leak and not expensive: it is exactly the quantity `bidding.ts` already
+computes as `bestBaseBid` and compares against `OPENER_THRESHOLD`, so #114 gets
+it for free. It carries the non-linear part of the valuation - run and marriage
+values, the competitive adjustment, the 400-cap - that no linear combination of
+`meld_total`, `ace_count` and `trump_length` can express, and it is worth about
+eight points of decision agreement on its own.
+
+Everything is stdlib. numpy is installed on this machine but nothing here needs
+it, the rest of the repo does not import it, and a fitted model that only a
+machine with numpy can reproduce is a worse artefact than one any Python can.
+
+    python fit_evaluator.py                       # fit, evaluate, write the model
+    python fit_evaluator.py --compare             # + baselines the "simple is enough" claim rests on
+    python fit_evaluator.py --disagreements       # + where the model and the rollout part company
+"""
+
+import argparse
+import csv
+import json
+import math
+
+from pinochle_engine import (
+    OPENER_THRESHOLD,
+    Suit,
+    capped_bid,
+    compute_max_bid,
+)
+from generate_rollout_dataset import (
+    BID_DECISION,
+    FOLD_DECISION,
+    decode_hand,
+    describe_live_configuration,
+)
+
+
+# ---------------------------------------------------------------------------
+# Features — the CSV columns, plus the one valuation `bidding.ts` already has.
+# ---------------------------------------------------------------------------
+
+# The default output. Committed alongside this module so #114 has an artefact to
+# export and #115 has something to measure, without re-running the fit.
+DEFAULT_MODEL_PATH = "rollout_evaluator.json"
+DEFAULT_DATASET_PATH = "rollout_dataset.csv"
+
+BID_FEATURES = [
+    "meld_total",
+    "ace_count",
+    "trump_length",
+    "longest_side_suit",
+    "has_run",
+    "has_pinochle",
+    "has_around",
+    "bid",
+    "score_diff",
+    "partner_has_bid",
+    "partner_has_passed",
+    "base_bid_ceiling",     # compute_max_bid + the cap rule — `bestBaseBid` in bidding.ts
+    "ceiling_minus_bid",    # how far the valuation clears the level under consideration
+]
+
+# `ceiling_minus_bid` is exactly `base_bid_ceiling - bid`, so those three columns
+# are collinear and the ridge penalty splits one effect across them: read the
+# fitted weights as the sums (+0.025 per point of ceiling, -0.026 per point of
+# bid), not individually. Dropping either redundant column moves five-fold
+# agreement by under 0.2% - well inside the +-1.9% fold spread - so all three are
+# kept for readability rather than because the third earns its place.
+
+# Deliberately *not* `score_diff`, and deliberately not the auction columns.
+#
+# `should_fold` was called with `our_score`/`their_score` withheld while
+# `use_win_probability` is off (see `label_fold_situation`), so `verdict_fold` is
+# mathematically independent of the game score - any weight fitted on it would be
+# fitting noise, and five-fold agreement does drop (93.6% -> 92.8%) when it is
+# included. `partner_has_bid`/`partner_has_passed` are constant False on every
+# fold row: the auction is over by then, so they carry no information at all.
+FOLD_FEATURES = [
+    "meld_total",
+    "ace_count",
+    "trump_length",
+    "longest_side_suit",
+    "has_run",
+    "has_pinochle",
+    "has_around",
+    "bid",
+    "bidding_meld",
+    "defending_meld",
+    "base_bid_ceiling",
+    "ceiling_minus_bid",
+    "tricks_needed",        # bid - bidding_meld: points still to be won in tricks
+    "fold_cost",            # bid + defending_meld: exactly what conceding costs
+]
+
+# Ridge strengths, chosen by the five-fold sweep `--compare` reproduces. The fold
+# model is regularised harder relative to its size because 345 rows and 14
+# features is a thin fit and the fold-to-fold spread is three times the bid
+# model's.
+BID_L2 = 0.01
+FOLD_L2 = 0.003
+
+
+def base_bid_ceiling(hand, trump, our_score=0, their_score=0):
+    """
+    The Base Bid valuation of `hand` in `trump`, after the competitive
+    adjustment and the 400-cap rule — i.e. the number `OPENER_THRESHOLD` is
+    compared against.
+
+    Named trump rather than searched, because by the time a row exists the trump
+    is already decided: on a bid row it is `best_base_bid`'s pick recorded in the
+    `trump` column, and on a fold row it is the suit that was actually declared.
+    Re-searching would value a contract nobody is playing.
+    """
+    total, _breakdown = compute_max_bid(hand, trump, our_score, their_score)
+    return capped_bid(hand, trump, total)
+
+
+def _number(text):
+    """CSV cell -> float, or None for a blank. Blank means "not measured here"
+    and must never silently become 0.0 — `ev_fold` of zero is a real value."""
+    return None if text == "" else float(text)
+
+
+def read_dataset(path=DEFAULT_DATASET_PATH):
+    """The CSV as dicts with numeric cells parsed and blanks kept as None."""
+    with open(path, newline="", encoding="utf-8") as handle:
+        rows = []
+        for raw in csv.DictReader(handle):
+            row = dict(raw)
+            for key, value in raw.items():
+                if key not in ("decision_point", "trump", "hand"):
+                    row[key] = _number(value)
+            rows.append(row)
+    return rows
+
+
+def bid_rows(rows):
+    return [r for r in rows if r["decision_point"] == BID_DECISION]
+
+
+def fold_rows(rows):
+    return [r for r in rows if r["decision_point"] == FOLD_DECISION]
+
+
+def bid_features(row):
+    """`BID_FEATURES` for one bid row, ceiling included.
+
+    The ceiling is computed at the row's live scores because the bid label is:
+    `label_bid_situation` picks trump with `best_base_bid(hand, our_score,
+    their_score)`, so the score is already inside the label through the trump
+    it selected.
+    """
+    hand = decode_hand(row["hand"])
+    ceiling = base_bid_ceiling(
+        hand, Suit(row["trump"]), int(row["our_score"]), int(row["their_score"]),
+    )
+    features = {name: row[name] for name in BID_FEATURES
+                if name not in ("base_bid_ceiling", "ceiling_minus_bid")}
+    features["base_bid_ceiling"] = float(ceiling)
+    features["ceiling_minus_bid"] = float(ceiling) - row["bid"]
+    return features
+
+
+def fold_features(row):
+    """
+    `FOLD_FEATURES` for one fold row.
+
+    Scores are passed as 0/0 on purpose. The fold label was measured with the
+    scores withheld, so a ceiling carrying a competitive adjustment would be the
+    one place a score could leak back into a model of a score-independent
+    quantity. (It happens to make no difference to five-fold agreement on this
+    dataset — the adjustment is small next to the cap — but "happens not to
+    matter here" is not a reason to ship the coupling.)
+    """
+    hand = decode_hand(row["hand"])
+    ceiling = float(base_bid_ceiling(hand, Suit(row["trump"])))
+    features = {name: row[name] for name in FOLD_FEATURES
+                if name not in ("base_bid_ceiling", "ceiling_minus_bid",
+                                "tricks_needed", "fold_cost")}
+    features["base_bid_ceiling"] = ceiling
+    features["ceiling_minus_bid"] = ceiling - row["bid"]
+    features["tricks_needed"] = row["bid"] - row["bidding_meld"]
+    features["fold_cost"] = row["bid"] + row["defending_meld"]
+    return features
+
+
+# The two decision problems, as one table, so evaluation and export can loop
+# over them instead of hard-coding "bid" and "fold" in six places.
+PROBLEMS = {
+    BID_DECISION: {
+        "rows": bid_rows,
+        "features": BID_FEATURES,
+        "extract": bid_features,
+        "label": "verdict_bid",
+        "l2": BID_L2,
+        "decision": "1 = bid (taking the contract beats defending it)",
+    },
+    FOLD_DECISION: {
+        "rows": fold_rows,
+        "features": FOLD_FEATURES,
+        "extract": fold_features,
+        "label": "verdict_fold",
+        "l2": FOLD_L2,
+        "decision": "1 = concede (playing the contract out is worse than folding)",
+    },
+}
+
+
+def design_matrix(rows, problem):
+    """(X, y) for one problem: X in `problem["features"]` order, y the verdict."""
+    extract, names = problem["extract"], problem["features"]
+    X = [[float(extract(row)[name]) for name in names] for row in rows]
+    y = [int(row[problem["label"]]) for row in rows]
+    return X, y
+
+
+# ---------------------------------------------------------------------------
+# Logistic regression — pure Python, IRLS.
+#
+# IRLS rather than gradient descent because it converges in under ten iterations
+# on a problem this small and needs no learning rate to tune. With 14 features
+# the Newton system is a 15x15 solve, which is nothing; the cost is entirely the
+# O(n*d^2) Hessian, and a full fit on 1655 rows takes a couple of seconds.
+#
+# Fitting happens on standardised columns (an unscaled `meld_total` of 510 next
+# to a 0/1 flag makes the Hessian badly conditioned), but the exported weights
+# are folded back into RAW feature units. #114 should not have to ship a mean
+# and a standard deviation alongside the model to use it.
+# ---------------------------------------------------------------------------
+
+MAX_IRLS_ITERATIONS = 40
+IRLS_TOLERANCE = 1e-9
+
+
+def _solve(matrix, vector):
+    """Gaussian elimination with partial pivoting. Raises on a singular system
+    rather than returning a plausible-looking wrong answer."""
+    size = len(vector)
+    augmented = [list(row) + [vector[i]] for i, row in enumerate(matrix)]
+    for col in range(size):
+        pivot = max(range(col, size), key=lambda r: abs(augmented[r][col]))
+        if abs(augmented[pivot][col]) < 1e-12:
+            raise ValueError("singular system in logistic fit")
+        augmented[col], augmented[pivot] = augmented[pivot], augmented[col]
+        pivot_row = augmented[col]
+        for row_index in range(col + 1, size):
+            row = augmented[row_index]
+            factor = row[col] / pivot_row[col]
+            if factor:
+                for k in range(col, size + 1):
+                    row[k] -= factor * pivot_row[k]
+    solution = [0.0] * size
+    for col in reversed(range(size)):
+        row = augmented[col]
+        total = row[size] - sum(row[k] * solution[k] for k in range(col + 1, size))
+        solution[col] = total / row[col]
+    return solution
+
+
+def _column_stats(X):
+    """Per-column mean and standard deviation, with zero-variance columns given
+    a scale of 1 so a constant feature cannot divide by zero."""
+    n, d = len(X), len(X[0])
+    means = [sum(row[j] for row in X) / n for j in range(d)]
+    scales = []
+    for j in range(d):
+        variance = sum((row[j] - means[j]) ** 2 for row in X) / n
+        scales.append(math.sqrt(variance) if variance > 1e-12 else 1.0)
+    return means, scales
+
+
+def _sigmoid(z):
+    return 1.0 / (1.0 + math.exp(-max(-30.0, min(30.0, z))))
+
+
+class LogisticModel:
+    """
+    A fitted linear-in-log-odds classifier in raw feature units.
+
+    `weights` and `intercept` are what #114 exports: the decision is
+    `sum(w[i] * x[i]) + intercept >= 0`, with no scaling step in between, which
+    is the whole reason the standardisation is unwound at the end of `fit`.
+    `threshold` is carried explicitly rather than assumed to be 0.5 so a later
+    issue can trade false bids against false passes without refitting.
+    """
+
+    def __init__(self, features, weights, intercept, threshold=0.5, decision=""):
+        self.features = list(features)
+        self.weights = list(weights)
+        self.intercept = intercept
+        self.threshold = threshold
+        self.decision = decision
+
+    def logit(self, features):
+        return self.intercept + sum(
+            weight * features[name] for name, weight in zip(self.features, self.weights)
+        )
+
+    def probability(self, features):
+        return _sigmoid(self.logit(features))
+
+    def decide(self, features):
+        """The model's decision, as a 0/1 matching the dataset's verdict column."""
+        return int(self.probability(features) >= self.threshold)
+
+    def to_dict(self):
+        return {
+            "kind": "logistic",
+            "decision": self.decision,
+            "threshold": self.threshold,
+            "intercept": self.intercept,
+            "features": self.features,
+            "weights": self.weights,
+        }
+
+    @classmethod
+    def from_dict(cls, payload):
+        if payload.get("kind") != "logistic":
+            raise ValueError(f"unsupported model kind {payload.get('kind')!r}")
+        return cls(payload["features"], payload["weights"], payload["intercept"],
+                   payload.get("threshold", 0.5), payload.get("decision", ""))
+
+
+def fit_logistic(X, y, feature_names, l2=0.01, decision=""):
+    """
+    Ridge-penalised logistic regression by IRLS, returned in raw feature units.
+
+    The penalty is on the weights only, never the intercept: penalising the
+    intercept would pull the model's base rate towards 50% on a problem whose
+    base rate is 17% (fold rows), which is not a prior anyone holds.
+    """
+    n, d = len(X), len(feature_names)
+    means, scales = _column_stats(X)
+    Z = [[(row[j] - means[j]) / scales[j] for j in range(d)] + [1.0] for row in X]
+
+    beta = [0.0] * (d + 1)
+    for _iteration in range(MAX_IRLS_ITERATIONS):
+        probabilities = [_sigmoid(sum(b * z for b, z in zip(beta, row))) for row in Z]
+        gradient = [
+            sum((probabilities[i] - y[i]) * Z[i][j] for i in range(n)) / n
+            + (l2 * beta[j] if j < d else 0.0)
+            for j in range(d + 1)
+        ]
+        weights_irls = [max(p * (1.0 - p), 1e-6) for p in probabilities]
+        hessian = [[0.0] * (d + 1) for _ in range(d + 1)]
+        for i in range(n):
+            row, w = Z[i], weights_irls[i]
+            for j in range(d + 1):
+                wz = w * row[j]
+                if wz:
+                    hessian_row = hessian[j]
+                    for k in range(j, d + 1):
+                        hessian_row[k] += wz * row[k]
+        for j in range(d + 1):
+            for k in range(j, d + 1):
+                hessian[j][k] /= n
+                hessian[k][j] = hessian[j][k]
+            if j < d:
+                hessian[j][j] += l2
+
+        step = _solve(hessian, gradient)
+        beta = [b - s for b, s in zip(beta, step)]
+        if max(abs(s) for s in step) < IRLS_TOLERANCE:
+            break
+
+    # Unwind the standardisation so the exported model reads raw features.
+    weights = [beta[j] / scales[j] for j in range(d)]
+    intercept = beta[d] - sum(weights[j] * means[j] for j in range(d))
+    return LogisticModel(feature_names, weights, intercept, decision=decision)
+
+
+# ---------------------------------------------------------------------------
+# Splits — grouped by capture order, not shuffled.
+#
+# `collect_situations` appends rows in play order, so a contiguous block is a
+# contiguous run of games. That matters: one deal produces up to four bid rows
+# and a fold row that share a shuffle, and a shuffled split would scatter those
+# across the boundary and quietly inflate every number below. A tail split can
+# straddle at most one round.
+# ---------------------------------------------------------------------------
+
+HOLDOUT_FRACTION = 0.25
+DEFAULT_FOLDS = 5
+
+
+def tail_split(rows, holdout=HOLDOUT_FRACTION):
+    """(train, test) — the last `holdout` of the rows, in capture order."""
+    cut = int(len(rows) * (1.0 - holdout))
+    return rows[:cut], rows[cut:]
+
+
+def contiguous_folds(count, folds=DEFAULT_FOLDS):
+    """Yields (train_indices, test_indices) for `folds` contiguous blocks."""
+    for index in range(folds):
+        low, high = count * index // folds, count * (index + 1) // folds
+        test = list(range(low, high))
+        train = [i for i in range(count) if i < low or i >= high]
+        yield train, test
+
+
+# ---------------------------------------------------------------------------
+# Evaluation — decisions, not p_make.
+#
+# The acceptance criterion for #113 is decision agreement: matching `p_make` to
+# three decimals is worthless if the comparison it feeds flips. Everything here
+# is measured against the verdict columns for that reason.
+# ---------------------------------------------------------------------------
+
+def decision_agreement(model, rows, problem):
+    """Fraction of `rows` where the model reaches the rollout's decision."""
+    X, y = design_matrix(rows, problem)
+    names = problem["features"]
+    agreed = sum(
+        1 for row, target in zip(X, y)
+        if model.decide(dict(zip(names, row))) == target
+    )
+    return agreed / len(rows)
+
+
+def majority_rate(rows, problem):
+    """What "always answer with the commoner verdict" scores — the floor any
+    fitted model has to clear before it has said anything at all."""
+    labels = [int(row[problem["label"]]) for row in rows]
+    positive = sum(labels) / len(labels)
+    return max(positive, 1.0 - positive)
+
+
+def cross_validated_agreement(rows, problem, folds=DEFAULT_FOLDS, l2=None):
+    """
+    Mean and spread of decision agreement over contiguous folds.
+
+    The spread is reported everywhere alongside the mean because the whole
+    "simple is enough" argument in this module's docstring is an argument about
+    a gap being smaller than the fold-to-fold noise, and a mean on its own
+    cannot support or refute that.
+    """
+    l2 = problem["l2"] if l2 is None else l2
+    X, y = design_matrix(rows, problem)
+    names = problem["features"]
+    scores = []
+    for train, test in contiguous_folds(len(rows), folds):
+        model = fit_logistic([X[i] for i in train], [y[i] for i in train], names, l2=l2)
+        agreed = sum(1 for i in test if model.decide(dict(zip(names, X[i]))) == y[i])
+        scores.append(agreed / len(test))
+    mean = sum(scores) / len(scores)
+    spread = math.sqrt(sum((s - mean) ** 2 for s in scores) / len(scores))
+    return mean, spread, scores
+
+
+# ---------------------------------------------------------------------------
+# Where it disagrees — the part #114 and #115 actually need.
+#
+# "78% agreement" and "86% agreement" are the same sentence to a reader who does
+# not know whether the missing rows are a hand class the model gets wrong every
+# time or a scatter around a boundary the rollout itself cannot resolve. These
+# are two different problems: the first is a modelling failure, the second is
+# label noise that no model can fix and that costs almost nothing at the table,
+# because a row where the two EVs are a coin flip apart is a row where either
+# decision is worth about the same.
+# ---------------------------------------------------------------------------
+
+# Boundaries in points of score differential. `ev_take` and `ev_defend` are each
+# a mean over 150 sampled rounds swinging hundreds of points, so their difference
+# carries a standard error in the tens: a margin under ~50 is inside the label's
+# own noise, and a margin over 200 is not.
+MARGIN_EDGES = [0, 25, 50, 100, 200, 400, float("inf")]
+
+
+def label_margin(row):
+    """
+    |EV(take) - EV(defend)| on a bid row, |EV(play on) - EV(fold)| on a fold row:
+    how decisively the rollout preferred what it preferred.
+
+    This is the axis a disagreement has to be read against. The verdict columns
+    are a sign, and a sign computed from a sampled difference of 3 points is not
+    the same claim as one computed from a difference of 300.
+    """
+    if row["decision_point"] == BID_DECISION:
+        return abs(row["ev_take"] - row["ev_defend"])
+    return abs(row["ev_play_on"] - row["ev_fold"])
+
+
+def mean_regret(model, rows, problem):
+    """
+    Mean EV given up per decision by following the model instead of the rollout,
+    in points of score differential.
+
+    Agreement counts every disagreement equally; this does not. A row where the
+    two futures are 4 points apart costs 4 points to get "wrong", and a
+    disagreement rate that lives entirely on such rows is worth almost nothing
+    at the table. This is the number that makes "the disagreements are near the
+    boundary" a claim about consequences rather than about a histogram, and it
+    is the number #115 should expect to see reflected in win rate.
+    """
+    names, extract = problem["features"], problem["extract"]
+    total = 0.0
+    for row in rows:
+        predicted = model.decide({n: float(extract(row)[n]) for n in names})
+        if predicted != int(row[problem["label"]]):
+            total += label_margin(row)
+    return total / len(rows)
+
+
+def shipped_rule_regret(rows):
+    """`mean_regret` for the rule that ships today, so the model's number has
+    something on the same scale to be compared against."""
+    total = 0.0
+    for row in rows:
+        ceiling = bid_features(row)["base_bid_ceiling"]
+        if int(ceiling >= OPENER_THRESHOLD) != int(row["verdict_bid"]):
+            total += label_margin(row)
+    return total / len(rows)
+
+
+def _buckets(rows, key, edges):
+    grouped = {}
+    for row in rows:
+        value = key(row)
+        for low, high in zip(edges, edges[1:]):
+            if low <= value < high:
+                grouped.setdefault((low, high), []).append(row)
+                break
+    return grouped
+
+
+def disagreement_by(model, rows, problem, key, edges):
+    """Disagreement rate per bucket of `key`, as (bucket, n, rate) tuples."""
+    names = problem["features"]
+    extract = problem["extract"]
+    report = []
+    for bucket, members in sorted(_buckets(rows, key, edges).items()):
+        wrong = sum(
+            1 for row in members
+            if model.decide({n: float(extract(row)[n]) for n in names})
+            != int(row[problem["label"]])
+        )
+        report.append((bucket, len(members), wrong / len(members)))
+    return report
+
+
+def disagreement_direction(model, rows, problem):
+    """
+    Splits the disagreements into the two ways they can go.
+
+    For bid rows: `false_positive` is the model bidding a contract the rollout
+    would have passed, `false_negative` is the reverse. They are not
+    interchangeable at the table - one loses points to sets, the other loses
+    contracts to the opponents - so #114 needs the split, not the total.
+    """
+    names, extract = problem["features"], problem["extract"]
+    counts = {"false_positive": 0, "false_negative": 0, "agreed": 0}
+    for row in rows:
+        predicted = model.decide({n: float(extract(row)[n]) for n in names})
+        target = int(row[problem["label"]])
+        if predicted == target:
+            counts["agreed"] += 1
+        elif predicted == 1:
+            counts["false_positive"] += 1
+        else:
+            counts["false_negative"] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Baselines — what "good enough" is measured against.
+#
+# The bar is not 50%. #114 replaces a rule that already exists, so the honest
+# comparison is against what ships today (`ceiling >= OPENER_THRESHOLD`) and
+# against the cheapest possible improvement on it (the same rule with the
+# constant refitted). A model that cannot beat a retuned constant does not
+# justify the export format, the wiring, or the maintenance.
+# ---------------------------------------------------------------------------
+
+def shipped_rule_agreement(rows):
+    """How often `bidding.ts`'s live rule agrees with the rollout on bid rows."""
+    agreed = 0
+    for row in rows:
+        ceiling = bid_features(row)["base_bid_ceiling"]
+        agreed += int(int(ceiling >= OPENER_THRESHOLD) == int(row["verdict_bid"]))
+    return agreed / len(rows)
+
+
+THRESHOLD_SEARCH = range(120, 525, 5)  # the observed ceiling range, in bid-level steps
+
+
+def tuned_threshold_agreement(train, test):
+    """
+    Fit the single constant `OPENER_THRESHOLD` on `train`, score it on `test`.
+
+    The steel-man for doing nothing. If a whole weight vector only matches this,
+    #114's correct move is a one-line constant change and not an exported model.
+    """
+    train_ceilings = [(bid_features(r)["base_bid_ceiling"], int(r["verdict_bid"]))
+                      for r in train]
+    best = max(
+        THRESHOLD_SEARCH,
+        key=lambda t: sum(1 for c, v in train_ceilings if int(c >= t) == v),
+    )
+    test_ceilings = [(bid_features(r)["base_bid_ceiling"], int(r["verdict_bid"]))
+                     for r in test]
+    agreed = sum(1 for c, v in test_ceilings if int(c >= best) == v)
+    return best, agreed / len(test)
+
+
+# ---------------------------------------------------------------------------
+# The fitted artefact.
+#
+# JSON, not a pickle: #114 has to read this from TypeScript, and a format only
+# Python can open would make the export step a rewrite instead of a read. Every
+# number a consumer needs is in the file, including the configuration the labels
+# describe - a model fitted against a flag that has since flipped is worse than
+# no model, and the file should be able to say so about itself.
+# ---------------------------------------------------------------------------
+
+MODEL_FORMAT_VERSION = 1
+
+
+def fit_evaluator(rows, holdout=HOLDOUT_FRACTION, folds=DEFAULT_FOLDS):
+    """
+    Fit both models on the training split and measure them on the held-out one.
+
+    Returns (models, metrics). Models are fitted on the TRAINING rows only, so
+    the reported agreement describes rows the fit never saw. `refit_on_all`
+    below is what produces the shipped weights, once the held-out numbers have
+    been read and accepted.
+    """
+    models, metrics = {}, {}
+    for name, problem in PROBLEMS.items():
+        subset = problem["rows"](rows)
+        train, test = tail_split(subset, holdout)
+        model = fit_logistic(*design_matrix(train, problem)[:2],
+                             feature_names=problem["features"], l2=problem["l2"],
+                             decision=problem["decision"])
+        mean, spread, scores = cross_validated_agreement(subset, problem, folds)
+        models[name] = model
+        metrics[name] = {
+            "rows": len(subset),
+            "train_rows": len(train),
+            "test_rows": len(test),
+            "train_agreement": decision_agreement(model, train, problem),
+            "holdout_agreement": decision_agreement(model, test, problem),
+            "holdout_majority_baseline": majority_rate(test, problem),
+            "cross_validated_agreement": mean,
+            "cross_validated_spread": spread,
+            "cross_validated_folds": scores,
+            "holdout_disagreement_direction": disagreement_direction(model, test, problem),
+            "holdout_mean_regret": mean_regret(model, test, problem),
+        }
+    return models, metrics
+
+
+def refit_on_all(rows):
+    """
+    The shipped weights: both models refitted on every row.
+
+    Held-out agreement is an estimate of how a model fitted this way behaves,
+    not a property of a particular 75% of the data - so once that estimate is in
+    hand there is no reason to ship a model that ignores a quarter of the
+    measurements. The metrics in the artefact still come from the split fit.
+    """
+    return {
+        name: fit_logistic(*design_matrix(problem["rows"](rows), problem)[:2],
+                           feature_names=problem["features"], l2=problem["l2"],
+                           decision=problem["decision"])
+        for name, problem in PROBLEMS.items()
+    }
+
+
+def build_artefact(rows, dataset_path=DEFAULT_DATASET_PATH,
+                   holdout=HOLDOUT_FRACTION, folds=DEFAULT_FOLDS):
+    """The full JSON payload: models, how they were measured, and against what."""
+    _split_models, metrics = fit_evaluator(rows, holdout, folds)
+    shipped = refit_on_all(rows)
+    return {
+        "format_version": MODEL_FORMAT_VERSION,
+        "issue": "113",
+        "generated_by": "fit_evaluator.py",
+        "dataset": dataset_path,
+        "dataset_rows": len(rows),
+        "labelled_configuration": describe_live_configuration(),
+        "holdout_fraction": holdout,
+        "split": "contiguous tail in capture order (a run of whole games)",
+        "models": {name: model.to_dict() for name, model in shipped.items()},
+        "metrics": metrics,
+    }
+
+
+def write_artefact(artefact, path=DEFAULT_MODEL_PATH):
+    """Pretty-printed and key-sorted, so a refit produces a readable diff rather
+    than one reordered line."""
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(artefact, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def load_models(path=DEFAULT_MODEL_PATH):
+    """The committed models, keyed by decision point. The reader #114 needs."""
+    with open(path, encoding="utf-8") as handle:
+        artefact = json.load(handle)
+    return {name: LogisticModel.from_dict(payload)
+            for name, payload in artefact["models"].items()}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _format_metrics(name, metrics):
+    m = metrics[name]
+    direction = m["holdout_disagreement_direction"]
+    return "\n".join([
+        f"{name} rows: {m['rows']} ({m['train_rows']} train / {m['test_rows']} held out)",
+        f"  held-out decision agreement   {m['holdout_agreement']:.3f}",
+        f"  majority-verdict baseline     {m['holdout_majority_baseline']:.3f}",
+        f"  training agreement            {m['train_agreement']:.3f}",
+        f"  5-fold agreement              {m['cross_validated_agreement']:.3f} "
+        f"+-{m['cross_validated_spread']:.3f}",
+        f"  held-out disagreements        {direction['false_positive']} false-positive, "
+        f"{direction['false_negative']} false-negative",
+        f"  held-out mean regret          {m['holdout_mean_regret']:.1f} points/decision",
+    ])
+
+
+def _print_comparison(rows):
+    """The baselines the "logistic is enough" claim rests on."""
+    problem = PROBLEMS[BID_DECISION]
+    subset = problem["rows"](rows)
+    train, test = tail_split(subset)
+    threshold, tuned = tuned_threshold_agreement(train, test)
+
+    without = [f for f in BID_FEATURES if f not in ("base_bid_ceiling", "ceiling_minus_bid")]
+    reduced = dict(problem, features=without)
+    reduced_mean, reduced_spread, _ = cross_validated_agreement(subset, reduced)
+    full_mean, full_spread, _ = cross_validated_agreement(subset, problem)
+
+    print("\nBid decision, alternatives (5-fold unless noted):")
+    print(f"  always pass (majority verdict)          {majority_rate(subset, problem):.3f}")
+    print(f"  shipped rule, ceiling >= {OPENER_THRESHOLD}           "
+          f"{shipped_rule_agreement(subset):.3f}")
+    print(f"  same rule, constant refit to {threshold} (held out)  {tuned:.3f}")
+    print(f"  logistic without the ceiling feature    {reduced_mean:.3f} +-{reduced_spread:.3f}")
+    print(f"  logistic as shipped                     {full_mean:.3f} +-{full_spread:.3f}")
+
+    fitted = fit_logistic(*design_matrix(train, problem)[:2],
+                          feature_names=problem["features"], l2=problem["l2"])
+    print("\nMean EV given up per held-out bid decision (points of differential):")
+    print(f"  shipped rule, ceiling >= {OPENER_THRESHOLD}           "
+          f"{shipped_rule_regret(test):.1f}")
+    print(f"  logistic as shipped                     {mean_regret(fitted, test, problem):.1f}")
+
+
+def _print_disagreements(rows, models):
+    for name, problem in PROBLEMS.items():
+        subset = problem["rows"](rows)
+        _train, test = tail_split(subset)
+        model = models[name]
+        print(f"\n{name} disagreements on the held-out split, "
+              f"by |EV difference| the rollout measured:")
+        for (low, high), count, rate in disagreement_by(
+                model, test, problem, label_margin, MARGIN_EDGES):
+            label = f"[{low:>5.0f}, {high:>5.0f})" if high != float("inf") else f"[{low:>5.0f},   inf)"
+            print(f"  margin {label}  n={count:<5d} disagree {rate:.3f}")
+        print(f"  {'bid level' if name == BID_DECISION else 'contract level'}:")
+        for (low, high), count, rate in disagreement_by(
+                model, test, problem, lambda r: r["bid"], [250, 300, 310, 320, 340, 1000]):
+            print(f"  bid [{low:>4.0f}, {high:>4.0f})       n={count:<5d} disagree {rate:.3f}")
+        print("  guaranteed meld:")
+        for (low, high), count, rate in disagreement_by(
+                model, test, problem, lambda r: r["meld_total"], [0, 60, 120, 200, 1000]):
+            print(f"  meld [{low:>4.0f}, {high:>4.0f})      n={count:<5d} disagree {rate:.3f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fit and evaluate a cheap evaluator on the rollout data (#113, epic #104)",
+    )
+    parser.add_argument("--dataset", default=DEFAULT_DATASET_PATH)
+    parser.add_argument("--out", default=DEFAULT_MODEL_PATH)
+    parser.add_argument("--holdout", type=float, default=HOLDOUT_FRACTION)
+    parser.add_argument("--folds", type=int, default=DEFAULT_FOLDS)
+    parser.add_argument("--compare", action="store_true",
+                        help="also print the baselines the model has to beat to be worth shipping")
+    parser.add_argument("--disagreements", action="store_true",
+                        help="also print where the model and the rollout part company")
+    parser.add_argument("--no-write", action="store_true", help="evaluate without writing the model")
+    args = parser.parse_args()
+
+    rows = read_dataset(args.dataset)
+    print(describe_live_configuration())
+    print(f"\n{len(rows)} rows from {args.dataset}\n")
+
+    split_models, metrics = fit_evaluator(rows, args.holdout, args.folds)
+    for name in PROBLEMS:
+        print(_format_metrics(name, metrics))
+        print()
+
+    if args.compare:
+        _print_comparison(rows)
+    if args.disagreements:
+        _print_disagreements(rows, split_models)
+
+    if not args.no_write:
+        artefact = build_artefact(rows, args.dataset, args.holdout, args.folds)
+        write_artefact(artefact, args.out)
+        print(f"\nmodel -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rollout_evaluator.json
+++ b/rollout_evaluator.json
@@ -1,0 +1,134 @@
+{
+  "dataset": "rollout_dataset.csv",
+  "dataset_rows": 2000,
+  "format_version": 1,
+  "generated_by": "fit_evaluator.py",
+  "holdout_fraction": 0.25,
+  "issue": "113",
+  "labelled_configuration": "GeneralStrategy skill 5, as configured in pinochle_engine.py:\n  hand_valuation       rollout_ev\n  bid_samples          50\n  defence_samples      20\n  fold_samples         50\n  use_auction_evidence False\n  use_win_probability  False\n  live bid path        choose_bid_vs_defence (bid_ev_differential vs defend_ev, 20 samples)\n  live fold path       should_fold (score differential)",
+  "metrics": {
+    "bid": {
+      "cross_validated_agreement": 0.8634441087613294,
+      "cross_validated_folds": [
+        0.8942598187311178,
+        0.8640483383685801,
+        0.8670694864048338,
+        0.8368580060422961,
+        0.8549848942598187
+      ],
+      "cross_validated_spread": 0.01866277366946283,
+      "holdout_agreement": 0.855072463768116,
+      "holdout_disagreement_direction": {
+        "agreed": 354,
+        "false_negative": 35,
+        "false_positive": 25
+      },
+      "holdout_majority_baseline": 0.572463768115942,
+      "holdout_mean_regret": 10.05426763285024,
+      "rows": 1655,
+      "test_rows": 414,
+      "train_agreement": 0.871071716357776,
+      "train_rows": 1241
+    },
+    "fold": {
+      "cross_validated_agreement": 0.9362318840579711,
+      "cross_validated_folds": [
+        0.9420289855072463,
+        0.9420289855072463,
+        0.927536231884058,
+        0.9565217391304348,
+        0.9130434782608695
+      ],
+      "cross_validated_spread": 0.014779766706066061,
+      "holdout_agreement": 0.9195402298850575,
+      "holdout_disagreement_direction": {
+        "agreed": 80,
+        "false_negative": 4,
+        "false_positive": 3
+      },
+      "holdout_majority_baseline": 0.8160919540229885,
+      "holdout_mean_regret": 3.121073563218391,
+      "rows": 345,
+      "test_rows": 87,
+      "train_agreement": 0.9612403100775194,
+      "train_rows": 258
+    }
+  },
+  "models": {
+    "bid": {
+      "decision": "1 = bid (taking the contract beats defending it)",
+      "features": [
+        "meld_total",
+        "ace_count",
+        "trump_length",
+        "longest_side_suit",
+        "has_run",
+        "has_pinochle",
+        "has_around",
+        "bid",
+        "score_diff",
+        "partner_has_bid",
+        "partner_has_passed",
+        "base_bid_ceiling",
+        "ceiling_minus_bid"
+      ],
+      "intercept": -6.190577377670678,
+      "kind": "logistic",
+      "threshold": 0.5,
+      "weights": [
+        -0.001833833460362434,
+        -0.12112882779741993,
+        1.4007208547822605,
+        0.3284565962226119,
+        2.019576694662309,
+        -0.4402662517070388,
+        -1.159328694264782,
+        -0.01233004913128889,
+        0.00048464844126663555,
+        -0.3718631886818257,
+        -0.12603341924333322,
+        0.011471091654723126,
+        0.013132724048172792
+      ]
+    },
+    "fold": {
+      "decision": "1 = concede (playing the contract out is worse than folding)",
+      "features": [
+        "meld_total",
+        "ace_count",
+        "trump_length",
+        "longest_side_suit",
+        "has_run",
+        "has_pinochle",
+        "has_around",
+        "bid",
+        "bidding_meld",
+        "defending_meld",
+        "base_bid_ceiling",
+        "ceiling_minus_bid",
+        "tricks_needed",
+        "fold_cost"
+      ],
+      "intercept": -2.089076061739785,
+      "kind": "logistic",
+      "threshold": 0.5,
+      "weights": [
+        -0.006252987699525758,
+        -0.46359935948202324,
+        -1.2754953667384412,
+        -0.29700126187654785,
+        -0.5837986203757082,
+        -1.0017942280941428,
+        -0.06634841725698079,
+        0.025970997438315855,
+        -0.018928284544457424,
+        -0.0059779317657320166,
+        0.00023452523687066736,
+        -0.003579553541357614,
+        0.02234604410242097,
+        0.004036487908599377
+      ]
+    }
+  },
+  "split": "contiguous tail in capture order (a run of whole games)"
+}

--- a/test_fit_evaluator.py
+++ b/test_fit_evaluator.py
@@ -1,0 +1,533 @@
+"""
+Tests for issue #113 (epic #104) - the cheap evaluator fitted to the rollout
+data. Plain assert-based, pytest-discoverable. Covers:
+
+  1. The features, including the one that is recomputed rather than read, and
+     the two the fold model deliberately refuses to look at.
+  2. Blanks stay blanks. #112's dataset writes an empty cell where no
+     measurement was taken, and reading one as 0.0 would feed the fit a
+     fabricated EV.
+  3. The logistic fit itself - the linear solve, convergence on a problem with a
+     known answer, and the raw-unit property the exported weights depend on.
+  4. Splits do not shuffle. One deal produces several rows, so a shuffled split
+     would put siblings on both sides of the boundary and inflate every number.
+  5. Evaluation measures decisions, and regret weights them by what the rollout
+     said they were worth.
+  6. The committed model is the one this code produces, and it clears the
+     baselines it has to clear to be worth shipping at all.
+
+The fits on the real dataset are cached module-wide: an IRLS pass over 1655 rows
+costs a couple of seconds and several tests need the same one.
+"""
+
+import json
+import math
+
+from pinochle_engine import OPENER_THRESHOLD, Suit, capped_bid, compute_max_bid
+from generate_rollout_dataset import BID_DECISION, FOLD_DECISION, decode_hand
+from fit_evaluator import (
+    BID_FEATURES,
+    DEFAULT_MODEL_PATH,
+    FOLD_FEATURES,
+    HOLDOUT_FRACTION,
+    LogisticModel,
+    MARGIN_EDGES,
+    PROBLEMS,
+    _solve,
+    base_bid_ceiling,
+    bid_features,
+    bid_rows,
+    contiguous_folds,
+    decision_agreement,
+    design_matrix,
+    disagreement_by,
+    disagreement_direction,
+    fit_logistic,
+    fold_features,
+    fold_rows,
+    label_margin,
+    load_models,
+    majority_rate,
+    mean_regret,
+    read_dataset,
+    refit_on_all,
+    shipped_rule_agreement,
+    tail_split,
+    tuned_threshold_agreement,
+)
+
+_CACHE = {}
+
+
+def dataset():
+    if "rows" not in _CACHE:
+        _CACHE["rows"] = read_dataset()
+    return _CACHE["rows"]
+
+
+def split_fit(name):
+    """The model for `name`, fitted on the training split only - the one whose
+    held-out numbers the PR quotes."""
+    key = f"split:{name}"
+    if key not in _CACHE:
+        problem = PROBLEMS[name]
+        train, _test = tail_split(problem["rows"](dataset()), HOLDOUT_FRACTION)
+        X, y = design_matrix(train, problem)
+        _CACHE[key] = fit_logistic(X, y, problem["features"], l2=problem["l2"])
+    return _CACHE[key]
+
+
+def held_out(name):
+    return tail_split(PROBLEMS[name]["rows"](dataset()), HOLDOUT_FRACTION)[1]
+
+
+# ---------------------------------------------------------------------------
+# 1. Features.
+# ---------------------------------------------------------------------------
+
+def test_bid_features_are_exactly_the_declared_columns():
+    row = bid_rows(dataset())[0]
+    assert set(bid_features(row)) == set(BID_FEATURES)
+
+
+def test_fold_features_are_exactly_the_declared_columns():
+    row = fold_rows(dataset())[0]
+    assert set(fold_features(row)) == set(FOLD_FEATURES)
+
+
+def test_the_ceiling_feature_is_the_engine_valuation_not_a_reimplementation():
+    """
+    `base_bid_ceiling` has to be the same number `bidding.ts` compares against
+    `OPENER_THRESHOLD`, or #114 wires up a model fitted to a quantity it cannot
+    compute. Asserted against the engine's own functions rather than a constant,
+    so a change to the valuation breaks this instead of silently splitting the
+    two definitions apart.
+    """
+    row = bid_rows(dataset())[0]
+    hand, trump = decode_hand(row["hand"]), Suit(row["trump"])
+    total, _breakdown = compute_max_bid(hand, trump, int(row["our_score"]),
+                                        int(row["their_score"]))
+    assert bid_features(row)["base_bid_ceiling"] == float(capped_bid(hand, trump, total))
+
+
+def test_ceiling_minus_bid_is_the_difference_it_claims_to_be():
+    for row in bid_rows(dataset())[:20]:
+        features = bid_features(row)
+        assert (features["ceiling_minus_bid"]
+                == features["base_bid_ceiling"] - features["bid"])
+
+
+def test_the_fold_model_cannot_see_the_game_score():
+    """
+    `label_fold_situation` calls `should_fold` with the scores withheld while
+    `use_win_probability` is off, so `verdict_fold` is mathematically
+    independent of the score. A model given `score_diff` anyway would be fitting
+    noise, and five-fold agreement measurably drops when it is included.
+    """
+    assert "score_diff" not in FOLD_FEATURES
+    assert "our_score" not in FOLD_FEATURES and "their_score" not in FOLD_FEATURES
+
+
+def test_the_fold_ceiling_does_not_smuggle_the_score_back_in():
+    """
+    `compute_max_bid` applies a competitive adjustment that reads both scores,
+    which makes the ceiling the one place a score could re-enter a model of a
+    score-independent label. The fold path must evaluate it at 0-0 regardless of
+    what the row's scores say.
+    """
+    row = next(r for r in fold_rows(dataset())
+               if r["our_score"] != 0 or r["their_score"] != 0)
+    hand, trump = decode_hand(row["hand"]), Suit(row["trump"])
+    assert fold_features(row)["base_bid_ceiling"] == float(base_bid_ceiling(hand, trump))
+
+
+def test_the_fold_model_ignores_the_auction_columns():
+    """Both are constant False on every fold row - the auction is over by the
+    time anyone is asked to concede - so they can only add variance."""
+    assert "partner_has_bid" not in FOLD_FEATURES
+    assert "partner_has_passed" not in FOLD_FEATURES
+    assert all(r["partner_has_bid"] == 0 and r["partner_has_passed"] == 0
+               for r in fold_rows(dataset()))
+
+
+def test_the_two_problems_are_kept_apart():
+    """One model over the union would have to invent `bidding_meld` for every
+    bid row, where no such measurement exists."""
+    rows = dataset()
+    assert len(bid_rows(rows)) + len(fold_rows(rows)) == len(rows)
+    assert not {id(r) for r in bid_rows(rows)} & {id(r) for r in fold_rows(rows)}
+    assert all(r["bidding_meld"] is None for r in bid_rows(rows))
+    assert "bidding_meld" in FOLD_FEATURES and "bidding_meld" not in BID_FEATURES
+
+
+# ---------------------------------------------------------------------------
+# 2. Blanks stay blanks.
+# ---------------------------------------------------------------------------
+
+def test_unmeasured_labels_read_as_none_and_never_as_zero():
+    """
+    A blank cell means "not measured on this kind of row", and zero is a real,
+    meaningful EV. If the reader coerced blanks to 0.0 the fold model would be
+    trained against a fabricated `ev_take` of exactly zero on every row.
+    """
+    rows = dataset()
+    for row in bid_rows(rows)[:20]:
+        assert row["ev_take"] is not None and row["ev_defend"] is not None
+        assert row["ev_play_on"] is None and row["ev_fold"] is None
+        assert row["verdict_fold"] is None
+    for row in fold_rows(rows)[:20]:
+        assert row["ev_play_on"] is not None and row["ev_fold"] is not None
+        assert row["ev_take"] is None and row["verdict_bid"] is None
+
+
+def test_a_measured_zero_survives_the_reader():
+    """The distinction blanks are being protected from: `our_score` is 0 on
+    every first round and must come back as 0.0, not None."""
+    assert any(row["our_score"] == 0.0 for row in dataset())
+    assert all(row["our_score"] is not None for row in dataset())
+
+
+# ---------------------------------------------------------------------------
+# 3. The fit.
+# ---------------------------------------------------------------------------
+
+def test_the_linear_solve_solves():
+    solution = _solve([[2.0, 1.0], [1.0, 3.0]], [5.0, 10.0])
+    assert math.isclose(solution[0], 1.0, abs_tol=1e-9)
+    assert math.isclose(solution[1], 3.0, abs_tol=1e-9)
+
+
+def test_the_linear_solve_needs_pivoting_and_does_it():
+    """A zero in the leading position is not a singular system, it is a system
+    that needs a row swap. Naive elimination divides by zero here."""
+    solution = _solve([[0.0, 2.0], [4.0, 1.0]], [4.0, 6.0])
+    assert math.isclose(solution[0], 1.0, abs_tol=1e-9)
+    assert math.isclose(solution[1], 2.0, abs_tol=1e-9)
+
+
+def test_a_singular_system_raises_rather_than_returning_a_plausible_answer():
+    try:
+        _solve([[1.0, 2.0], [2.0, 4.0]], [3.0, 6.0])
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for a singular system")
+
+
+def test_the_fit_recovers_a_boundary_it_was_shown():
+    """
+    Data separated at x == 5 must produce a model that decides at roughly x == 5.
+    A fit that converged to something else would make every agreement number
+    below a measurement of a bug.
+    """
+    X = [[float(x)] for x in range(11)]
+    y = [int(x > 5) for x in range(11)]
+    model = fit_logistic(X, y, ["x"], l2=1e-6)
+    assert model.decide({"x": 0.0}) == 0
+    assert model.decide({"x": 10.0}) == 1
+    assert model.weights[0] > 0
+    boundary = -model.intercept / model.weights[0]
+    assert 5.0 <= boundary <= 6.0
+
+
+def test_exported_weights_are_in_raw_feature_units():
+    """
+    Fitting happens on standardised columns, but #114 reads the weights and
+    applies them to raw features with no scaling step. So rescaling a column by
+    10 must scale its weight by 1/10 and leave the predictions alone - if the
+    standardisation were not unwound, the exported weights would be identical
+    for both and one of the two would be wrong.
+    """
+    X = [[float(x)] for x in range(11)]
+    y = [int(x > 5) for x in range(11)]
+    plain = fit_logistic(X, y, ["x"], l2=1e-6)
+    scaled = fit_logistic([[10.0 * x] for [x] in X], y, ["x"], l2=1e-6)
+    assert math.isclose(scaled.weights[0], plain.weights[0] / 10.0, rel_tol=1e-4)
+    assert math.isclose(scaled.probability({"x": 30.0}),
+                        plain.probability({"x": 3.0}), rel_tol=1e-4)
+
+
+def test_the_penalty_shrinks_weights_but_not_the_intercept():
+    """
+    The intercept carries the base rate, and the fold problem's base rate is
+    17%. Penalising it would drag the model towards a 50/50 prior nobody holds,
+    so the ridge term is applied to the weights only.
+    """
+    X = [[float(x % 3)] for x in range(120)]
+    y = [1 if x < 20 else 0 for x in range(120)]   # base rate 1/6, feature uninformative
+    light = fit_logistic(X, y, ["x"], l2=1e-6)
+    heavy = fit_logistic(X, y, ["x"], l2=100.0)
+    assert abs(heavy.weights[0]) < abs(light.weights[0])
+    # With the feature crushed to nothing, the model should still predict the
+    # base rate rather than a half.
+    assert math.isclose(heavy.probability({"x": 1.0}), 1.0 / 6.0, abs_tol=0.05)
+
+
+def test_a_model_round_trips_through_its_dict_form():
+    """The artefact is JSON because #114 reads it from TypeScript; if the
+    round-trip loses anything, the exported model is not the fitted one."""
+    model = LogisticModel(["a", "b"], [1.5, -0.25], 0.75, threshold=0.4, decision="why")
+    restored = LogisticModel.from_dict(json.loads(json.dumps(model.to_dict())))
+    assert restored.features == model.features
+    assert restored.weights == model.weights
+    assert restored.intercept == model.intercept
+    assert restored.threshold == model.threshold
+    assert restored.probability({"a": 2.0, "b": 4.0}) == model.probability({"a": 2.0, "b": 4.0})
+
+
+def test_an_unknown_model_kind_is_refused():
+    """#114 must fail loudly rather than silently treat some future tree model's
+    payload as a weight vector."""
+    try:
+        LogisticModel.from_dict({"kind": "forest", "features": [], "weights": [],
+                                 "intercept": 0.0})
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for an unsupported model kind")
+
+
+# ---------------------------------------------------------------------------
+# 4. Splits do not shuffle.
+# ---------------------------------------------------------------------------
+
+def test_the_holdout_split_preserves_capture_order():
+    """
+    One deal yields up to four bid rows and a fold row that share a shuffle.
+    Rows are stored in play order, so a contiguous tail keeps those siblings
+    together; a shuffled split would scatter them across the boundary and every
+    agreement number in the PR would be measuring memorisation.
+    """
+    rows = bid_rows(dataset())
+    train, test = tail_split(rows, 0.25)
+    assert train + test == rows
+    assert len(test) == len(rows) - int(len(rows) * 0.75)
+
+
+def test_the_folds_partition_every_row_exactly_once():
+    seen = []
+    for train, test in contiguous_folds(23, folds=5):
+        assert not set(train) & set(test)
+        assert sorted(train + test) == list(range(23))
+        seen.extend(test)
+    assert sorted(seen) == list(range(23))
+
+
+def test_each_fold_is_a_contiguous_block():
+    """Same reason as the tail split: a fold made of scattered indices would
+    split a deal's rows across train and test."""
+    for _train, test in contiguous_folds(20, folds=4):
+        assert test == list(range(test[0], test[-1] + 1))
+
+
+# ---------------------------------------------------------------------------
+# 5. Evaluation measures decisions, weighted by what they were worth.
+# ---------------------------------------------------------------------------
+
+class _AlwaysSays:
+    """A stand-in model, so the metrics can be checked against an answer that is
+    known without running a fit."""
+
+    def __init__(self, answer):
+        self.answer = answer
+
+    def decide(self, _features):
+        return self.answer
+
+
+def test_agreement_is_measured_on_decisions_not_on_p_make():
+    """
+    The acceptance criterion for #113. A model that always says "bid" must score
+    exactly the fraction of rows whose verdict is 1 - if agreement were being
+    computed from a regression error on `p_make` instead, this identity would
+    not hold.
+    """
+    problem = PROBLEMS[BID_DECISION]
+    rows = bid_rows(dataset())
+    verdicts = [int(r["verdict_bid"]) for r in rows]
+    assert math.isclose(decision_agreement(_AlwaysSays(1), rows, problem),
+                        sum(verdicts) / len(verdicts))
+    assert math.isclose(decision_agreement(_AlwaysSays(0), rows, problem),
+                        1 - sum(verdicts) / len(verdicts))
+
+
+def test_the_majority_baseline_is_the_better_of_the_two_constant_answers():
+    problem = PROBLEMS[FOLD_DECISION]
+    rows = fold_rows(dataset())
+    assert math.isclose(
+        majority_rate(rows, problem),
+        max(decision_agreement(_AlwaysSays(a), rows, problem) for a in (0, 1)),
+    )
+
+
+def test_label_margin_reads_the_columns_that_exist_on_each_kind_of_row():
+    """Bid rows measure take-vs-defend and fold rows measure play-on-vs-fold;
+    reading the wrong pair would raise on a None, not quietly mislead."""
+    bid_row = bid_rows(dataset())[0]
+    fold_row = fold_rows(dataset())[0]
+    assert label_margin(bid_row) == abs(bid_row["ev_take"] - bid_row["ev_defend"])
+    assert label_margin(fold_row) == abs(fold_row["ev_play_on"] - fold_row["ev_fold"])
+
+
+def test_regret_weights_a_disagreement_by_what_the_rollout_said_it_was_worth():
+    """
+    Agreement counts every disagreement equally; regret does not. A model that
+    always agrees gives up nothing, and one that always disagrees gives up the
+    mean margin - which is what makes "the disagreements sit near the boundary"
+    a statement about cost rather than about a histogram.
+    """
+    problem = PROBLEMS[BID_DECISION]
+    rows = bid_rows(dataset())[:200]
+
+    class _Oracle:
+        def decide(self, features):
+            return self.answers[tuple(features[n] for n in problem["features"])]
+
+    oracle = _Oracle()
+    oracle.answers = {
+        tuple(float(bid_features(r)[n]) for n in problem["features"]): int(r["verdict_bid"])
+        for r in rows
+    }
+    assert mean_regret(oracle, rows, problem) == 0.0
+
+    inverted = _Oracle()
+    inverted.answers = {k: 1 - v for k, v in oracle.answers.items()}
+    assert math.isclose(mean_regret(inverted, rows, problem),
+                        sum(label_margin(r) for r in rows) / len(rows), rel_tol=1e-9)
+
+
+def test_disagreement_direction_splits_the_two_ways_it_can_go():
+    """
+    Bidding a contract the rollout would pass and passing one it would take are
+    different mistakes at the table, so the report has to separate them rather
+    than report a total.
+    """
+    problem = PROBLEMS[BID_DECISION]
+    rows = bid_rows(dataset())[:100]
+    counts = disagreement_direction(_AlwaysSays(1), rows, problem)
+    assert counts["false_negative"] == 0
+    assert counts["agreed"] + counts["false_positive"] == len(rows)
+
+
+# ---------------------------------------------------------------------------
+# 6. The committed model, and the bar it has to clear.
+# ---------------------------------------------------------------------------
+
+def test_the_committed_model_matches_what_this_code_produces():
+    """
+    The artefact is checked in, which means it can rot: someone regenerates the
+    dataset, or changes a feature, and the JSON keeps describing the old fit.
+    Refitting from the committed CSV and comparing weights is the only thing
+    that catches that.
+    """
+    committed = load_models()
+    fresh = refit_on_all(dataset())
+    assert set(committed) == set(fresh) == set(PROBLEMS)
+    for name, model in fresh.items():
+        assert committed[name].features == model.features
+        assert math.isclose(committed[name].intercept, model.intercept, rel_tol=1e-6,
+                            abs_tol=1e-9)
+        for expected, actual in zip(model.weights, committed[name].weights):
+            assert math.isclose(expected, actual, rel_tol=1e-6, abs_tol=1e-9)
+
+
+def test_the_artefact_records_the_configuration_it_was_fitted_against():
+    """
+    A model distilled from a flag that has since been flipped is worse than no
+    model. The file has to be able to answer "which AI is this" on its own,
+    without anyone remembering.
+    """
+    with open(DEFAULT_MODEL_PATH, encoding="utf-8") as handle:
+        artefact = json.load(handle)
+    assert "use_auction_evidence" in artefact["labelled_configuration"]
+    assert "use_win_probability" in artefact["labelled_configuration"]
+    assert artefact["dataset_rows"] == len(dataset())
+    assert artefact["models"]["bid"]["features"] == BID_FEATURES
+    assert artefact["models"]["fold"]["features"] == FOLD_FEATURES
+
+
+def test_the_fitted_model_beats_the_rule_that_ships_today():
+    """
+    #114's whole reason to exist. If a fitted weight vector cannot beat
+    `ceiling >= OPENER_THRESHOLD` on held-out rows, the honest outcome is to
+    leave the constant alone and ship nothing.
+    """
+    problem = PROBLEMS[BID_DECISION]
+    test = held_out(BID_DECISION)
+    fitted = decision_agreement(split_fit(BID_DECISION), test, problem)
+    assert fitted > shipped_rule_agreement(test)
+    assert fitted > majority_rate(test, problem)
+
+
+def test_the_fitted_model_beats_merely_retuning_the_constant():
+    """
+    The steel-man for doing nothing. A whole model has to earn its export
+    format and its wiring against the one-line alternative of refitting
+    `OPENER_THRESHOLD` itself, not just against the value it currently holds.
+    """
+    train, test = tail_split(bid_rows(dataset()), HOLDOUT_FRACTION)
+    _threshold, tuned = tuned_threshold_agreement(train, test)
+    fitted = decision_agreement(split_fit(BID_DECISION), test, PROBLEMS[BID_DECISION])
+    assert fitted > tuned + 0.03
+
+
+def test_the_fold_model_beats_never_folding():
+    """Folding is rare (17% of fold rows), so "never concede" is a strong
+    baseline and the one this model has to clear."""
+    problem = PROBLEMS[FOLD_DECISION]
+    test = held_out(FOLD_DECISION)
+    assert decision_agreement(split_fit(FOLD_DECISION), test, problem) > majority_rate(test, problem)
+
+
+def test_disagreements_concentrate_where_the_rollout_itself_is_undecided():
+    """
+    The characterisation #114 and #115 need, asserted rather than left in a
+    printout. Systematic disagreement on a hand class would be a modelling
+    failure; a scatter around rows where the two futures are a few points apart
+    is label noise no model can remove and that costs almost nothing to get
+    "wrong". This asserts the second shape, so a refit that turns into the first
+    is caught.
+    """
+    problem = PROBLEMS[BID_DECISION]
+    report = dict(
+        ((low, high), rate)
+        for (low, high), _count, rate in disagreement_by(
+            split_fit(BID_DECISION), held_out(BID_DECISION), problem,
+            label_margin, MARGIN_EDGES)
+    )
+    closest = report[(MARGIN_EDGES[0], MARGIN_EDGES[1])]
+    decisive = report[(MARGIN_EDGES[4], MARGIN_EDGES[5])]
+    assert closest > 0.3, "rows the rollout could barely separate should be the hard ones"
+    assert decisive < 0.05, "rows it separated by 200+ points should be nearly all agreed"
+    assert closest > 4 * decisive
+
+
+def test_no_hand_class_is_systematically_wrong():
+    """
+    The other half of the characterisation: the errors must not pile onto one
+    band of bid level or one band of meld. A bucket that the model gets wrong
+    most of the time would mean #114 ships a rule with a known blind spot,
+    which is a completely different report than "it is noisy near the boundary".
+    """
+    problem = PROBLEMS[BID_DECISION]
+    model, test = split_fit(BID_DECISION), held_out(BID_DECISION)
+    for key, edges in ((lambda r: r["bid"], [250, 300, 310, 320, 340, 1000]),
+                       (lambda r: r["meld_total"], [0, 60, 120, 200, 1000]),
+                       (lambda r: r["trump_length"], [0, 4, 5, 6, 20])):
+        for bucket, count, rate in disagreement_by(model, test, problem, key, edges):
+            if count >= 20:
+                assert rate < 0.35, f"bucket {bucket} disagrees {rate:.2f} of the time"
+
+
+def test_the_ceiling_feature_is_what_carries_the_model():
+    """
+    Documents why an already-computed valuation is in the feature list at all:
+    without it the same fit lands near a retuned constant, which would not have
+    justified #114. If a refactor ever drops it, this says what was lost.
+    """
+    problem = PROBLEMS[BID_DECISION]
+    train, test = tail_split(bid_rows(dataset()), HOLDOUT_FRACTION)
+    reduced = dict(problem, features=[f for f in BID_FEATURES
+                                      if f not in ("base_bid_ceiling", "ceiling_minus_bid")])
+    without = fit_logistic(*design_matrix(train, reduced)[:2],
+                           feature_names=reduced["features"], l2=problem["l2"])
+    assert (decision_agreement(split_fit(BID_DECISION), test, problem)
+            > decision_agreement(without, test, reduced) + 0.04)


### PR DESCRIPTION
Closes #113. Part of epic #104.

Fits a cheap predictor to #112's `rollout_dataset.csv` and reports how well it reproduces the rollout's **decisions**. No TS export and no `bidding.ts` wiring — that is #114.

## Verdict up front

**The simple model was good enough.** Logistic regression over the recorded features. Nothing heavier is justified from the numbers, and the numbers that say so are printed by `--compare` rather than asserted here.

## Two models, not one

`decision_point` splits the dataset and the two halves are not interchangeable, exactly as #112 expected:

| | asks | melds | auction |
|---|---|---|---|
| `bid` (1655) | does taking this contract beat defending it? | both unknown | still running |
| `fold` (345) | does playing it out beat conceding? | both face up | over |

A fold row's hand is a *different* 12 cards from the bid row it descends from — post-pass. One model over the union would have to invent `bidding_meld` for every bid row, where no such measurement exists; blank cells stayed blank.

## Held-out decision agreement

Held out the last 25% of rows **in capture order**. Rows are stored in play order, so a contiguous tail is a run of whole games; a shuffled split would put a single deal's four bid rows and its fold row on both sides of the boundary and inflate everything below.

| | held out | 5-fold | majority baseline | shipped rule |
|---|---|---|---|---|
| **bid** | **85.5%** (414 rows) | 86.3% ±1.9% | 54.6% | 74.3% (`ceiling >= 320`) |
| **fold** | **92.0%** (87 rows) | 93.6% ±1.5% | 81.6% (never concede) | — |

Bid alternatives, all measured the same way:

```
  always pass (majority verdict)          0.546
  shipped rule, ceiling >= 320            0.743
  same rule, constant refit to 285        0.775   (held out)
  logistic without the ceiling feature    0.784 +-0.014
  logistic as shipped                     0.863 +-0.019
```

Mean EV given up per held-out bid decision, in points of score differential: **10.1** for the model against **23.5** for the rule that ships today.

## Where it disagrees

Almost entirely where the rollout itself could not separate the two futures — scattered boundary noise, **not** a hand class:

```
bid, held out, by |EV(take) - EV(defend)| the rollout measured
  margin [    0,    25)  n=43    disagree 0.488
  margin [   25,    50)  n=21    disagree 0.333
  margin [   50,   100)  n=61    disagree 0.279
  margin [  100,   200)  n=123   disagree 0.114
  margin [  200,   400)  n=144   disagree 0.000
  margin [  400,   inf)  n=22    disagree 0.045
```

`ev_take` and `ev_defend` are each a mean over 150 sampled rounds swinging hundreds of points, so a margin under ~50 is inside the label's own Monte Carlo error — those rows are coin flips whose "correct" answer would move if #112 were re-run on another seed. Rows the rollout separated by 200+ points are matched essentially perfectly.

Nothing systematic on any other axis. Bid level: 13.9% / 13.5% / 16.4% / 17.5% across 300–310 / 310–320 / 320–340 / 340+. Guaranteed meld: 15.4% / 13.7% / 17.4% / 6.9% across 0–60 / 60–120 / 120–200 / 200+. Direction is close to balanced — 25 false-positive (model bids, rollout passes) against 35 false-negative — so it is not systematically over- or under-bidding either.

Fold rows: all 7 held-out disagreements sit at margin < 100; every row from 100 points up is matched. The one thin spot is low-meld hands (27.3%, n=22), which are the same rows.

**For #114/#115:** this is the noise shape, not the blind-spot shape. Expect the distilled AI to differ from the rollout on hands where the rollout was nearly indifferent, which should cost close to nothing in win rate. If #115 measures a real strength gap, the cause is somewhere other than these disagreements.

## Why nothing heavier

A gradient-boosted ensemble (150 trees, depth 3) on identical features and folds scores **86.7% ±1.1%** against the linear model's **86.3% ±1.9%**. Four tenths of a point, well inside the fold-to-fold spread, in exchange for losing a model that is a dot product and a comparison. Polynomial and interaction expansions of the linear model added nothing measurable either (86.5%). A bucketed lookup table — the other option the issue named — was clearly worse: 76.8% at its best, because the useful axes are continuous and the buckets either lose the resolution or run out of rows.

## The one feature that is not a CSV column

`base_bid_ceiling` is recomputed from the row's `hand` via `compute_max_bid` + `capped_bid`. This is not a label leak and not expensive — it is exactly the quantity `bidding.ts` already computes as `bestBaseBid` and compares against `OPENER_THRESHOLD`, so #114 gets it for free. It carries the non-linear part of the valuation (run and marriage values, the competitive adjustment, the 400-cap) that no linear combination of `meld_total` / `ace_count` / `trump_length` can express, and it is the difference between 78.4% and 86.3%. Without it the fitted model would barely have beaten refitting the constant, and the honest recommendation would have been to change the constant and ship nothing.

## Contradicting the issue's assumptions

- **The bar was not 50%.** The shipped `ceiling >= 320` rule already agrees with the skill-5 rollout 74.3% of the time, and merely refitting that one constant (to 285) reaches 77.5%. Both matter for #104's framing — the existing constants are not arbitrary, they are a decent approximation, and any distilled model has to be argued against a retuned constant rather than against nothing.
- **The fold label is provably score-independent.** #112 called `should_fold` with `our_score`/`their_score` withheld while `use_win_probability` is off, so `verdict_fold` cannot depend on the game score. `score_diff` is therefore excluded from `FOLD_FEATURES` on principle, and the fold ceiling is evaluated at 0–0 so the competitive adjustment cannot smuggle a score back in. Including `score_diff` does measurably worse (93.6% → 92.8%), which is what fitting noise looks like.
- **`partner_has_bid` / `partner_has_passed` are constant `False` on every fold row** — the auction is over by then — so they are excluded too.

## Artifact

`rollout_evaluator.json` — both models in raw feature units (`sum(w[i] * x[i]) + intercept >= 0`, no scaling step for a consumer to reproduce), plus the metrics above and `describe_live_configuration()`'s account of which AI was distilled. JSON so #114 reads it rather than rewrites it. Shipped weights are refit on all rows; the metrics come from the split fit.

## Dependencies

None added. Stdlib only — IRLS with a hand-rolled pivoting linear solve. numpy and pandas are installed on this machine and were used to explore, but nothing in the committed code imports them: the rest of the repo does not, and a fitted model only reproducible on a machine with numpy is a worse artifact than one any Python can rebuild.

## Tests

`test_fit_evaluator.py`, 34 new tests, matching `test_rollout_dataset.py`'s style. Full suite: **252 passed** (was 218).

Notable ones, since several encode findings rather than mechanics: the committed JSON is refit from the CSV and compared weight-by-weight so the artifact cannot silently rot; the disagreement *shape* is asserted (near-boundary high, decisive-margin low, no bucket over 35%) so a refit that turns noise into a blind spot fails; the model is asserted to beat both the shipped rule and a retuned constant; and the raw-unit property the export depends on is checked by rescaling a feature and confirming the weight scales inversely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
