### PR TITLE
Measure the distilled PWA AI, and switch it on for hard+ (#115)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -22,6 +22,56 @@ npm test        # vitest
   same edge cases as the Python `__main__` self-checks (Double Run vs. Run,
   Double Pinochle vs. Pinochle, etc.) plus additional coverage.
 - `src/App.tsx` — UI shell, currently a placeholder.
+- `src/ab/` — the measurement harness (issue #115). Not shipped: nothing under
+  `src/` outside the App's import graph reaches the bundle. See below.
+
+## Measuring the AI (`src/ab/`)
+
+`chooseBid` runs one of two policies per skill level (`SKILL_PARAMS.bidPolicy`
+in `src/engine/skills.ts`): the hand-tuned thresholds that predate epic #104, or
+the evaluator distilled from the Python rollout AI. Issue #115 had to decide
+whether the second is worth switching on, which `ab_harness.py` cannot answer
+because both sides are TypeScript.
+
+`headlessGame.ts` plays complete games without React, calling the same reducers
+and the same AI entry points `GameFlow.tsx` calls, in the same order, with the
+delays and the rendering removed. `abRun.ts` pairs them the way `ab_harness.py`
+does — identical deals derived from (seed, round) so they cannot drift, seats
+mirrored, significance over pairs rather than games, split pairs discarded, and
+a bootstrap interval on score margin because games-won alone is too coarse.
+`stats.ts` is a direct port of that module's three statistics.
+
+```
+node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts selftest --pairs 100
+node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts ab --pairs 1000
+node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts latency --positions 4000
+```
+
+Run `selftest` before believing `ab`: one policy against itself must find
+nothing, and here it must find *exactly* nothing — with the same policy in all
+four seats the mirrored orientations are the same game relabelled, so every pair
+splits and every paired margin is zero. `ab.test.ts` asserts that in the suite.
+
+What it found, over 1000 pairs / 2000 games: distilled swept 211 deals to
+static's 50 (739 split), 95% CI 75.6%–85.2% of decisive deals, p < 1e-4, and
++227 score margin per deal with a 95% CI of +198 to +257. The evaluator takes a
+third fewer contracts and makes 63.7% of them against static's 54.6% — declining
+the `DEFENSIVE_PUSH_FLOOR` raise, which is what the static rule does on almost
+any hand, is worth more than the contracts it gives up. Cost: +872 B gzipped,
+and a p95 per decision of 72 µs (Node) / 495 µs (Chrome at 375×812), against the
+600 ms the auction already waits before each AI bid. `hard` and above now run
+`'distilled'`; `easy` and `medium` keep the thresholds.
+
+Two bounds on that conclusion. The evaluator only governs the opening decision
+and the defensive push — the ordinary raise ladder and the 330/340 constants in
+`chooseBid` are untouched, and the two policies return a different bid on 6.5%
+of real auction positions, which is the ceiling on what the model can be
+credited with. And every seat in the harness is an AI, so this says the policy
+is stronger, not that it is a better partner for a human.
+
+`bench/index.html` is the browser side of the latency measurement, served by
+`npm run dev` at `/pinochle/bench/`. It is never an input to `vite build`, so it
+cannot reach a player or the PWA precache.
 
 ## Notes
 

--- a/web/bench/index.html
+++ b/web/bench/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<!--
+  Dev-only latency bench for #115. Served by `npm run dev` at
+  /pinochle/bench/; never an input to `vite build`, so it cannot reach a
+  player or the PWA precache. See src/ab/benchPage.ts.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pinochle — bid decision latency bench (#115)</title>
+    <style>
+      body { font: 12px/1.5 ui-monospace, monospace; margin: 12px; }
+      pre { white-space: pre-wrap; }
+      label { margin-right: 8px; }
+      input { width: 5em; }
+    </style>
+  </head>
+  <body>
+    <h1>Bid decision latency (#115)</h1>
+    <label>positions <input id="positions" value="2000" /></label>
+    <label>repeats <input id="repeats" value="60" /></label>
+    <button id="go">run</button>
+    <pre id="out">idle</pre>
+    <script type="module" src="/src/ab/benchPage.ts"></script>
+  </body>
+</html>

--- a/web/src/ab/ab.test.ts
+++ b/web/src/ab/ab.test.ts
@@ -1,0 +1,145 @@
+// The measurement harness's own correctness check (#115).
+//
+// `ab_harness.py` ships a self-test for the same reason: a harness that reports
+// a difference between two identical configurations is not making a discovery
+// about the AI, it is describing a bug in itself — in seating, in deal
+// assignment, or in bookkeeping. A conclusion drawn from an unchecked harness
+// is worth nothing, and #115's conclusion flips a flag that changes every AI
+// seat of the default game.
+//
+// Kept small deliberately. The full runs (hundreds of pairs) live behind
+// `src/ab/cli.ts`; what belongs in the suite is the property that makes those
+// runs meaningful, at the smallest size that demonstrates it.
+
+import { describe, expect, it } from 'vitest'
+import { SKILL_PARAMS } from '../engine/skills'
+import type { PlayerIndex } from '../engine/trick'
+import type { SkillLevel } from '../persistence/options'
+import { DISTILLED_LEVEL, STATIC_LEVEL, analyse, installPolicies, runAb } from './abRun'
+import { makeRng, playHeadlessGame } from './headlessGame'
+import { binomialTwoSidedP, bootstrapMeanCi, percentile, wilsonInterval } from './stats'
+
+describe('the statistics', () => {
+  it('reports no evidence rather than certainty when there are no trials', () => {
+    // The value that stops a caller reading "no data" as "no difference".
+    expect(binomialTwoSidedP(0, 0)).toBe(1)
+    expect(wilsonInterval(0, 0)).toEqual([0, 1])
+  })
+
+  it('matches the exact binomial on cases small enough to check by hand', () => {
+    // 1 head in 10 tosses: 2 * (C(10,0) + C(10,1)) / 2^10 = 22/1024.
+    expect(binomialTwoSidedP(1, 10)).toBeCloseTo(22 / 1024, 12)
+    // An even split is the most likely outcome, so every outcome counts in.
+    expect(binomialTwoSidedP(5, 10)).toBeCloseTo(1, 12)
+    // The size a real run reaches — well past where naive factorials overflow.
+    expect(binomialTwoSidedP(211, 261)).toBeLessThan(1e-20)
+  })
+
+  it('keeps a Wilson interval inside [0, 1] at the extremes', () => {
+    const [low, high] = wilsonInterval(20, 20)
+    expect(low).toBeGreaterThan(0.8)
+    expect(high).toBe(1)
+  })
+
+  it('brackets the mean with a bootstrap interval that excludes zero when the effect is real', () => {
+    const noisyPositive = Array.from({ length: 200 }, (_, i) => 100 + ((i * 37) % 41) - 20)
+    const [low, high] = bootstrapMeanCi(noisyPositive, makeRng(3))
+    expect(low).toBeGreaterThan(0)
+    expect(high).toBeLessThan(200)
+
+    const centred = Array.from({ length: 200 }, (_, i) => ((i * 37) % 41) - 20)
+    const [zeroLow, zeroHigh] = bootstrapMeanCi(centred, makeRng(3))
+    expect(zeroLow).toBeLessThan(0)
+    expect(zeroHigh).toBeGreaterThan(0)
+  })
+
+  it('takes p95 by nearest rank, so the reported number is one that occurred', () => {
+    const values = Array.from({ length: 100 }, (_, i) => i + 1)
+    expect(percentile(values, 0.5)).toBe(50)
+    expect(percentile(values, 0.95)).toBe(95)
+    expect(percentile(values, 1)).toBe(100)
+  })
+})
+
+describe('the policy override', () => {
+  it('puts the two policies side by side and hands the dial back untouched', () => {
+    // The A/B needs both policies live in one process, since both sit at the
+    // same table. Restoring matters: a leaked override would quietly change
+    // every later assertion about the shipped dial.
+    const before = { ...SKILL_PARAMS }
+    const restore = installPolicies()
+    expect(SKILL_PARAMS[STATIC_LEVEL].bidPolicy).toBe('static')
+    expect(SKILL_PARAMS[DISTILLED_LEVEL].bidPolicy).toBe('distilled')
+    // Same hand valuation on both sides, so passing, trump choice and card play
+    // are identical and bidding policy is the only thing under test.
+    expect(SKILL_PARAMS[STATIC_LEVEL].handValuation).toBe('base_bid')
+    expect(SKILL_PARAMS[DISTILLED_LEVEL].handValuation).toBe('base_bid')
+    restore()
+    expect(SKILL_PARAMS).toEqual(before)
+  })
+})
+
+describe('the headless game', () => {
+  it('plays a full game to a result, with every seat an AI', () => {
+    const seatSkills = { 0: 'hard', 1: 'hard', 2: 'hard', 3: 'hard' } as Record<PlayerIndex, SkillLevel>
+    const result = playHeadlessGame({ seatSkills, dealSeed: 42 })
+    expect([0, 1]).toContain(result.winner)
+    expect(result.rounds).toBeGreaterThan(0)
+    // One side has to have crossed a threshold for the game to have ended.
+    const crossed = Math.max(result.scoresByTeam[0], result.scoresByTeam[1]) >= 1000
+    const busted = Math.min(result.scoresByTeam[0], result.scoresByTeam[1]) <= -1000
+    expect(crossed || busted).toBe(true)
+  })
+
+  it('reproduces a game exactly from its seed', () => {
+    const seatSkills = { 0: 'hard', 1: 'hard', 2: 'hard', 3: 'hard' } as Record<PlayerIndex, SkillLevel>
+    const a = playHeadlessGame({ seatSkills, dealSeed: 99 })
+    const b = playHeadlessGame({ seatSkills, dealSeed: 99 })
+    expect(b).toEqual(a)
+  })
+})
+
+describe('the A/B self-test', () => {
+  // A configuration against itself. Any difference here is a harness bug, and
+  // because the deal and the player seed are both pinned the expectation is
+  // stronger than "not significant": with the same policy in all four seats the
+  // two orientations of a deal are the same game with the sides relabelled, so
+  // every pair must split and every *paired* margin must be exactly zero.
+  //
+  // Note it is the paired margin that must vanish, not the per-game one. Seat 3
+  // deals the first round in both orientations, so one side holds the dealer in
+  // one orientation and the other side holds it in the other — a real per-game
+  // swing (the numbers below run to four figures) that averaging the pair
+  // cancels. That is precisely the positional edge the mirroring exists to
+  // remove, and seeing it cancel to zero here is the evidence that it does.
+  for (const [name, level] of [
+    ['static', STATIC_LEVEL],
+    ['distilled', DISTILLED_LEVEL],
+  ] as const) {
+    it(`finds nothing when ${name} plays itself`, () => {
+      const report = runAb({ nPairs: 6, seed: 5, levelA: level, levelB: level })
+      const analysis = analyse(report)
+      expect(analysis.decisivePairs).toBe(0)
+      expect(analysis.pairsSplit).toBe(6)
+      expect(analysis.pairMargins.every((m) => m === 0)).toBe(true)
+      expect(analysis.marginExcludesZero).toBe(false)
+      // Per-game margins are non-trivial and exactly opposite — the seat effect
+      // is present in each game and cancels across the pair.
+      expect(report.marginsA.some((m) => m !== 0)).toBe(true)
+      for (let i = 0; i + 1 < report.marginsA.length; i += 2) {
+        expect(report.marginsA[i]).toBe(-report.marginsA[i + 1])
+      }
+      expect(report.statsA.contracts).toBe(report.statsB.contracts)
+      expect(report.statsA.set).toBe(report.statsB.set)
+    })
+  }
+
+  it('leaves Math.random as it found it', () => {
+    // The run reseeds `Math.random` per pair, since the AI reaches for it in a
+    // few places and an unseeded run is not reproducible. Not restoring it
+    // would make every later test in the file deterministic by accident.
+    const before = Math.random
+    runAb({ nPairs: 1, seed: 1 })
+    expect(Math.random).toBe(before)
+  })
+})

--- a/web/src/ab/abRun.ts
+++ b/web/src/ab/abRun.ts
@@ -1,0 +1,284 @@
+// Paired A/B of the two bidding policies (#115), on the discipline
+// `ab_harness.py` sets.
+//
+// Four properties, all of them load-bearing, all of them lifted from the Python
+// harness rather than reinvented:
+//
+//   Identical deals. Both orientations of a pair derive every round's shuffle
+//   from (deal seed, round index) alone, so the deal does not drift when one
+//   policy consumes more random values while thinking. The deal is by far the
+//   largest source of variance in Pinochle; holding it fixed removes most of it
+//   for free, and is worth many times more than simply running more games.
+//
+//   Mirrored seats. Each deal is played twice, swapping which side sits in
+//   seats 0&2. Seat 0 is dealt first and the dealer rotation starts from a
+//   fixed seat, so any positional edge would otherwise read as a skill gap.
+//
+//   Significance over pairs, not games. The two games in a pair are the same
+//   deal mirrored and so are strongly anti-correlated; treating them as
+//   independent trials would roughly halve the standard error and manufacture
+//   confidence. Split pairs carry no direction and are discarded, as in a sign
+//   test, so `decisivePairs` is the real sample size.
+//
+//   An interval on score margin. Games-won is coarse — it discards *how* a game
+//   was won — and with tightly paired configs most pairs split, leaving very few
+//   decisive ones. This project has been burned by that specific null more than
+//   once. Margin keeps the magnitude and usually resolves a real difference
+//   long before games-won does.
+//
+// -- On how the two policies are selected -----------------------------------
+//
+// `chooseBid` takes a `SkillLevel` and reads `SKILL_PARAMS[skill]`, so the only
+// way to have both policies live in one process — which a mirrored A/B needs,
+// since both sit at the same table — is to run two skill levels that differ in
+// `bidPolicy` and in nothing else. `installPolicies` therefore overwrites two
+// entries of `SKILL_PARAMS` for the duration of a run and restores them after.
+//
+// This is not a shortcut around the gate in `skills.ts`; it is what makes the
+// measurement independent of it. Both entries are written explicitly, so the
+// harness reports the same numbers whether the shipped dial is gated off or
+// switched on. Every other consumer of `SKILL_PARAMS` (`passing.ts`,
+// `tracker.ts`, `chooseTrump`) branches only on `handValuation`, which both
+// entries set to `'base_bid'` — so the two sides play identical cards, pass
+// identical cards and pick trump identically, and the only thing that differs
+// between them is which rule answers "is this hand worth a contract here".
+
+import { SKILL_PARAMS, type SkillParams } from '../engine/skills'
+import type { TeamId } from '../engine/round'
+import type { PlayerIndex } from '../engine/trick'
+import type { SkillLevel } from '../persistence/options'
+import { type SideStats, makeRng, newSideStats, playHeadlessGame } from './headlessGame'
+import { binomialTwoSidedP, bootstrapMeanCi, wilsonInterval } from './stats'
+
+/** The two dial entries the harness commandeers. Both are `base_bid` levels, so
+ *  overwriting them changes bidding policy and nothing else. */
+export const STATIC_LEVEL: SkillLevel = 'hard'
+export const DISTILLED_LEVEL: SkillLevel = 'expert'
+
+const AB_POLICIES: Record<string, SkillParams> = {
+  [STATIC_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'static' },
+  [DISTILLED_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'distilled' },
+}
+
+/** Overwrites the two entries above, returning a function that restores them.
+ *  Callers must restore in a `finally` — a leaked override would silently
+ *  change any later test in the same module registry. */
+export function installPolicies(): () => void {
+  const saved: Partial<Record<SkillLevel, SkillParams>> = {}
+  for (const [level, params] of Object.entries(AB_POLICIES) as [SkillLevel, SkillParams][]) {
+    saved[level] = SKILL_PARAMS[level]
+    SKILL_PARAMS[level] = params
+  }
+  return () => {
+    for (const level of Object.keys(AB_POLICIES) as SkillLevel[]) {
+      SKILL_PARAMS[level] = saved[level] as SkillParams
+    }
+  }
+}
+
+export interface AbReport {
+  readonly labelA: string
+  readonly labelB: string
+  readonly nPairs: number
+  readonly winsA: number
+  readonly winsB: number
+  /** A's score margin in each game, in play order (two entries per pair). */
+  readonly marginsA: readonly number[]
+  /** +1 where A swept both orientations of a deal, -1 where B did, 0 on a split. */
+  readonly pairResults: readonly number[]
+  readonly statsA: SideStats
+  readonly statsB: SideStats
+  readonly elapsedMs: number
+}
+
+export interface AbAnalysis {
+  readonly pairsA: number
+  readonly pairsB: number
+  readonly pairsSplit: number
+  readonly decisivePairs: number
+  readonly pValue: number
+  readonly shareCi: readonly [number, number]
+  /** A's average margin per deal, averaged across the deal's two orientations
+   *  so any seat advantage cancels before it reaches the statistics. */
+  readonly pairMargins: readonly number[]
+  readonly marginMean: number
+  readonly marginCi: readonly [number, number]
+  readonly marginExcludesZero: boolean
+}
+
+export function analyse(report: AbReport, ciSeed = 0): AbAnalysis {
+  const pairsA = report.pairResults.filter((r) => r > 0).length
+  const pairsB = report.pairResults.filter((r) => r < 0).length
+  const decisivePairs = pairsA + pairsB
+
+  const pairMargins: number[] = []
+  for (let i = 0; i + 1 < report.marginsA.length; i += 2) {
+    pairMargins.push((report.marginsA[i] + report.marginsA[i + 1]) / 2)
+  }
+  const marginMean = pairMargins.length
+    ? pairMargins.reduce((s, v) => s + v, 0) / pairMargins.length
+    : 0
+  const marginCi = bootstrapMeanCi(pairMargins, makeRng(ciSeed))
+
+  return {
+    pairsA,
+    pairsB,
+    pairsSplit: report.pairResults.filter((r) => r === 0).length,
+    decisivePairs,
+    pValue: binomialTwoSidedP(pairsA, decisivePairs),
+    shareCi: wilsonInterval(pairsA, decisivePairs),
+    pairMargins,
+    marginMean,
+    marginCi,
+    marginExcludesZero: marginCi[0] > 0 || marginCi[1] < 0,
+  }
+}
+
+export interface RunAbOptions {
+  readonly nPairs: number
+  readonly seed?: number
+  readonly labelA?: string
+  readonly labelB?: string
+  /** Skill level for side A's two seats, and for side B's. Defaults to the
+   *  distilled/static pair this issue exists to compare; passing the same level
+   *  twice is the harness's own self-test. */
+  readonly levelA?: SkillLevel
+  readonly levelB?: SkillLevel
+}
+
+/**
+ * Plays `nPairs` deals, each twice with the seats mirrored. Total games is
+ * `2 * nPairs`.
+ *
+ * `Math.random` is reseeded per pair and shared by both orientations. The AI
+ * reaches for it in a few places (`meldOnlyBid`'s noise, `choosePassCards`'
+ * fallback), and leaving those unseeded is exactly the irreproducibility
+ * `ab_harness.py`'s docstring records having produced both "not significant"
+ * and "significant" from one invocation.
+ */
+export function runAb(options: RunAbOptions): AbReport {
+  const {
+    nPairs,
+    seed = 1,
+    labelA = 'distilled',
+    labelB = 'static',
+    levelA = DISTILLED_LEVEL,
+    levelB = STATIC_LEVEL,
+  } = options
+
+  const restore = installPolicies()
+  const realRandom = Math.random
+  const seedSource = makeRng(seed)
+  const marginsA: number[] = []
+  const pairResults: number[] = []
+  const statsA = newSideStats()
+  const statsB = newSideStats()
+  let winsA = 0
+  let winsB = 0
+  const started = performance.now()
+
+  try {
+    for (let pair = 0; pair < nPairs; pair++) {
+      const dealSeed = Math.floor(seedSource() * 2 ** 31)
+      const playSeed = Math.floor(seedSource() * 2 ** 31)
+      let pairWinsA = 0
+
+      for (const aFirst of [true, false]) {
+        // Both orientations share one player seed, so they differ only by
+        // seating — the thing the mirroring exists to cancel.
+        Math.random = makeRng(playSeed)
+
+        const seatSkills = {
+          0: aFirst ? levelA : levelB,
+          1: aFirst ? levelB : levelA,
+          2: aFirst ? levelA : levelB,
+          3: aFirst ? levelB : levelA,
+        } as Record<PlayerIndex, SkillLevel>
+
+        // Seats 0&2 are team 0, so which team object is "A" flips with the
+        // orientation — same bookkeeping as `run_ab`'s `team_a_obj`.
+        const teamA: TeamId = aFirst ? 0 : 1
+        const teamB: TeamId = aFirst ? 1 : 0
+        const stats = { [teamA]: statsA, [teamB]: statsB } as Record<TeamId, SideStats>
+
+        const result = playHeadlessGame({ seatSkills, dealSeed, stats })
+        marginsA.push(result.scoresByTeam[teamA] - result.scoresByTeam[teamB])
+        if (result.winner === teamA) {
+          winsA++
+          pairWinsA++
+        } else {
+          winsB++
+        }
+      }
+
+      pairResults.push(pairWinsA === 2 ? 1 : pairWinsA === 0 ? -1 : 0)
+    }
+  } finally {
+    Math.random = realRandom
+    restore()
+  }
+
+  return {
+    labelA,
+    labelB,
+    nPairs,
+    winsA,
+    winsB,
+    marginsA,
+    pairResults,
+    statsA,
+    statsB,
+    elapsedMs: performance.now() - started,
+  }
+}
+
+const pct = (x: number) => `${(x * 100).toFixed(1)}%`
+const signed = (x: number) => `${x >= 0 ? '+' : ''}${x.toFixed(0)}`
+const rate = (n: number, d: number) => (d ? pct(n / d) : '—')
+const avg = (xs: readonly number[]) => (xs.length ? xs.reduce((s, v) => s + v, 0) / xs.length : 0)
+
+/** The Python harness's `summary()`, near enough line for line — including the
+ *  refusal to print a bare win count without saying whether it means anything. */
+export function summarise(report: AbReport, analysis = analyse(report)): string {
+  const games = report.winsA + report.winsB
+  const verdict =
+    analysis.decisivePairs === 0
+      ? 'NO EVIDENCE — every deal split, the two policies are indistinguishable here'
+      : analysis.pValue < 0.05
+        ? `SIGNIFICANT at p<0.05 — ${analysis.pairsA > analysis.pairsB ? report.labelA : report.labelB} is ahead`
+        : 'NOT significant — this difference is consistent with chance'
+  const marginVerdict =
+    analysis.marginCi[0] > 0
+      ? `CI excludes zero — ${report.labelA} really is ahead on margin`
+      : analysis.marginCi[1] < 0
+        ? `CI excludes zero — ${report.labelB} really is ahead on margin`
+        : 'CI includes zero — no established difference in margin'
+
+  return [
+    `A/B: ${report.labelA} vs ${report.labelB}`,
+    `  ${report.nPairs} deals x 2 seat orientations = ${games} games ` +
+      `(${(report.elapsedMs / 1000).toFixed(1)}s, ${(report.elapsedMs / Math.max(1, games)).toFixed(0)} ms/game)`,
+    '',
+    '  Games (descriptive):',
+    `    ${report.labelA}: ${report.winsA} (${rate(report.winsA, games)})   avg margin ${signed(avg(report.marginsA))}`,
+    `    ${report.labelB}: ${report.winsB} (${rate(report.winsB, games)})   avg margin ${signed(-avg(report.marginsA))}`,
+    '',
+    '  Paired deals (inferential — split pairs carry no information):',
+    `    ${report.labelA} swept ${analysis.pairsA},  ${report.labelB} swept ${analysis.pairsB},  split ${analysis.pairsSplit}`,
+    `    95% CI on ${report.labelA}'s share of ${analysis.decisivePairs} decisive deals: ` +
+      `${pct(analysis.shareCi[0])} – ${pct(analysis.shareCi[1])}`,
+    `    two-sided exact binomial p = ${analysis.pValue.toFixed(4)}`,
+    `    ${verdict}`,
+    '',
+    '  Paired score margin (more sensitive than games won):',
+    `    ${report.labelA} avg margin per deal ${signed(analysis.marginMean)}   ` +
+      `95% CI ${signed(analysis.marginCi[0])} to ${signed(analysis.marginCi[1])}`,
+    `    ${marginVerdict}`,
+    '',
+    `  ${''.padEnd(18)}${report.labelA.padStart(12)}${report.labelB.padStart(12)}`,
+    `  ${'contracts won'.padEnd(18)}${String(report.statsA.contracts).padStart(12)}${String(report.statsB.contracts).padStart(12)}`,
+    `  ${'made'.padEnd(18)}${rate(report.statsA.made, report.statsA.contracts).padStart(12)}${rate(report.statsB.made, report.statsB.contracts).padStart(12)}`,
+    `  ${'set'.padEnd(18)}${rate(report.statsA.set, report.statsA.contracts).padStart(12)}${rate(report.statsB.set, report.statsB.contracts).padStart(12)}`,
+    `  ${'avg bid'.padEnd(18)}${avg(report.statsA.bids).toFixed(0).padStart(12)}${avg(report.statsB.bids).toFixed(0).padStart(12)}`,
+  ].join('\n')
+}

--- a/web/src/ab/benchPage.ts
+++ b/web/src/ab/benchPage.ts
@@ -1,0 +1,45 @@
+// Browser side of #115's cost measurement.
+//
+// The Node numbers answer "what does the model cost per decision"; this answers
+// it in the runtime the product actually runs in, at the viewport it ships to.
+// Same code path, same positions, same statistic — only the host differs.
+//
+// Loaded by `bench/index.html`, which the Vite dev server serves and the
+// production build ignores (`build.rollupOptions.input` is `index.html` alone),
+// so nothing here reaches a player or the PWA precache.
+//
+// Two caveats a reader of the numbers needs:
+//
+//   Dev-server code, not the minified bundle. Minification does not change what
+//   the arithmetic does, and the Node run measures the same source, so this is
+//   a cross-check on the runtime rather than an independent third number.
+//
+//   `performance.now()` is clamped to 100us in Chrome outside a
+//   cross-origin-isolated context, which is why every position is timed over
+//   repeats — see `latency.ts`. Single-shot samples are not collected here;
+//   they would be measuring the clamp.
+
+import { formatLatency, runLatencyBenchmark } from './latency'
+
+const output = document.getElementById('out') as HTMLElement
+
+function run(positions: number, repeats: number): void {
+  output.textContent = 'measuring…'
+  // Yield first so the "measuring" text paints before the main thread blocks.
+  setTimeout(() => {
+    const report = runLatencyBenchmark(positions, repeats, false)
+    output.textContent = [
+      `viewport ${window.innerWidth}x${window.innerHeight}, dpr ${window.devicePixelRatio}`,
+      `userAgent ${navigator.userAgent}`,
+      '',
+      formatLatency(report),
+    ].join('\n')
+  }, 50)
+}
+
+;(document.getElementById('go') as HTMLElement).addEventListener('click', () =>
+  run(
+    Number((document.getElementById('positions') as HTMLInputElement).value),
+    Number((document.getElementById('repeats') as HTMLInputElement).value),
+  ),
+)

--- a/web/src/ab/cli.ts
+++ b/web/src/ab/cli.ts
@@ -1,0 +1,53 @@
+// CLI entry point for #115's two measurements.
+//
+// Run through jiti, which is already a dependency (Tailwind pulls it in) and
+// executes TypeScript directly, so this needs no build step and no new package:
+//
+//   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts ab --pairs 400
+//   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts selftest --pairs 100
+//   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts latency --positions 4000
+//
+// `selftest` is the harness's own correctness check, exactly as in
+// `ab_harness.py`: one policy against itself must not produce a significant
+// result, because only seating, deal assignment or bookkeeping could separate
+// the two sides. Run it before believing anything the `ab` command says.
+//
+// `process` is reached through `globalThis` because tsconfig.app.json does not
+// load Node's types — this file lives under `src` so it is type-checked with
+// the rest of the engine, and paying for that with one cast is the cheaper
+// trade than a second tsconfig project.
+
+import { DISTILLED_LEVEL, STATIC_LEVEL, analyse, runAb, summarise } from './abRun'
+import { formatLatency, runLatencyBenchmark } from './latency'
+
+const argv = (globalThis as { process?: { argv: string[] } }).process?.argv ?? []
+const args = argv.slice(2)
+const command = args[0] ?? 'ab'
+
+function flag(name: string, fallback: number): number {
+  const i = args.indexOf(`--${name}`)
+  if (i === -1 || i + 1 >= args.length) return fallback
+  const value = Number(args[i + 1])
+  return Number.isFinite(value) ? value : fallback
+}
+
+if (command === 'ab' || command === 'selftest') {
+  const pairs = flag('pairs', command === 'selftest' ? 100 : 400)
+  const seed = flag('seed', 1)
+  // `--policy distilled` self-tests the model path instead of the threshold
+  // path. Worth having separately: the evaluator is the side that could be
+  // non-deterministic, and a self-test that never exercises it would not notice.
+  const policy = args.includes('--policy') ? args[args.indexOf('--policy') + 1] : 'static'
+  const level = policy === 'distilled' ? DISTILLED_LEVEL : STATIC_LEVEL
+  const report =
+    command === 'selftest'
+      ? runAb({ nPairs: pairs, seed, labelA: `${policy} A`, labelB: `${policy} B`, levelA: level, levelB: level })
+      : runAb({ nPairs: pairs, seed, levelA: DISTILLED_LEVEL, levelB: STATIC_LEVEL })
+  console.log(summarise(report, analyse(report, seed)))
+} else if (command === 'latency') {
+  const positions = flag('positions', 3000)
+  const repeats = flag('repeats', 40)
+  console.log(formatLatency(runLatencyBenchmark(positions, repeats)))
+} else {
+  console.log('usage: cli.ts [ab|selftest|latency] [--pairs N] [--seed N] [--positions N] [--repeats N]')
+}

--- a/web/src/ab/headlessGame.ts
+++ b/web/src/ab/headlessGame.ts
@@ -1,0 +1,255 @@
+// A headless driver for the real TS game (#115).
+//
+// #115 needs to A/B two TypeScript bidding policies, which `ab_harness.py`
+// cannot do — it drives the Python engine, and both sides here are TS. This
+// module is the smallest thing that plays a complete game without React: it
+// calls the *same* reducers and the *same* AI entry points the app calls
+// (`auctionReducer`, `chooseBid`, `chooseTrump`, `choosePassCards`,
+// `playTrickTakingPhase`, `chooseLeadCard`/`chooseFollowCard`,
+// `meldPointsByTeam`, `scoreRound`, `checkGameOutcome`), in the order
+// `GameFlow.tsx` calls them, with the delays and the rendering removed.
+//
+// It is deliberately not a second engine. Every rule it appears to implement is
+// a call into the module that already owns that rule; what lives here is only
+// the loop GameFlow's `useEffect`s form, plus seeding.
+//
+// Two things it does NOT model, both on purpose:
+//
+//   The human seat. Every seat is an AI, as in `biddingSim.test.ts`. That is
+//   what makes the comparison a comparison.
+//
+//   Conceding. `trickPlayReducer`'s CONCEDE action has exactly one caller in
+//   the app — the human's fold button (#83) — so no AI seat ever concedes, and
+//   `evaluator.ts`'s `shouldConcede` has no call site at all. Adding one here
+//   would measure a feature the product does not ship.
+
+import { auctionReducer, initAuctionState, passedPlayersOf, type AuctionState } from '../components/auctionReducer'
+import { meldPointsByTeam } from '../components/gameFlowReducer'
+import { teammatesOf } from '../components/trickPlayReducer'
+import { type AuctionContext, chooseBid, chooseTrump } from '../engine/bidding'
+import { Card, type CopyId, RANKS, type Suit, SUITS } from '../engine/card'
+import { checkGameOutcome } from '../engine/game'
+import { isMisdealEligible } from '../engine/misdeal'
+import { PASS_COUNT, choosePassCards } from '../engine/passing'
+import { type Hands, playTrickTakingPhase, scoreRound, teamOf, type TeamId } from '../engine/round'
+import { PlayTracker, chooseFollowCard, chooseLeadCard } from '../engine/tracker'
+import type { PlayerIndex } from '../engine/trick'
+import type { SkillLevel } from '../persistence/options'
+
+/** Matches AuctionFlow's MIN_INCREMENT. */
+const MIN_INCREMENT = 10
+const SEATS: readonly PlayerIndex[] = [0, 1, 2, 3]
+const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'S0', 1: 'S1', 2: 'S2', 3: 'S3' }
+/** A real game reaches 1000 in well under this. The guard exists so a rules
+ *  change that stalls scoring shows up as a loud failure rather than a hang. */
+const MAX_ROUNDS = 300
+
+export type Rng = () => number
+
+/** mulberry32. Small, fast, and good enough for shuffling — the property that
+ *  matters here is that a seed reproduces a run exactly, so a surprising A/B
+ *  result can be replayed. */
+export function makeRng(seed: number): Rng {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** Mixes two 32-bit values into one seed. Used to derive round N's deal from
+ *  (game seed, round index) alone — the same trick `Game.play(deal_seed=...)`
+ *  uses in Python, and for the same reason: the deal must not drift when one
+ *  configuration consumes more random values than the other while thinking. */
+export function mixSeed(a: number, b: number): number {
+  let h = (a ^ 0x9e3779b9) >>> 0
+  h = Math.imul(h ^ (b + 0x85ebca6b), 0xcc9e2d51) >>> 0
+  h = (h ^ (h >>> 13)) >>> 0
+  return Math.imul(h, 0x1b873593) >>> 0
+}
+
+/** A shuffled 48-card deal from a seeded RNG. Rebuilt here rather than calling
+ *  `Deck` because `Deck.shuffle` draws from `Math.random`, which cannot be
+ *  pinned to a deal seed. Card construction and the Fisher-Yates loop are
+ *  otherwise identical to `card.ts`. */
+export function dealFromRng(rand: Rng): Hands {
+  const cards: Card[] = []
+  for (const suit of SUITS) {
+    for (const rank of RANKS) {
+      for (const copyId of [1, 2] as CopyId[]) cards.push(new Card(suit, rank, copyId))
+    }
+  }
+  for (let i = cards.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1))
+    ;[cards[i], cards[j]] = [cards[j], cards[i]]
+  }
+  return SEATS.map((i) => cards.slice(i * 12, (i + 1) * 12)) as Hands
+}
+
+/** Round-level behaviour for one side, aggregated across a run. Mirrors
+ *  `ab_harness.SideStats` minus `conceded`, which cannot happen here. */
+export interface SideStats {
+  contracts: number
+  made: number
+  set: number
+  bids: number[]
+}
+
+export function newSideStats(): SideStats {
+  return { contracts: 0, made: 0, set: 0, bids: [] }
+}
+
+export interface GameResult {
+  readonly winner: TeamId
+  readonly scoresByTeam: Record<TeamId, number>
+  readonly rounds: number
+}
+
+/** Collected only when a caller asks for it — the latency benchmark replays
+ *  real auction positions rather than invented ones, since the cost of a bid
+ *  decision depends on the hand and on how far the auction has run. */
+export interface BidSituationSample {
+  readonly player: PlayerIndex
+  readonly hand: readonly Card[]
+  readonly currentBid: number
+  readonly context: AuctionContext
+}
+
+export interface HeadlessGameOptions {
+  /** Skill level per seat. Two seats of one level and two of another is what
+   *  makes this an A/B; the levels differ only in `SKILL_PARAMS`. */
+  readonly seatSkills: Record<PlayerIndex, SkillLevel>
+  /** Derives every deal in the game. Identical across the mirrored orientations
+   *  of a pair. */
+  readonly dealSeed: number
+  /** Per-side round bookkeeping, keyed by team id, if the caller wants it. */
+  readonly stats?: Record<TeamId, SideStats>
+  /** Appended to, if supplied. See `BidSituationSample`. */
+  readonly collectBidSituations?: BidSituationSample[]
+}
+
+/** Plays one complete game to the +/-1000 thresholds and reports who won. */
+export function playHeadlessGame(options: HeadlessGameOptions): GameResult {
+  const { seatSkills, dealSeed, stats, collectBidSituations } = options
+  const scoresByTeam: Record<TeamId, number> = { 0: 0, 1: 0 }
+  let dealer: PlayerIndex = 3
+
+  for (let round = 0; round < MAX_ROUNDS; round++) {
+    // -- Deal, with the misdeal/reshuffle house rule ------------------------
+    // GameFlow checks each seat in fixed order and auto-reshuffles for an
+    // eligible AI seat. Every seat is an AI here, so the first eligible one
+    // triggers a redeal. Each reshuffle gets its own derived seed so a redeal
+    // is a genuinely different deal rather than the same one again.
+    let hands: Hands = [[], [], [], []]
+    for (let attempt = 0; attempt < 64; attempt++) {
+      hands = dealFromRng(makeRng(mixSeed(dealSeed, round * 64 + attempt)))
+      if (!SEATS.some((seat) => isMisdealEligible(hands[seat]))) break
+    }
+
+    // -- Auction -----------------------------------------------------------
+    let state: AuctionState = initAuctionState(hands, dealer, SEAT_NAMES, scoresByTeam)
+    let guard = 0
+    while (state.phase === 'bidding' && guard++ < 100) {
+      const turn = state.bidding.turn
+      const context: AuctionContext = {
+        everBid: state.bidding.everBid,
+        passesSoFar: state.bidding.passes,
+        bidHistory: state.bidding.bidHistory,
+        dealer: state.dealer,
+        scores: state.scoresByTeam,
+        passedPlayers: passedPlayersOf(state.bidding.active),
+      }
+      if (collectBidSituations !== undefined) {
+        collectBidSituations.push({
+          player: turn,
+          hand: state.hands[turn],
+          currentBid: state.bidding.currentBid,
+          context,
+        })
+      }
+      const decision = chooseBid(
+        turn,
+        state.hands[turn],
+        state.bidding.currentBid,
+        MIN_INCREMENT,
+        context,
+        seatSkills[turn],
+      )
+      state =
+        decision === null
+          ? auctionReducer(state, { type: 'PASS_BID', player: turn })
+          : auctionReducer(state, { type: 'BID', player: turn, amount: decision })
+    }
+    if (state.phase === 'bidding') throw new Error('auction did not settle')
+
+    const bidWinner = state.bidWinner as PlayerIndex
+    const bid = state.bid
+    state = auctionReducer(state, {
+      type: 'CHOOSE_TRUMP',
+      player: bidWinner,
+      suit: chooseTrump(state.hands[bidWinner], seatSkills[bidWinner]),
+    })
+    const trumpSuit = state.trumpSuit as Suit
+
+    // -- The 3-card pass, both directions, then the reveal ------------------
+    const partner = ((bidWinner + 2) % 4) as PlayerIndex
+    state = auctionReducer(state, {
+      type: 'PASS_CARDS',
+      from: bidWinner,
+      cards: choosePassCards(state.hands[bidWinner], PASS_COUNT, trumpSuit, true, seatSkills[bidWinner]),
+    })
+    state = auctionReducer(state, {
+      type: 'PASS_CARDS',
+      from: partner,
+      cards: choosePassCards(state.hands[partner], PASS_COUNT, trumpSuit, false, seatSkills[partner]),
+    })
+    state = auctionReducer(state, { type: 'CONFIRM_PASS_REVEAL' })
+
+    // -- Meld, trick play, round score -------------------------------------
+    const meldPoints = meldPointsByTeam(state.hands, trumpSuit)
+    const tracker = new PlayTracker()
+    let cardsPlayed = 0
+    const { trickPointsByTeam } = playTrickTakingPhase(
+      state.hands,
+      trumpSuit,
+      bidWinner,
+      (player, hand, legal, trick) => {
+        const skill = seatSkills[player]
+        // TrickPlayFlow's own conditions, with `trickNumber === 0` expressed as
+        // "nothing has been played yet" since playTrickTakingPhase does not
+        // hand the trick index to `chooseCard`.
+        const isBidderFirstLead = cardsPlayed === 0 && player === bidWinner
+        const card =
+          trick.plays.length === 0
+            ? chooseLeadCard(hand, trumpSuit, tracker, isBidderFirstLead, skill, teamOf(player) === teamOf(bidWinner))
+            : chooseFollowCard(hand, legal, trick.plays, trumpSuit, teammatesOf(player), tracker, skill)
+        tracker.record(card)
+        cardsPlayed++
+        return card
+      },
+    )
+
+    const bidWinnerTeam = teamOf(bidWinner)
+    const roundScore = scoreRound({ meldPointsByTeam: meldPoints, trickPointsByTeam, bidWinnerTeam, bid })
+    if (stats !== undefined) {
+      const side = stats[bidWinnerTeam]
+      side.contracts++
+      side.bids.push(bid)
+      if (roundScore[bidWinnerTeam] < 0) side.set++
+      else side.made++
+    }
+
+    scoresByTeam[0] += roundScore[0]
+    scoresByTeam[1] += roundScore[1]
+
+    const winner = checkGameOutcome(scoresByTeam, bidWinnerTeam)
+    if (winner !== null) return { winner, scoresByTeam, rounds: round + 1 }
+
+    dealer = ((dealer + 1) % 4) as PlayerIndex
+  }
+
+  throw new Error(`game did not finish in ${MAX_ROUNDS} rounds`)
+}

--- a/web/src/ab/latency.ts
+++ b/web/src/ab/latency.ts
@@ -1,0 +1,222 @@
+// Per-decision cost of the distilled evaluator (#115).
+//
+// The half of #115 that is not about win rate. The PWA targets an iPhone, and a
+// bid decision that takes visible time is a regression however well it plays —
+// so this measures the thing a player would feel: how long one call to
+// `chooseBid` takes, under each policy, on positions taken from real auctions
+// rather than invented ones (the cost depends on the hand and on how far the
+// auction has run, so synthetic positions would be measuring the wrong thing).
+//
+// p95 rather than the mean, because the mean is the number that hides a stall.
+//
+// -- Why each situation is timed over repeats rather than once ---------------
+//
+// A bid decision costs single-digit microseconds. `performance.now()` in a
+// browser is deliberately coarse — Chrome clamps it to 100us outside a
+// cross-origin-isolated context — so a single call cannot be timed there at
+// all: every sample would read 0 or 100us and the percentiles would be an
+// artefact of the clamp. Timing a fixed number of repeats of the *same*
+// situation and dividing keeps the measurement meaningful on both runtimes, and
+// the resulting distribution is over situations, which is what "per-decision
+// latency" is asking about. Node's timer is fine-grained enough to also report
+// single-shot samples, which is where jitter would show up; the CLI prints both.
+
+import { type AuctionContext, chooseBid } from '../engine/bidding'
+import type { Card } from '../engine/card'
+import type { PlayerIndex } from '../engine/trick'
+import type { SkillLevel } from '../persistence/options'
+import { type BidSituationSample, makeRng, playHeadlessGame } from './headlessGame'
+import { DISTILLED_LEVEL, STATIC_LEVEL, installPolicies } from './abRun'
+import { percentile } from './stats'
+
+const MIN_INCREMENT = 10
+
+/** Collects auction positions by playing real games. Both seats run `level` so
+ *  the positions are the ones that policy actually produces. */
+export function collectSituations(count: number, level: SkillLevel, seed = 7): BidSituationSample[] {
+  const collected: BidSituationSample[] = []
+  const seedSource = makeRng(seed)
+  const seatSkills = { 0: level, 1: level, 2: level, 3: level } as Record<PlayerIndex, SkillLevel>
+  const realRandom = Math.random
+  try {
+    while (collected.length < count) {
+      Math.random = makeRng(Math.floor(seedSource() * 2 ** 31))
+      playHeadlessGame({
+        seatSkills,
+        dealSeed: Math.floor(seedSource() * 2 ** 31),
+        collectBidSituations: collected,
+      })
+    }
+  } finally {
+    Math.random = realRandom
+  }
+  return collected.slice(0, count)
+}
+
+export interface LatencySummary {
+  readonly label: string
+  readonly samples: number
+  /** Microseconds per decision. */
+  readonly mean: number
+  readonly p50: number
+  readonly p95: number
+  readonly p99: number
+  readonly max: number
+}
+
+function summarise(label: string, micros: number[]): LatencySummary {
+  return {
+    label,
+    samples: micros.length,
+    mean: micros.reduce((s, v) => s + v, 0) / Math.max(1, micros.length),
+    p50: percentile(micros, 0.5),
+    p95: percentile(micros, 0.95),
+    p99: percentile(micros, 0.99),
+    max: micros.reduce((m, v) => Math.max(m, v), 0),
+  }
+}
+
+function callOnce(s: BidSituationSample, level: SkillLevel): number {
+  const decision = chooseBid(
+    s.player,
+    s.hand as readonly Card[],
+    s.currentBid,
+    MIN_INCREMENT,
+    s.context as AuctionContext,
+    level,
+  )
+  return decision ?? 0
+}
+
+function timeRepeats(s: BidSituationSample, level: SkillLevel, repeats: number): number {
+  const started = performance.now()
+  let sink = 0
+  for (let i = 0; i < repeats; i++) sink += callOnce(s, level)
+  const micros = ((performance.now() - started) * 1000) / repeats
+  return sink === Number.MIN_SAFE_INTEGER ? -1 : micros
+}
+
+/**
+ * Per-situation cost in microseconds for both policies, amortised over
+ * `repeats` calls each.
+ *
+ * The two are measured *interleaved*, alternating which of them goes first on
+ * each situation. Measuring one policy to completion and then the other does
+ * not work: an early attempt did exactly that and reported the static path as
+ * slower than the distilled one, which is impossible — distilled is the static
+ * path plus a second `bestBaseBid` and a dot product. Whatever produced that
+ * (JIT warm-up carrying across the two loops, cache state, clock drift) is
+ * removed by alternating, and the fact that the ordering could invert the sign
+ * of the result is the reason this note exists.
+ *
+ * `sink` accumulates the returned bids so no engine can decide the work is dead
+ * and remove it.
+ */
+export function measureAmortisedPair(
+  situations: readonly BidSituationSample[],
+  levels: readonly [SkillLevel, SkillLevel],
+  repeats = 40,
+): [number[], number[]] {
+  const first: number[] = []
+  const second: number[] = []
+  situations.forEach((s, i) => {
+    if (i % 2 === 0) {
+      first.push(timeRepeats(s, levels[0], repeats))
+      second.push(timeRepeats(s, levels[1], repeats))
+    } else {
+      second.push(timeRepeats(s, levels[1], repeats))
+      first.push(timeRepeats(s, levels[0], repeats))
+    }
+  })
+  return [first, second]
+}
+
+/** One timing per situation, both policies interleaved for the same reason
+ *  `measureAmortisedPair` interleaves. Only meaningful where the clock is
+ *  fine-grained (Node); in a browser the 100us clamp makes these useless, so
+ *  the caller decides whether to ask for them. */
+export function measureSingleShotPair(
+  situations: readonly BidSituationSample[],
+  levels: readonly [SkillLevel, SkillLevel],
+): [number[], number[]] {
+  return measureAmortisedPair(situations, levels, 1)
+}
+
+export interface LatencyReport {
+  readonly amortised: readonly LatencySummary[]
+  readonly singleShot: readonly LatencySummary[]
+  /** Share of the collected positions where the two policies return a different
+   *  bid. The upper bound on how much of any strength difference can be
+   *  attributed to the evaluator: every other decision is made by the raise
+   *  ladder and the 330/340 constants the model does not touch. */
+  readonly disagreementRate: number
+  readonly disagreements: number
+  readonly decisions: number
+}
+
+/**
+ * Warms both paths, then measures them interleaved so a drifting CPU clock
+ * cannot favour whichever ran first.
+ */
+export function runLatencyBenchmark(situationCount = 3000, repeats = 40, includeSingleShot = true): LatencyReport {
+  const restore = installPolicies()
+  try {
+    const situations = collectSituations(situationCount, STATIC_LEVEL)
+
+    // Warm-up: let the JIT settle on both paths before anything is recorded.
+    const warm = situations.slice(0, Math.min(500, situations.length))
+    measureAmortisedPair(warm, [STATIC_LEVEL, DISTILLED_LEVEL], 20)
+    measureAmortisedPair(warm, [DISTILLED_LEVEL, STATIC_LEVEL], 20)
+
+    const [staticAmortised, distilledAmortised] = measureAmortisedPair(
+      situations,
+      [STATIC_LEVEL, DISTILLED_LEVEL],
+      repeats,
+    )
+
+    let disagreements = 0
+    for (const s of situations) {
+      if (callOnce(s, STATIC_LEVEL) !== callOnce(s, DISTILLED_LEVEL)) disagreements++
+    }
+
+    return {
+      amortised: [
+        summarise('static', staticAmortised),
+        summarise('distilled', distilledAmortised),
+      ],
+      singleShot: includeSingleShot
+        ? (([s, d]) => [summarise('static', s), summarise('distilled', d)])(
+            measureSingleShotPair(situations, [STATIC_LEVEL, DISTILLED_LEVEL]),
+          )
+        : [],
+      disagreementRate: disagreements / Math.max(1, situations.length),
+      disagreements,
+      decisions: situations.length,
+    }
+  } finally {
+    restore()
+  }
+}
+
+export function formatLatency(report: LatencyReport): string {
+  const row = (s: LatencySummary) =>
+    `    ${s.label.padEnd(11)}mean ${s.mean.toFixed(2).padStart(7)}us   ` +
+    `p50 ${s.p50.toFixed(2).padStart(7)}us   p95 ${s.p95.toFixed(2).padStart(7)}us   ` +
+    `p99 ${s.p99.toFixed(2).padStart(7)}us   max ${s.max.toFixed(2).padStart(8)}us`
+  const lines = [
+    `Per-decision latency over ${report.decisions} real auction positions`,
+    '',
+    '  Amortised (each position timed over repeats — comparable across runtimes):',
+    ...report.amortised.map(row),
+  ]
+  if (report.singleShot.length > 0) {
+    lines.push('', '  Single-shot (one call per position — includes jitter; needs a fine-grained clock):', ...report.singleShot.map(row))
+  }
+  lines.push(
+    '',
+    `  Policies returned a different bid on ${report.disagreements}/${report.decisions} ` +
+      `positions (${(report.disagreementRate * 100).toFixed(1)}%) — the ceiling on what the`,
+    '  evaluator can be credited or blamed for; the rest is the untouched raise ladder.',
+  )
+  return lines.join('\n')
+}

--- a/web/src/ab/stats.ts
+++ b/web/src/ab/stats.ts
@@ -1,0 +1,121 @@
+// The three statistics `ab_harness.py` reports, ported to TS (#115).
+//
+// This is a deliberate port rather than a fresh design. #115's A/B compares two
+// TypeScript AIs, so the Python harness cannot run it — but its *discipline* is
+// the part that matters, and re-deriving it here would be how a subtly weaker
+// test creeps in. The three functions below are `binomial_two_sided_p`,
+// `wilson_interval` and `bootstrap_mean_ci` from that module, with the same
+// contracts:
+//
+//   - `binomialTwoSidedP` returns 1.0 on zero trials. No evidence is not
+//     evidence of no difference, and 1.0 is the value that stops a caller
+//     claiming one.
+//   - The interval on margin is a percentile bootstrap, not a normal
+//     approximation. Pinochle margins are a mix of comfortable wins, blowouts
+//     and near-ties; nothing about them is normal.
+//   - Wilson rather than the normal approximation for a rate, because it stays
+//     inside [0, 1] at the extremes a small run hits regularly.
+//
+// One genuine difference from Python. `math.comb` there is exact arbitrary
+// precision; here the binomial coefficient goes through `logGamma`, because a
+// run with a few hundred decisive pairs produces a coefficient near the double
+// overflow boundary multiplied by a probability near the underflow one. Working
+// in log space keeps the product accurate. The consequence is that two outcomes
+// that are exactly symmetric can differ in the last bits, which is why the
+// "no more likely than observed" comparison carries a relative tolerance — the
+// same tolerance, and for the same reason, as the Python original.
+
+/** Lanczos log-gamma (g=7, n=9). Accurate to ~1e-15 relative over the range
+ *  factorials of trial counts need, which is far more than a sign test does. */
+function logGamma(x: number): number {
+  const g = [
+    0.99999999999980993, 676.5203681218851, -1259.1392167224028, 771.32342877765313,
+    -176.61502916214059, 12.507343278686905, -0.13857109526572012, 9.9843695780195716e-6,
+    1.5056327351493116e-7,
+  ]
+  if (x < 0.5) {
+    // Reflection, so the caller never has to care which side of 0.5 it is on.
+    return Math.log(Math.PI / Math.sin(Math.PI * x)) - logGamma(1 - x)
+  }
+  const z = x - 1
+  let a = g[0]
+  const t = z + 7.5
+  for (let i = 1; i < 9; i++) a += g[i] / (z + i)
+  return 0.5 * Math.log(2 * Math.PI) + (z + 0.5) * Math.log(t) - t + Math.log(a)
+}
+
+function logChoose(n: number, k: number): number {
+  return logGamma(n + 1) - logGamma(k + 1) - logGamma(n - k + 1)
+}
+
+/**
+ * Exact two-sided binomial test that `wins` out of `trials` differs from `p`.
+ * Sums the probability of every outcome no more likely than the observed one —
+ * the standard exact construction, and the one that behaves sensibly for the
+ * small symmetric case a paired A/B produces.
+ */
+export function binomialTwoSidedP(wins: number, trials: number, p = 0.5): number {
+  if (trials <= 0) return 1
+  const pmf = (k: number) =>
+    Math.exp(logChoose(trials, k) + k * Math.log(p) + (trials - k) * Math.log(1 - p))
+  const observed = pmf(wins)
+  const tolerance = observed * 1e-9
+  let total = 0
+  for (let k = 0; k <= trials; k++) {
+    const q = pmf(k)
+    if (q <= observed + tolerance) total += q
+  }
+  return Math.min(1, total)
+}
+
+/** Wilson score interval for a win rate. */
+export function wilsonInterval(wins: number, trials: number, z = 1.96): [number, number] {
+  if (trials <= 0) return [0, 1]
+  const phat = wins / trials
+  const denom = 1 + (z * z) / trials
+  const centre = (phat + (z * z) / (2 * trials)) / denom
+  const half =
+    (z * Math.sqrt((phat * (1 - phat)) / trials + (z * z) / (4 * trials * trials))) / denom
+  return [Math.max(0, centre - half), Math.min(1, centre + half)]
+}
+
+/**
+ * Percentile-bootstrap confidence interval for the mean of `values`.
+ *
+ * Games-won is coarse: it discards *how* a game was won, so a real edge can
+ * fail to register over a few hundred games. Margin keeps that magnitude, and
+ * an interval on it will usually resolve a difference long before games-won
+ * does. An interval excluding zero is evidence of a real difference in margin.
+ *
+ * `rand` is injected rather than taken from `Math.random` so a reported
+ * interval is reproducible from the run's seed alone.
+ */
+export function bootstrapMeanCi(
+  values: readonly number[],
+  rand: () => number,
+  iters = 5000,
+  alpha = 0.05,
+): [number, number] {
+  const n = values.length
+  if (n === 0) return [0, 0]
+  if (n === 1) return [values[0], values[0]]
+
+  const means: number[] = []
+  for (let i = 0; i < iters; i++) {
+    let total = 0
+    for (let j = 0; j < n; j++) total += values[Math.floor(rand() * n)]
+    means.push(total / n)
+  }
+  means.sort((a, b) => a - b)
+  return [means[Math.floor((alpha / 2) * iters)], means[Math.min(iters - 1, Math.floor((1 - alpha / 2) * iters))]]
+}
+
+/** Percentile of an unsorted sample, by nearest rank. Used for the latency
+ *  report, where p95 is the number that decides whether a model is affordable
+ *  and the mean is the number that hides a stall. */
+export function percentile(values: readonly number[], q: number): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1))
+  return sorted[idx]
+}

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -244,21 +244,22 @@ describe('chooseBid', () => {
       // 4th bidder (passesSoFar=3, dealer): partner (player 2) has already had
       // their turn, so the "partner hasn't bid" rule doesn't apply.
       // Pinned to a 'static' skill level (#114): this is the OPENER_THRESHOLD
-      // rule specifically, and 'hard' no longer runs it.
+      // rule specifically, and since #115 opened the gate only `easy` and
+      // `medium` still run it.
       const context = baseContext({ dealer: 0, passesSoFar: 3 })
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'proficient')).toBeNull()
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
     })
 
-    it('passes this hand on every level while the evaluator is gated off (#114/#115)', () => {
+    it('takes this hand on a distilled level and passes it on a static one (#114/#115)', () => {
       // runOnlyHand's ceiling is 300, under OPENER_THRESHOLD, so the static
-      // rule passes. The distilled evaluator would take it — it sees a full
-      // trump Run, 150 guaranteed meld before a trick is played, offered the
-      // contract at the 300 minimum. That divergence is the clearest single
-      // illustration of what #114 changes, and it is switched off at every
-      // skill level pending #115's measurement. `evaluator.test.ts` asserts
-      // the evaluator's side of it directly, so the behaviour stays covered.
+      // rule passes. The distilled evaluator takes it — it sees a full trump
+      // Run, 150 guaranteed meld before a trick is played, offered the contract
+      // at the 300 minimum. That divergence is the clearest single illustration
+      // of what #114 changes, and #115's A/B is why `hard` now follows the
+      // evaluator rather than the threshold.
       const context = baseContext({ dealer: 0, passesSoFar: 3 })
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'hard')).toBeNull()
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
     })
 
     it('always opens (dealer-protection) when partner is dealer and my score is >= 850 with opponent under 500', () => {

--- a/web/src/engine/evaluator.test.ts
+++ b/web/src/engine/evaluator.test.ts
@@ -162,7 +162,7 @@ describe('the fold model', () => {
   })
 })
 
-describe('the skill dial gates the evaluator (#114)', () => {
+describe('the skill dial selects the bid policy (#114, opened by #115)', () => {
   const context: AuctionContext = {
     everBid: false,
     passesSoFar: 3,
@@ -177,33 +177,37 @@ describe('the skill dial gates the evaluator (#114)', () => {
   // policies, which is what makes it a usable probe of the dial.
   const runOnlyHand = RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1))
 
-  it('has the evaluator gated off at every level pending #115', () => {
-    // Deliberate, not an oversight. Pushing to main deploys to GitHub Pages and
-    // DEFAULT_OPTIONS puts both AI seats on `hard`, so enabling the model there
-    // would change every seat of the default game on merge — a measured change
-    // (settled contract 335.4 -> 323.6; hands ending at exactly 300 3% -> 36%)
-    // that #115 has not yet judged. #101 and #102 shipped the same way: wiring
-    // live, flag off, pending evidence.
+  it('runs the evaluator on hard and above, and the thresholds below (#115)', () => {
+    // #114 pinned every level to 'static' so the model could not reach a player
+    // by accident; #115 measured it and opened the gate for `hard` upward —
+    // 211 deals swept to static's 50 over 1000 mirrored pairs, +227 score
+    // margin per deal with a 95% CI of +198 to +257 (see src/ab/).
     //
-    // Flipping a level to 'distilled' should be a deliberate act with an A/B
-    // behind it, so this fails loudly if one drifts back on.
-    for (const level of ['easy', 'medium', 'hard', 'proficient', 'expert'] as const) {
-      expect(SKILL_PARAMS[level].bidPolicy).toBe('static')
+    // Still an assertion rather than a shrug, and still the place a drift shows
+    // up: `hard` is what DEFAULT_OPTIONS gives both AI seats, so a level moving
+    // in either direction here changes the default game on merge and should be
+    // a deliberate act with a measurement behind it.
+    expect(SKILL_PARAMS.easy.bidPolicy).toBe('static')
+    expect(SKILL_PARAMS.medium.bidPolicy).toBe('static')
+    for (const level of ['hard', 'proficient', 'expert'] as const) {
+      expect(SKILL_PARAMS[level].bidPolicy).toBe('distilled')
     }
   })
 
-  it('runs the static thresholds on every level while gated', () => {
-    for (const level of ['medium', 'hard', 'proficient', 'expert'] as const) {
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, level)).toBeNull()
+  it('separates the two policies on one hand the dial can be probed with', () => {
+    // Ceiling 300, under OPENER_THRESHOLD, so the static rule passes while the
+    // evaluator opens — one hand that reads the dial directly rather than
+    // asserting on SKILL_PARAMS a second time.
+    expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
+    for (const level of ['hard', 'proficient', 'expert'] as const) {
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, level)).toBe(OPENING_BID)
     }
   })
 
-  it('still opens this hand when the evaluator is consulted directly', () => {
-    // The gate is a policy choice, not a missing implementation. Exercised
-    // directly so the distilled path stays covered while no level selects it —
-    // otherwise gating would quietly turn the whole of #114 into dead code.
-    // This is the decision the dial would surface if #115 enables it: the same
-    // sub-320 hand the static rule passes on.
+  it('opens this hand when the evaluator is consulted directly', () => {
+    // The same decision as above with the dial taken out of the picture: a full
+    // trump Run is 150 guaranteed meld, and the model takes the contract on it
+    // where a threshold on the ceiling alone does not.
     expect(
       shouldBid({
         hand: runOnlyHand,

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -8,7 +8,9 @@ export type HandValuation = 'meld_only' | 'base_bid'
  * Which rule decides "is this hand worth a contract at this level" (#114).
  *
  *   `'static'`    the hand-tuned constants — `OPENER_THRESHOLD`,
- *                 `DEFENSIVE_PUSH_FLOOR` — that shipped before epic #104.
+ *                 `DEFENSIVE_PUSH_FLOOR` — that shipped before epic #104. Still
+ *                 live: `medium` runs them, and they still decide the auction's
+ *                 raise ladder on every level (see `chooseBid`).
  *   `'distilled'` the evaluator fitted to 2000 measured rollout decisions
  *                 (`evaluator.ts`), which reads the bid level, the auction
  *                 state and the hand's shape rather than one number against
@@ -28,41 +30,70 @@ export interface SkillParams {
 /**
  * The dial.
  *
- * Every level is currently `'static'`. The distilled evaluator is fully wired,
- * exported and parity-tested against Python (180/180 fixture hands exact) — it
- * is simply not switched on for anyone yet, because #115 has not measured
- * whether it plays better. Same discipline as the rest of epic #106: #101 and
- * #102 both shipped with their wiring live and their flag off after measuring
- * no benefit, and #103 was only enabled once an A/B justified it.
+ * #114 landed the evaluator wired but switched on for nobody, because pushing
+ * to `main` deploys to GitHub Pages and `DEFAULT_OPTIONS` puts both AI seats on
+ * `hard` — enabling it there changes every seat of the default game on merge,
+ * and #114 could describe the behaviour change without judging it. #115
+ * measured it, and the gate is now open for `hard` and above.
  *
- * This matters more here than in the Python engine, because pushing to `main`
- * deploys to GitHub Pages and `DEFAULT_OPTIONS` sets both `opponentSkill` and
- * `teammateSkill` to `hard`. Enabling the model on `hard` would therefore
- * change every seat of the default game the moment it merged. Measured over
- * 2000 simulated auctions that is not a subtle change: the settled contract
- * averages 323.6 rather than 335.4, and the share of hands settling at exactly
- * 300 goes from 3% to 36%, because the model usually declines the defensive
- * push `DEFENSIVE_PUSH_FLOOR` mandates. That may well be an improvement — but
- * "may well be" is exactly what #115 exists to settle.
+ * What #115 found, over 1000 paired deals played twice with the seats mirrored
+ * (2000 headless games, `src/ab/`):
  *
- * Two notes for whoever flips these:
+ *   distilled swept 211 deals, static 50, 739 split. 95% CI on distilled's
+ *   share of the 261 decisive deals: 75.6%–85.2%, exact two-sided binomial
+ *   p < 1e-4. Score margin +227 per deal, 95% CI +198 to +257.
  *
- *   easy should stay 'static' regardless. Its bidding never reaches the Base
- *   Bid path (`handValuation: 'meld_only'` short-circuits into `meldOnlyBid`),
- *   and the evaluator distils *skill 5* — wiring it in would not make easy
- *   better-calibrated, it would make easy the strongest bidder in the game and
- *   delete the tier.
+ * The mechanism is the one #114 flagged and could not evaluate.
+ * `DEFENSIVE_PUSH_FLOOR = 200` tells a seat to raise a 300 opener on almost any
+ * hand — a ceiling of 200 is barely above the "no meld, no aces" floor — so the
+ * static side buys a great many cheap contracts and is set on 45.4% of them.
+ * The model declines most of those pushes: it takes a third fewer contracts and
+ * makes 63.7% of them against static's 54.6%. Declining a contract you cannot
+ * make is worth more than the contract.
  *
- *   proficient and expert are reserved for real rollouts "where affordable"
- *   per epic #104 (Web Worker, or desktop), which is separate work. Until that
- *   exists they run the pre-#104 constants.
+ * That effect survives the harness's own control: the same policy against
+ * itself splits every pair with a paired margin of exactly zero, so the
+ * mirroring really is cancelling the seat advantage rather than hiding a bug.
+ * It is also not a quirk of playing *against* the static rule — an all-
+ * distilled table is set on 38.8% of its contracts where an all-static table is
+ * set on 42.3%.
+ *
+ * Cost, since a model that thinks visibly is a regression however well it
+ * plays: +1.9 kB raw / +872 B gzipped on the shipped bundle (255.1 kB -> 253.2
+ * kB with it removed), and p95 per-decision latency of 72us against static's
+ * 41us in Node, 495us against 313us in Chrome at a 375x812 viewport. Even
+ * multiplied by a 6x mobile-CPU emulation factor that is ~3 ms, against the
+ * 600 ms `AI_BID_DELAY_MS` the auction already waits before each AI bid.
+ *
+ * Why the levels land where they do:
+ *
+ *   easy stays 'static' — its bidding never reaches the Base Bid path
+ *   (`handValuation: 'meld_only'` short-circuits into `meldOnlyBid`), and the
+ *   evaluator distils *skill 5*, so wiring it in would not make easy
+ *   better-calibrated, it would make easy the strongest bidder and delete the
+ *   tier.
+ *
+ *   medium stays 'static', unchanged from what it plays today. Before this
+ *   change medium, hard, proficient and expert were byte-identical, so the dial
+ *   had exactly two settings; leaving medium on the thresholds gives it a real
+ *   third one — a bidder that opens on a rule of thumb and pushes every cheap
+ *   contract is a fair description of a middling player.
+ *
+ *   proficient and expert take 'distilled' rather than staying on the
+ *   thresholds. Epic #104's sketch was the other way round — evaluator for
+ *   skills 1-3, real rollouts for 4-5 — but that mapping assumed 4-5 would
+ *   *have* rollouts, and in the browser they do not and will not until the Web
+ *   Worker work exists. Between the two policies that do exist here, distilled
+ *   is the measurably stronger one, so leaving the top tiers on the weaker rule
+ *   would rank them below `hard`. When real rollouts land they replace this on
+ *   4-5; until then it is the floor, not the ceiling.
  */
 export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
   easy: { handValuation: 'meld_only', bidPolicy: 'static' },
   medium: { handValuation: 'base_bid', bidPolicy: 'static' },
-  hard: { handValuation: 'base_bid', bidPolicy: 'static' },
-  proficient: { handValuation: 'base_bid', bidPolicy: 'static' },
-  expert: { handValuation: 'base_bid', bidPolicy: 'static' },
+  hard: { handValuation: 'base_bid', bidPolicy: 'distilled' },
+  proficient: { handValuation: 'base_bid', bidPolicy: 'distilled' },
+  expert: { handValuation: 'base_bid', bidPolicy: 'distilled' },
 }
 
 /** Flat trick-point estimate for meld-only bidding (skill 1), matching


### PR DESCRIPTION
Closes #115.

The gate #114 deliberately left closed is now **open for `hard`, `proficient` and `expert`**. `easy` and `medium` keep the thresholds. `hard` is what `DEFAULT_OPTIONS` gives both AI seats, so this changes the default game on merge — which is why the measurement came first.

## Strength

`ab_harness.py` can't run this: both sides are TypeScript. `web/src/ab/` is the smallest thing that can, and it borrows that module's discipline rather than reinventing it.

- `headlessGame.ts` plays complete games by calling the same reducers and the same AI entry points `GameFlow.tsx` calls, in the same order, minus the delays and the rendering. It implements no rule of its own.
- `abRun.ts` derives every deal from `(seed, round)` so the deal can't drift when one policy thinks longer; plays each deal in both seat orientations; tests over **pairs**, not games; discards split pairs; and puts a percentile-bootstrap interval on score margin.
- `stats.ts` ports the three statistics directly (exact binomial, Wilson, bootstrap).

**1000 pairs / 2000 games, distilled vs static:**

| | |
|---|---|
| games won | distilled 1161 (58.1%) — static 839 |
| decisive pairs | distilled swept **211**, static **50**, 739 split |
| 95% CI on distilled's share | **75.6% – 85.2%** |
| exact two-sided binomial p | **< 1e-4** |
| **score margin per deal** | **+227**, 95% CI **+198 to +257** |

Reproduced at seeds 2 and 3: +210 [+168, +252] and +230 [+182, +280]. Every seed significant on both statistics.

**Why.** `DEFENSIVE_PUSH_FLOOR = 200` sits barely above the "no meld, no aces" floor, so the static rule raises a 300 opener on almost any hand. It buys a third more contracts and is set on **45.4%** of them, against the evaluator's **36.3%** (make rate 54.6% vs 63.7%). Declining a contract you can't make is worth more than the contract.

Not an artefact of playing *against* the static rule: an all-distilled table is set on 38.8% of its contracts where an all-static table is set on 42.3%.

**The self-test is the check this rests on.** One policy against itself must find nothing — and here it finds *exactly* nothing: every pair splits and every paired margin is 0, while per-game margins run to four figures from the dealer sitting on one side. That's the seat effect being visibly cancelled by the mirroring rather than assumed away. `ab.test.ts` asserts it for both policies.

## Cost

| | static | distilled | delta |
|---|---|---|---|
| bundle (raw) | 253,220 B | 255,103 B | **+1,883 B** |
| bundle (gzip -9) | 76,985 B | 77,857 B | **+872 B** |
| p95 / decision, Node | 41 µs | 72 µs | +31 µs |
| p95 / decision, Chrome @ 375×812 | 313 µs | 495 µs | +182 µs |

Bundle delta measured against a real build with the evaluator patched out of `bidding.ts`, not estimated. Latency measured over 4000 positions taken from real auctions, both policies interleaved per position (an earlier non-interleaved run reported the *static* path as slower, which is impossible — noted in the code).

At a 6× Lighthouse-style mobile-CPU emulation factor the distilled p95 is ~3 ms, against the **600 ms** `AI_BID_DELAY_MS` the auction already waits before each AI bid, and well inside a 16.7 ms frame. p50 is unchanged (35 µs both ways) because most decisions never reach either rule — which is precisely why p95 is the number reported.

## Things that contradict the issue's assumptions

1. **`FOLD_MODEL` costs zero bytes.** #115 asked for it to be counted in the bundle figure. It can't be: `shouldConcede` has no call site, so Rollup drops it — none of its 14 weights, none of its feature names, and not `MODEL_PROVENANCE`, appear anywhere in the built asset (verified by grepping the artefact for `2.089076061739785`, `tricks_needed`, `fold_cost`, `datasetRows`). The 872 B is the bid model alone. Wiring an AI concede later would add the fold model's bytes *then*.

2. **Epic #104's skill mapping is inverted here.** #104 suggested the evaluator for skills 1–3 and real rollouts for 4–5. That assumed 4–5 would *have* rollouts; in the browser they don't and won't until the Web Worker work exists. Between the two policies that actually exist, distilled is the stronger, so leaving `proficient`/`expert` on the weaker rule would rank them below `hard`. When real rollouts land they replace this on 4–5; until then it's the floor, not the ceiling.

3. **#114's "distilled settles lower" doesn't survive a mixed table.** #114 measured 323.6 vs 335.4 in all-distilled auctions. At a mixed table distilled's *own* contracts average 336 to static's 326 — it declines the cheap pushes and lets the static side buy them. Both are true; they answer different questions.

## Bounds on the claim

Both limitations #114 flagged, quantified rather than restated:

- The evaluator governs only the opening decision and the defensive push. The ordinary raise ladder (`nextBid <= competitiveCeiling`) and the 330/340 constants are untouched, and a distilled seat that declines a push at 310 can still bid 310 via the ladder. Measured directly: the two policies return a **different bid on 6.5%** of real auction positions (261/4000). That is the ceiling on what the model can be credited or blamed for.
- Every seat in the harness is an AI. This establishes that the *policy* is stronger, not that it is a better *partner* for a human — which is what `hard` mostly is in the default game.

## Checks

- `npm run build` clean.
- `npx vitest run` — **298 passed** (287 before; +11 from `src/ab/ab.test.ts`).
- `python -m pytest -q` — **269 passed**, unchanged.
- `npm run lint` — only the three pre-existing `exhaustive-deps` warnings in `TrickPlayFlow.tsx`/`AuctionFlow.tsx`; nothing new.
- Nothing under `src/ab/` or `bench/` is in the App's import graph or a `vite build` input, so none of it ships. Flipping the gate itself moved the bundle by 8 bytes.

## Reproducing

```
cd web
node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts selftest --pairs 100   # run this first
node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts ab --pairs 1000 --seed 1
node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts latency --positions 4000
npm run dev   # then /pinochle/bench/ for the browser latency numbers
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
