### PR TITLE
Wire the fold model for every skill level (#123)

### DIFF
--- a/profile_skills.py
+++ b/profile_skills.py
@@ -1,0 +1,457 @@
+"""
+Skill-profile harness - per-skill behavioural statistics over random
+mixed-skill games.
+
+`tournament_sim.py` answers "which of these two configurations wins?".
+This answers a different question: "what does each skill level actually
+*do*, and are the five levels still distinguishable from each other?".
+Win rate cannot answer that - two tiers can have very different win rates
+while playing an identical style, and (more to the point here) two tiers
+with identical parameters will look like two different tiers in a
+tournament purely through noise.
+
+Seats are assigned skill levels uniformly at random, independently, every
+game - the same draw `RandomStrategy` makes, but done here so the
+harness knows which level sat where and can attribute every decision to
+it. Random mixing rather than fixed matchups is deliberate: a level's
+numbers should describe the level, not the specific opponent it was
+pinned against, and every level meets every other level in every seat
+combination over enough games.
+
+## The fold question this is built to answer
+
+Fold rate on its own does not rank players. A strong player folds
+because they counted the hand and the contract is not there; a weak
+player folds because the hand looks scary. Both show up as "folds
+often". What separates them is *which* hands they fold, so this harness
+measures discrimination rather than frequency:
+
+  - `needed` = bid - bidding-team meld: the trick points the contract
+    still requires, known exactly at the fold decision point, out of the
+    250 available. This is the number a thinking player computes, so it
+    is the natural axis to test folds against.
+
+  - Fold AUC = P(a folded contract needed more than a played one),
+    computed per level over its own decisions. 0.50 means folds are
+    uncorrelated with how hard the contract was - fear, or a coin flip.
+    1.00 means the level folds exactly the hard ones and plays exactly
+    the easy ones. This is rank-based, so it is unaffected by how *often*
+    a level folds; a level that folds 5% and one that folds 40% are
+    directly comparable.
+
+  - Missed folds, for the levels that never fold at all. Conceding is
+    scored at -bid for the bidding team and denies the defenders their
+    trick points (`Round._score_conceded_round`), so the fold payoff is
+    known exactly at decision time: margin = -bid - defending_meld. Any
+    played contract whose realised margin came in below that number was
+    a contract the level should have conceded. This turns "level N never
+    folds" from a code observation into a points-per-round cost.
+
+Run:
+
+    python profile_skills.py --games 300
+    python profile_skills.py --games 300 --seed 11 --json out.json
+"""
+
+import argparse
+import json
+import random
+import statistics
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from pinochle_engine import (
+    GENERAL_STRATEGY_SKILL_PARAMS,
+    Game,
+    GeneralStrategy,
+    score_melds,
+)
+
+SKILL_LEVELS = sorted(GENERAL_STRATEGY_SKILL_PARAMS)
+MAX_TRICK_POINTS = 250  # 240 in card points + 10 for last trick, per pinochle_rules.md
+
+
+# ---------------------------------------------------------------------------
+# Collection - one record per decision, aggregated at the end.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ContractRecord:
+    """One taken contract, filled in across two callbacks: the fold hook
+    (which fires before any card is led, and so is the only place the
+    pre-trick state still exists) and the round hook (which has the
+    result). `folded` is the level's decision; `margin` is what the
+    bidding team actually scored minus what the defenders scored."""
+    winner_skill: int
+    bid: int
+    bidding_meld: int
+    defending_meld: int
+    winner_own_meld: int
+    folded: bool
+    margin: int = 0
+    made: bool = False
+
+    @property
+    def needed(self):
+        """Trick points the contract still requires. Negative means meld
+        alone already covers the bid; above MAX_TRICK_POINTS means it is
+        arithmetically unreachable no matter how the cards fall."""
+        return self.bid - self.bidding_meld
+
+    @property
+    def fold_margin(self):
+        """What conceding would have scored, exactly. Known at decision
+        time - the defenders keep their meld and take no tricks."""
+        return -self.bid - self.defending_meld
+
+    @property
+    def auto_set(self):
+        """The contract is arithmetically unreachable: even taking every
+        trick point on the table leaves the bidding team short.
+
+        Worth separating out, because folding one of these is not a
+        judgment call - it is subtraction, and `should_fold` shortcuts
+        straight to True on it without consulting a rollout. A level whose
+        folds are all auto-sets has not demonstrated it can read a hand;
+        it has demonstrated it can subtract. The interesting question is
+        how well a level folds on the contracts that are *live*."""
+        return self.needed > MAX_TRICK_POINTS
+
+
+@dataclass
+class SkillTally:
+    """Everything counted for one skill level, across all seats it
+    occupied. Bid-level counters are per auction turn; contract-level
+    counters are per contract won."""
+    seat_games: int = 0
+    auction_turns: int = 0
+    bids: int = 0
+    opening_turns: int = 0  # turns where nobody had bid yet
+    opens: int = 0
+    bid_amounts: list = field(default_factory=list)
+    melds_at_meld_time: list = field(default_factory=list)
+    contracts: list = field(default_factory=list)  # ContractRecord
+
+
+class Collector:
+    """Shared sink. One instance per run, handed to every player."""
+
+    def __init__(self):
+        self.tallies = defaultdict(SkillTally)
+        self.pending = None  # ContractRecord awaiting its round result
+
+    def record_bid(self, skill, opening, bid_amount):
+        tally = self.tallies[skill]
+        tally.auction_turns += 1
+        if opening:
+            tally.opening_turns += 1
+        if bid_amount is not None:
+            tally.bids += 1
+            tally.bid_amounts.append(bid_amount)
+            if opening:
+                tally.opens += 1
+
+    def record_meld(self, skill, meld):
+        self.tallies[skill].melds_at_meld_time.append(meld)
+
+    def record_contract(self, record):
+        self.pending = record
+        self.tallies[record.winner_skill].contracts.append(record)
+
+    def close_round(self, margin, made):
+        if self.pending is None:
+            return
+        self.pending.margin = margin
+        self.pending.made = made
+        self.pending = None
+
+
+# ---------------------------------------------------------------------------
+# Instrumented player - records, decides nothing itself.
+# ---------------------------------------------------------------------------
+
+class ProfiledStrategy(GeneralStrategy):
+    """`GeneralStrategy` with the two decision points this harness reads
+    wrapped. Every override calls `super()` for the actual decision and
+    only observes the answer, so a run measures the shipped AI and not a
+    variant of it."""
+
+    def __init__(self, name, team=None, skill_level=3, rng=None, collector=None):
+        super().__init__(name, team, skill_level=skill_level, rng=rng)
+        self.collector = collector
+
+    def choose_bid(self, current_bid, min_increment, context=None):
+        decision = super().choose_bid(current_bid, min_increment, context)
+        if self.collector is not None and context is not None:
+            self.collector.record_bid(
+                self.skill_level,
+                opening=not context.get("ever_bid", False),
+                bid_amount=decision,
+            )
+        return decision
+
+    def decide_fold(self, trump, bid, bidding_meld, defending_meld):
+        folded = bool(super().decide_fold(trump, bid, bidding_meld, defending_meld))
+        if self.collector is None:
+            return folded
+
+        # Only the bid winner is asked to fold, and it happens after meld
+        # and before the first lead - the one moment all four hands are
+        # both scored and still intact. Reaching the other three seats
+        # through the team wiring is what lets per-seat meld be attributed
+        # to a skill level without patching Round._meld_phase.
+        for player in self._all_players():
+            self.collector.record_meld(player.skill_level, score_melds(player.hand, trump)[0])
+
+        self.collector.record_contract(ContractRecord(
+            winner_skill=self.skill_level,
+            bid=bid,
+            bidding_meld=bidding_meld,
+            defending_meld=defending_meld,
+            winner_own_meld=score_melds(self.hand, trump)[0],
+            folded=folded,
+        ))
+        return folded
+
+    def _all_players(self):
+        seats = list(self.team.players)
+        opponent = getattr(self.team, "opponent", None)
+        if opponent is not None:
+            seats += list(opponent.players)
+        return [p for p in seats if isinstance(p, ProfiledStrategy)]
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def run_profile(n_games, seed=None, progress_every=25):
+    """Play `n_games` games, each with a fresh uniform-random skill level
+    per seat. Returns the populated Collector.
+
+    Skills are redrawn per game rather than per run so that no level is
+    stuck facing one particular opponent, and the deal seed is derived per
+    game from the master RNG so a surprising game can be replayed."""
+    rng = random.Random(seed)
+    collector = Collector()
+    start = time.perf_counter()
+
+    for game_index in range(n_games):
+        skills = [rng.choice(SKILL_LEVELS) for _ in range(4)]
+        players = [
+            ProfiledStrategy(f"S{seat}", None, skill_level=skill, rng=rng, collector=collector)
+            for seat, skill in enumerate(skills)
+        ]
+        for skill in skills:
+            collector.tallies[skill].seat_games += 1
+
+        game = Game.from_players(players)
+
+        def on_round(round_, round_scores, _game=game):
+            bidding_team = round_.bid_winner.team
+            defending_team = next(t for t in _game.teams if t is not bidding_team)
+            margin = round_scores[bidding_team] - round_scores[defending_team]
+            collector.close_round(margin, made=round_scores[bidding_team] > 0)
+
+        game.play(deal_seed=rng.randrange(2 ** 31), on_round=on_round)
+
+        if progress_every and (game_index + 1) % progress_every == 0:
+            elapsed = time.perf_counter() - start
+            print(f"  {game_index + 1}/{n_games} games  ({elapsed:.0f}s)", flush=True)
+
+    return collector, time.perf_counter() - start
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+def fold_auc(records):
+    """P(a folded contract needed more trick points than a played one),
+    with ties counted as half - the Mann-Whitney U statistic, which is
+    what AUC is.
+
+    Returns None unless the level both folded and played at least one
+    contract, since discrimination is undefined with only one class.
+    Computed on `needed` because that is the quantity available at the
+    decision point; scoring it against the eventual result instead would
+    reward luck."""
+    folded = [r.needed for r in records if r.folded]
+    played = [r.needed for r in records if not r.folded]
+    if not folded or not played:
+        return None
+    wins = sum(
+        1.0 if f > p else 0.5 if f == p else 0.0
+        for f in folded
+        for p in played
+    )
+    return wins / (len(folded) * len(played))
+
+
+def missed_folds(records):
+    """Played contracts that scored below what conceding would have paid -
+    the value a level would have captured by folding with perfect
+    foresight.
+
+    Read this as a ceiling, not as a count of blunders. Conceding *always*
+    beats being set: both pay the bidding team -bid, but a concede denies
+    the defenders their trick points, so the set is strictly worse by
+    exactly those points. That makes this count identically equal to the
+    level's set count - it is not evidence of a detectable mistake, since
+    nobody knows in advance which contracts will fail. What it does
+    measure honestly is the size of the prize: how many points a perfect
+    fold oracle would be worth per contract, and therefore how much room a
+    real fold policy has to work in. Comparing a folding level's residual
+    against a never-folding level's total is the useful reading.
+
+    Returns (count, played_total, mean points left on the table across
+    *all* played contracts)."""
+    played = [r for r in records if not r.folded]
+    if not played:
+        return 0, 0, 0.0
+    missed = [r for r in played if r.fold_margin > r.margin]
+    forgone = sum(r.fold_margin - r.margin for r in missed)
+    return len(missed), len(played), forgone / len(played)
+
+
+def _mean(values):
+    return statistics.mean(values) if values else 0.0
+
+
+def summarise(collector, elapsed, n_games):
+    tallies = collector.tallies
+    total_contracts = sum(len(t.contracts) for t in tallies.values())
+    lines = [
+        f"Skill profile - {n_games} games, random skill per seat "
+        f"({elapsed:.0f}s, {elapsed / n_games * 1000:.0f} ms/game)",
+        f"{total_contracts} contracts across all levels",
+        "",
+        "Level  seats  bid%   open%   avgbid  contracts  make%   set%   fold%   meld  ownmeld",
+        "-" * 92,
+    ]
+
+    for skill in SKILL_LEVELS:
+        tally = tallies[skill]
+        records = tally.contracts
+        n = len(records)
+        folded = sum(1 for r in records if r.folded)
+        played = [r for r in records if not r.folded]
+        made = sum(1 for r in played if r.made)
+        lines.append(
+            f"  {skill}    {tally.seat_games:4d}  "
+            f"{tally.bids / tally.auction_turns:5.1%} "
+            f"{tally.opens / tally.opening_turns if tally.opening_turns else 0:6.1%}  "
+            f"{_mean(tally.bid_amounts):6.0f}  "
+            f"{n:8d}  "
+            f"{made / len(played) if played else 0:5.1%}  "
+            f"{(len(played) - made) / len(played) if played else 0:5.1%}  "
+            f"{folded / n if n else 0:5.1%}  "
+            f"{_mean(tally.melds_at_meld_time):5.0f}  "
+            f"{_mean([r.winner_own_meld for r in records]):6.0f}"
+        )
+
+    lines += [
+        "",
+        "Fold quality - is a level's folding skill or fear?",
+        "",
+        "Level  folds  fold%   AUC(all)  AUC(live)  autoset%  needed(fold)  needed(play)",
+        "-" * 92,
+    ]
+    for skill in SKILL_LEVELS:
+        records = tallies[skill].contracts
+        n = len(records)
+        folded = [r for r in records if r.folded]
+        played = [r for r in records if not r.folded]
+        auc_all = fold_auc(records)
+        auc_live = fold_auc([r for r in records if not r.auto_set])
+        auto = sum(1 for r in folded if r.auto_set)
+        lines.append(
+            f"  {skill}  {len(folded):5d}  {len(folded) / n if n else 0:5.1%}  "
+            f"{f'{auc_all:.3f}' if auc_all is not None else '-':>8}  "
+            f"{f'{auc_live:.3f}' if auc_live is not None else '-':>9}  "
+            f"{auto / len(folded) if folded else 0:7.1%}  "
+            f"{_mean([r.needed for r in folded]):11.0f}  "
+            f"{_mean([r.needed for r in played]):12.0f}"
+        )
+
+    lines += [
+        "",
+        "Hindsight value of folding - what a perfect fold oracle would be worth",
+        "(equal to the set count by identity: a concede always beats a set by the",
+        " defenders' trick points, so this is the size of the prize, not a blunder count)",
+        "",
+        "Level   sets/played    set%   oracle gain/contract   gain when it applies",
+        "-" * 92,
+    ]
+    for skill in SKILL_LEVELS:
+        records = tallies[skill].contracts
+        n_missed, n_played, cost = missed_folds(records)
+        played = [r for r in records if not r.folded]
+        missed = [r for r in played if r.fold_margin > r.margin]
+        lines.append(
+            f"  {skill}  {n_missed:6d}/{n_played:<7d} "
+            f"{n_missed / n_played if n_played else 0:6.1%}  "
+            f"{cost:+12.0f}   "
+            f"{_mean([r.fold_margin - r.margin for r in missed]):+18.0f}"
+        )
+
+    lines += [
+        "",
+        f"`needed` = bid - bidding meld, out of {MAX_TRICK_POINTS} trick points available.",
+        "AUC 0.50 = folds unrelated to how hard the contract was; 1.00 = perfectly targeted.",
+        "AUC(live) excludes auto-set contracts, where folding is subtraction, not judgment.",
+        "oracle gain = mean margin a perfect fold oracle would add; an upper bound, not a debt.",
+    ]
+    return "\n".join(lines)
+
+
+def to_json(collector, elapsed, n_games):
+    out = {"games": n_games, "elapsed_seconds": elapsed, "levels": {}}
+    for skill in SKILL_LEVELS:
+        tally = collector.tallies[skill]
+        records = tally.contracts
+        played = [r for r in records if not r.folded]
+        n_missed, n_played, cost = missed_folds(records)
+        out["levels"][skill] = {
+            "params": GENERAL_STRATEGY_SKILL_PARAMS[skill],
+            "seat_games": tally.seat_games,
+            "auction_turns": tally.auction_turns,
+            "bid_rate": tally.bids / tally.auction_turns if tally.auction_turns else 0,
+            "open_rate": tally.opens / tally.opening_turns if tally.opening_turns else 0,
+            "avg_bid": _mean(tally.bid_amounts),
+            "contracts": len(records),
+            "make_rate": sum(1 for r in played if r.made) / len(played) if played else 0,
+            "fold_rate": sum(1 for r in records if r.folded) / len(records) if records else 0,
+            "fold_auc": fold_auc(records),
+            "avg_meld": _mean(tally.melds_at_meld_time),
+            "avg_own_meld_as_bidder": _mean([r.winner_own_meld for r in records]),
+            "avg_needed_folded": _mean([r.needed for r in records if r.folded]),
+            "avg_needed_played": _mean([r.needed for r in played]),
+            "missed_folds": n_missed,
+            "played_contracts": n_played,
+            "missed_fold_cost_per_contract": cost,
+            "avg_margin_as_bidder": _mean([r.margin for r in records]),
+        }
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--games", type=int, default=300, help="games to simulate (default: 300)")
+    parser.add_argument("--seed", type=int, default=None, help="master seed for reproducibility")
+    parser.add_argument("--json", type=str, default=None, help="also write raw stats to this path")
+    args = parser.parse_args()
+
+    collector, elapsed = run_profile(args.games, seed=args.seed)
+    print()
+    print(summarise(collector, elapsed, args.games))
+
+    if args.json:
+        with open(args.json, "w") as handle:
+            json.dump(to_json(collector, elapsed, args.games), handle, indent=2)
+        print(f"\nraw stats -> {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/src/ab/ab.test.ts
+++ b/web/src/ab/ab.test.ts
@@ -12,11 +12,19 @@
 // runs meaningful, at the smallest size that demonstrates it.
 
 import { describe, expect, it } from 'vitest'
+import type { TeamId } from '../engine/round'
 import { SKILL_PARAMS } from '../engine/skills'
 import type { PlayerIndex } from '../engine/trick'
 import type { SkillLevel } from '../persistence/options'
-import { DISTILLED_LEVEL, STATIC_LEVEL, analyse, installPolicies, runAb } from './abRun'
-import { makeRng, playHeadlessGame } from './headlessGame'
+import {
+  DISTILLED_LEVEL,
+  FOLD_AB_POLICIES,
+  STATIC_LEVEL,
+  analyse,
+  installPolicies,
+  runAb,
+} from './abRun'
+import { type SideStats, makeRng, newSideStats, playHeadlessGame } from './headlessGame'
 import { binomialTwoSidedP, bootstrapMeanCi, percentile, wilsonInterval } from './stats'
 
 describe('the statistics', () => {
@@ -96,6 +104,52 @@ describe('the headless game', () => {
     const a = playHeadlessGame({ seatSkills, dealSeed: 99 })
     const b = playHeadlessGame({ seatSkills, dealSeed: 99 })
     expect(b).toEqual(a)
+  })
+
+  // -- Conceding (#123) -----------------------------------------------------
+
+  it('concedes contracts, and counts them as set rather than as a third outcome', () => {
+    // Aggregated over seeds rather than pinned to one: roughly a fifth of
+    // contracts are conceded, so a single ~6-round game has no fold at all
+    // often enough (17 of 40 seeds) that a one-seed version of this test would
+    // fail for reasons having nothing to do with the code.
+    const seatSkills = { 0: 'hard', 1: 'hard', 2: 'hard', 3: 'hard' } as Record<PlayerIndex, SkillLevel>
+    const stats = { 0: newSideStats(), 1: newSideStats() } as Record<TeamId, SideStats>
+    for (let dealSeed = 1; dealSeed <= 12; dealSeed++) {
+      playHeadlessGame({ seatSkills, dealSeed, stats })
+    }
+
+    const conceded = stats[0].conceded + stats[1].conceded
+    expect(conceded).toBeGreaterThan(0)
+    for (const team of [0, 1] as TeamId[]) {
+      // A concede is a contract taken and not made. Both invariants would break
+      // if the concede branch forgot its bookkeeping or double-counted.
+      expect(stats[team].conceded).toBeLessThanOrEqual(stats[team].set)
+      expect(stats[team].made + stats[team].set).toBe(stats[team].contracts)
+      expect(stats[team].bids).toHaveLength(stats[team].contracts)
+    }
+  })
+
+  it('never concedes when the dial says never, and folds strictly more often when it does', () => {
+    // The comparison `foldPolicy` exists to make measurable. Same deal, same
+    // seats, one field different — so any difference in concedes is the policy.
+    const never = { 0: newSideStats(), 1: newSideStats() } as Record<TeamId, SideStats>
+    const model = { 0: newSideStats(), 1: newSideStats() } as Record<TeamId, SideStats>
+
+    const restore = installPolicies(FOLD_AB_POLICIES)
+    try {
+      const seats = (level: SkillLevel) =>
+        ({ 0: level, 1: level, 2: level, 3: level }) as Record<PlayerIndex, SkillLevel>
+      for (let dealSeed = 1; dealSeed <= 12; dealSeed++) {
+        playHeadlessGame({ seatSkills: seats(STATIC_LEVEL), dealSeed, stats: never })
+        playHeadlessGame({ seatSkills: seats(DISTILLED_LEVEL), dealSeed, stats: model })
+      }
+    } finally {
+      restore()
+    }
+
+    expect(never[0].conceded + never[1].conceded).toBe(0)
+    expect(model[0].conceded + model[1].conceded).toBeGreaterThan(0)
   })
 })
 

--- a/web/src/ab/abRun.ts
+++ b/web/src/ab/abRun.ts
@@ -51,26 +51,41 @@ import { type SideStats, makeRng, newSideStats, playHeadlessGame } from './headl
 import { binomialTwoSidedP, bootstrapMeanCi, wilsonInterval } from './stats'
 
 /** The two dial entries the harness commandeers. Both are `base_bid` levels, so
- *  overwriting them changes bidding policy and nothing else. */
+ *  overwriting them changes the one field under test and nothing else. */
 export const STATIC_LEVEL: SkillLevel = 'hard'
 export const DISTILLED_LEVEL: SkillLevel = 'expert'
 
-const AB_POLICIES: Record<string, SkillParams> = {
-  [STATIC_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'static' },
-  [DISTILLED_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'distilled' },
+/** Bidding A/B (#115): distilled vs static, both folding as the product does. */
+export const BID_AB_POLICIES: Record<string, SkillParams> = {
+  [STATIC_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'static', foldPolicy: 'model' },
+  [DISTILLED_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
 }
 
-/** Overwrites the two entries above, returning a function that restores them.
- *  Callers must restore in a `finally` — a leaked override would silently
+/**
+ * Fold A/B (#123): identical bidders, one allowed to concede and one not.
+ *
+ * `foldPolicy` is uniform across the shipped dial by design, so there is no
+ * pair of real skill levels that differ in it — which is exactly why the
+ * override mechanism has to carry this comparison. Both sides bid `distilled`
+ * here rather than `static`, so the measurement describes folding as it will
+ * actually ship on `hard` and above.
+ */
+export const FOLD_AB_POLICIES: Record<string, SkillParams> = {
+  [STATIC_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'never' },
+  [DISTILLED_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
+}
+
+/** Overwrites the two entries in `policies`, returning a function that restores
+ *  them. Callers must restore in a `finally` — a leaked override would silently
  *  change any later test in the same module registry. */
-export function installPolicies(): () => void {
+export function installPolicies(policies: Record<string, SkillParams> = BID_AB_POLICIES): () => void {
   const saved: Partial<Record<SkillLevel, SkillParams>> = {}
-  for (const [level, params] of Object.entries(AB_POLICIES) as [SkillLevel, SkillParams][]) {
+  for (const [level, params] of Object.entries(policies) as [SkillLevel, SkillParams][]) {
     saved[level] = SKILL_PARAMS[level]
     SKILL_PARAMS[level] = params
   }
   return () => {
-    for (const level of Object.keys(AB_POLICIES) as SkillLevel[]) {
+    for (const level of Object.keys(policies) as SkillLevel[]) {
       SKILL_PARAMS[level] = saved[level] as SkillParams
     }
   }
@@ -144,6 +159,9 @@ export interface RunAbOptions {
    *  twice is the harness's own self-test. */
   readonly levelA?: SkillLevel
   readonly levelB?: SkillLevel
+  /** Which pair of overrides to install for the run. Defaults to the bidding
+   *  comparison; pass `FOLD_AB_POLICIES` for the fold one. */
+  readonly policies?: Record<string, SkillParams>
 }
 
 /**
@@ -164,9 +182,10 @@ export function runAb(options: RunAbOptions): AbReport {
     labelB = 'static',
     levelA = DISTILLED_LEVEL,
     levelB = STATIC_LEVEL,
+    policies = BID_AB_POLICIES,
   } = options
 
-  const restore = installPolicies()
+  const restore = installPolicies(policies)
   const realRandom = Math.random
   const seedSource = makeRng(seed)
   const marginsA: number[] = []
@@ -279,6 +298,10 @@ export function summarise(report: AbReport, analysis = analyse(report)): string 
     `  ${'contracts won'.padEnd(18)}${String(report.statsA.contracts).padStart(12)}${String(report.statsB.contracts).padStart(12)}`,
     `  ${'made'.padEnd(18)}${rate(report.statsA.made, report.statsA.contracts).padStart(12)}${rate(report.statsB.made, report.statsB.contracts).padStart(12)}`,
     `  ${'set'.padEnd(18)}${rate(report.statsA.set, report.statsA.contracts).padStart(12)}${rate(report.statsB.set, report.statsB.contracts).padStart(12)}`,
+    // Conceded is a subset of set, not a third outcome — see `SideStats`. A
+    // side that never folds reads 0% here, which is what makes the fold A/B
+    // legible at a glance rather than only through the margin.
+    `  ${'  of which folded'.padEnd(18)}${rate(report.statsA.conceded, report.statsA.contracts).padStart(12)}${rate(report.statsB.conceded, report.statsB.contracts).padStart(12)}`,
     `  ${'avg bid'.padEnd(18)}${avg(report.statsA.bids).toFixed(0).padStart(12)}${avg(report.statsB.bids).toFixed(0).padStart(12)}`,
   ].join('\n')
 }

--- a/web/src/ab/cli.ts
+++ b/web/src/ab/cli.ts
@@ -4,6 +4,7 @@
 // executes TypeScript directly, so this needs no build step and no new package:
 //
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts ab --pairs 400
+//   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts fold --pairs 400
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts selftest --pairs 100
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts latency --positions 4000
 //
@@ -17,7 +18,14 @@
 // the rest of the engine, and paying for that with one cast is the cheaper
 // trade than a second tsconfig project.
 
-import { DISTILLED_LEVEL, STATIC_LEVEL, analyse, runAb, summarise } from './abRun'
+import {
+  DISTILLED_LEVEL,
+  FOLD_AB_POLICIES,
+  STATIC_LEVEL,
+  analyse,
+  runAb,
+  summarise,
+} from './abRun'
 import { formatLatency, runLatencyBenchmark } from './latency'
 
 const argv = (globalThis as { process?: { argv: string[] } }).process?.argv ?? []
@@ -31,7 +39,19 @@ function flag(name: string, fallback: number): number {
   return Number.isFinite(value) ? value : fallback
 }
 
-if (command === 'ab' || command === 'selftest') {
+if (command === 'fold') {
+  // #123's measurement: identical distilled bidders, one allowed to concede.
+  const pairs = flag('pairs', 400)
+  const seed = flag('seed', 1)
+  const report = runAb({
+    nPairs: pairs,
+    seed,
+    labelA: 'fold',
+    labelB: 'no-fold',
+    policies: FOLD_AB_POLICIES,
+  })
+  console.log(summarise(report, analyse(report, seed)))
+} else if (command === 'ab' || command === 'selftest') {
   const pairs = flag('pairs', command === 'selftest' ? 100 : 400)
   const seed = flag('seed', 1)
   // `--policy distilled` self-tests the model path instead of the threshold
@@ -49,5 +69,5 @@ if (command === 'ab' || command === 'selftest') {
   const repeats = flag('repeats', 40)
   console.log(formatLatency(runLatencyBenchmark(positions, repeats)))
 } else {
-  console.log('usage: cli.ts [ab|selftest|latency] [--pairs N] [--seed N] [--positions N] [--repeats N]')
+  console.log('usage: cli.ts [ab|fold|selftest|latency] [--pairs N] [--seed N] [--positions N] [--repeats N]')
 }

--- a/web/src/ab/headlessGame.ts
+++ b/web/src/ab/headlessGame.ts
@@ -13,25 +13,30 @@
 // a call into the module that already owns that rule; what lives here is only
 // the loop GameFlow's `useEffect`s form, plus seeding.
 //
-// Two things it does NOT model, both on purpose:
+// One thing it does NOT model, on purpose:
 //
 //   The human seat. Every seat is an AI, as in `biddingSim.test.ts`. That is
 //   what makes the comparison a comparison.
 //
-//   Conceding. `trickPlayReducer`'s CONCEDE action has exactly one caller in
-//   the app — the human's fold button (#83) — so no AI seat ever concedes, and
-//   `evaluator.ts`'s `shouldConcede` has no call site at all. Adding one here
-//   would measure a feature the product does not ship.
+// Conceding used to be a second such exclusion, on the grounds that
+// `trickPlayReducer`'s CONCEDE action had exactly one caller — the human's fold
+// button (#83) — so modelling it here would have measured a feature the product
+// did not ship. #123 wired `shouldConcede` for every AI bid winner, so that
+// reasoning inverted: leaving it out would now measure a *different* game from
+// the one the app plays. The concede window below is the same one
+// `TrickPlayFlow` gives the AI, and both read the same `foldPolicy`.
 
 import { auctionReducer, initAuctionState, passedPlayersOf, type AuctionState } from '../components/auctionReducer'
 import { meldPointsByTeam } from '../components/gameFlowReducer'
 import { teammatesOf } from '../components/trickPlayReducer'
 import { type AuctionContext, chooseBid, chooseTrump } from '../engine/bidding'
 import { Card, type CopyId, RANKS, type Suit, SUITS } from '../engine/card'
+import { shouldConcede } from '../engine/evaluator'
 import { checkGameOutcome } from '../engine/game'
 import { isMisdealEligible } from '../engine/misdeal'
 import { PASS_COUNT, choosePassCards } from '../engine/passing'
 import { type Hands, playTrickTakingPhase, scoreRound, teamOf, type TeamId } from '../engine/round'
+import { SKILL_PARAMS } from '../engine/skills'
 import { PlayTracker, chooseFollowCard, chooseLeadCard } from '../engine/tracker'
 import type { PlayerIndex } from '../engine/trick'
 import type { SkillLevel } from '../persistence/options'
@@ -90,16 +95,20 @@ export function dealFromRng(rand: Rng): Hands {
 }
 
 /** Round-level behaviour for one side, aggregated across a run. Mirrors
- *  `ab_harness.SideStats` minus `conceded`, which cannot happen here. */
+ *  `ab_harness.SideStats`, `conceded` included since #123. A conceded contract
+ *  counts in `contracts` and in `set` — it is a contract that was taken and not
+ *  made, and rolling it into the set rate keeps "made %" answering the same
+ *  question it did before folding existed. */
 export interface SideStats {
   contracts: number
   made: number
   set: number
+  conceded: number
   bids: number[]
 }
 
 export function newSideStats(): SideStats {
-  return { contracts: 0, made: 0, set: 0, bids: [] }
+  return { contracts: 0, made: 0, set: 0, conceded: 0, bids: [] }
 }
 
 export interface GameResult {
@@ -208,8 +217,55 @@ export function playHeadlessGame(options: HeadlessGameOptions): GameResult {
     })
     state = auctionReducer(state, { type: 'CONFIRM_PASS_REVEAL' })
 
-    // -- Meld, trick play, round score -------------------------------------
+    // -- Meld, then the concede window --------------------------------------
     const meldPoints = meldPointsByTeam(state.hands, trumpSuit)
+    const bidWinnerTeam = teamOf(bidWinner)
+    const defendingTeam = (1 - bidWinnerTeam) as TeamId
+
+    // Asked of the bid winner only, once, after meld and before the first lead
+    // — `Round._concede_phase`'s window in Python and `canConcede`'s in
+    // `TrickPlayFlow`. The partner cannot concede a contract they did not take
+    // and the defenders have nothing to concede.
+    const conceded =
+      SKILL_PARAMS[seatSkills[bidWinner]].foldPolicy === 'model' &&
+      shouldConcede({
+        hand: state.hands[bidWinner],
+        trump: trumpSuit,
+        bid,
+        biddingMeld: meldPoints[bidWinnerTeam],
+        defendingMeld: meldPoints[defendingTeam],
+      })
+
+    if (conceded) {
+      // Same scoring as `gameFlowReducer`'s TRICK_COMPLETE concede branch: the
+      // bidding team forfeits its meld and takes -bid, the defenders keep their
+      // meld and score no trick points because no trick was played.
+      const roundScore = scoreRound({
+        meldPointsByTeam: { ...meldPoints, [bidWinnerTeam]: 0 } as Record<TeamId, number>,
+        trickPointsByTeam: { 0: 0, 1: 0 },
+        bidWinnerTeam,
+        bid,
+      })
+      if (stats !== undefined) {
+        const side = stats[bidWinnerTeam]
+        side.contracts++
+        side.bids.push(bid)
+        side.set++
+        side.conceded++
+      }
+
+      scoresByTeam[0] += roundScore[0]
+      scoresByTeam[1] += roundScore[1]
+
+      const winnerAfterConcede = checkGameOutcome(scoresByTeam, bidWinnerTeam)
+      if (winnerAfterConcede !== null) {
+        return { winner: winnerAfterConcede, scoresByTeam, rounds: round + 1 }
+      }
+      dealer = ((dealer + 1) % 4) as PlayerIndex
+      continue
+    }
+
+    // -- Trick play, round score --------------------------------------------
     const tracker = new PlayTracker()
     let cardsPlayed = 0
     const { trickPointsByTeam } = playTrickTakingPhase(
@@ -232,7 +288,6 @@ export function playHeadlessGame(options: HeadlessGameOptions): GameResult {
       },
     )
 
-    const bidWinnerTeam = teamOf(bidWinner)
     const roundScore = scoreRound({ meldPointsByTeam: meldPoints, trickPointsByTeam, bidWinnerTeam, bid })
     if (stats !== undefined) {
       const side = stats[bidWinnerTeam]

--- a/web/src/components/TrickPlayFlow.test.tsx
+++ b/web/src/components/TrickPlayFlow.test.tsx
@@ -4,13 +4,33 @@ import { Card, Deck, Suit } from '../engine/card'
 import type { Hands } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
+import { SKILL_PARAMS } from '../engine/skills'
 import { AI_PLAY_DELAY_MS, TrickPlayFlow } from './TrickPlayFlow'
 import type { TrickPlayResult } from './trickPlayTypes'
 
 const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'You', 1: 'West', 2: 'Partner', 3: 'East' }
 const SCORES = { 0: 0, 1: 0 }
 
+/**
+ * #123 wired an AI bid winner to concede before the first lead, which the
+ * card-legality tests below trip over: they deal *one card per seat* so every
+ * follow is forced, and the fold model — fitted on 12-card hands — correctly
+ * reads a 300 contract on a one-card hand with no meld as hopeless and throws
+ * it in before anything can be clicked.
+ *
+ * Those tests are about legal-move highlighting, not folding, so they pin the
+ * fold off rather than contriving meld to talk the model out of it. Save and
+ * restore of a `SKILL_PARAMS` entry is the same shape `abRun.installPolicies`
+ * uses; `DEFAULT_OPTIONS` puts both AI seats on `hard`, so that is the entry
+ * that matters here.
+ */
+const PRISTINE_HARD = SKILL_PARAMS.hard
+function disableAiFold() {
+  SKILL_PARAMS.hard = { ...PRISTINE_HARD, foldPolicy: 'never' }
+}
+
 afterEach(() => {
+  SKILL_PARAMS.hard = PRISTINE_HARD
   cleanup()
   vi.useRealTimers()
 })
@@ -18,6 +38,7 @@ afterEach(() => {
 describe('TrickPlayFlow (component)', () => {
   it('highlights only legal cards for the human, forcing a follow of the lead suit', () => {
     vi.useFakeTimers()
+    disableAiFold()
 
     const humanHand = [new Card(Suit.Hearts, 'A', 1), new Card(Suit.Spades, '9', 1)]
     const hands: Hands = [
@@ -71,6 +92,7 @@ describe('TrickPlayFlow (component)', () => {
 
   it('never lets the human play an illegal card by clicking a disabled button', () => {
     vi.useFakeTimers()
+    disableAiFold()
 
     const humanHand = [new Card(Suit.Hearts, 'A', 1), new Card(Suit.Spades, '9', 1)]
     const hands: Hands = [
@@ -160,5 +182,102 @@ describe('TrickPlayFlow (component)', () => {
     // +10 last-trick bonus — the full round's points always sum to this,
     // regardless of who won which trick.
     expect(result.trickPointsByTeam[0] + result.trickPointsByTeam[1]).toBe(250)
+  })
+
+  // -- AI concede (#123) ----------------------------------------------------
+
+  it('concedes an arithmetically dead contract for an AI bid winner before any card is played', () => {
+    vi.useFakeTimers()
+
+    const hands = new Deck().deal()
+    const onComplete = vi.fn()
+
+    render(
+      <TrickPlayFlow
+        hands={hands}
+        trumpSuit={Suit.Hearts}
+        bidWinner={1}
+        bid={500}
+        // 500 needed against 0 meld — more than the 250 trick points that
+        // exist, so the contract cannot be made however the cards fall.
+        meldPointsByTeam={{ 0: 0, 1: 0 }}
+        seatNames={SEAT_NAMES}
+        humanPlayer={0}
+        scoresByTeam={SCORES}
+        dealer={0}
+        onComplete={onComplete}
+        options={{ ...DEFAULT_OPTIONS, hideTrickLog: false } as GameOptions}
+      />,
+    )
+
+    // No timer advance: the fold is decided in the same commit as the mount,
+    // before the AI-play delay can elapse. That ordering is the point — a
+    // conceded hand must never see a card hit the table first.
+    expect(onComplete).toHaveBeenCalledOnce()
+    const result = onComplete.mock.calls[0][0] as TrickPlayResult
+    expect(result.conceded).toBe(true)
+    expect(result.trickWinners).toHaveLength(0)
+  })
+
+  it('plays on when the contract is live, rather than conceding everything', () => {
+    vi.useFakeTimers()
+
+    const hands = new Deck().deal()
+    const onComplete = vi.fn()
+
+    render(
+      <TrickPlayFlow
+        hands={hands}
+        trumpSuit={Suit.Hearts}
+        bidWinner={1}
+        bid={300}
+        // Meld already covers the bid, so the contract is won before a card is
+        // led and there is nothing to concede.
+        meldPointsByTeam={{ 0: 0, 1: 320 }}
+        seatNames={SEAT_NAMES}
+        humanPlayer={0}
+        scoresByTeam={SCORES}
+        dealer={0}
+        onComplete={onComplete}
+        options={{ ...DEFAULT_OPTIONS, hideTrickLog: false } as GameOptions}
+      />,
+    )
+
+    expect(onComplete).not.toHaveBeenCalled()
+    // West (the bid winner) leads instead of throwing the hand in. Checking the
+    // log rather than the human's playable cards because the human does not act
+    // until the lead has gone round to them.
+    act(() => vi.advanceTimersByTime(AI_PLAY_DELAY_MS))
+    expect(screen.getByText(/^West led the /)).not.toBeNull()
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('never concedes on the human\'s behalf when the human won the bid', () => {
+    vi.useFakeTimers()
+
+    const hands = new Deck().deal()
+    const onComplete = vi.fn()
+
+    render(
+      <TrickPlayFlow
+        hands={hands}
+        trumpSuit={Suit.Hearts}
+        bidWinner={0}
+        bid={500}
+        // The same hopeless contract as the concede test above. The human owns
+        // this decision — the fold button (#83) is offered, never taken for
+        // them.
+        meldPointsByTeam={{ 0: 0, 1: 0 }}
+        seatNames={SEAT_NAMES}
+        humanPlayer={0}
+        scoresByTeam={SCORES}
+        dealer={0}
+        onComplete={onComplete}
+        options={{ ...DEFAULT_OPTIONS, hideTrickLog: false } as GameOptions}
+      />,
+    )
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Concede hand' })).not.toBeNull()
   })
 })

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type { Card, Suit } from '../engine/card'
+import { shouldConcede } from '../engine/evaluator'
 import { partnerOf, teamOf, type Hands, type TeamId } from '../engine/round'
+import { SKILL_PARAMS } from '../engine/skills'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from '../engine/tracker'
 import type { PlayerIndex } from '../engine/trick'
 import type { SkillLevel } from '../persistence/options'
@@ -127,6 +129,43 @@ export function TrickPlayFlow({
   const trackerRef = useRef(new PlayTracker())
   const completedRef = useRef(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
+
+  // Concede/fold for an AI bid winner (#123), in the same window the human's
+  // fold button gets: after meld, before the first card of the round.
+  //
+  // Declared *before* the AI-play effect on purpose. Both run in the same
+  // commit, so this one dispatches CONCEDE while that one is still only
+  // scheduling a timer; the resulting re-render lands on `phase: 'complete'`,
+  // whose cleanup clears that timer before it can fire. Ordering them the other
+  // way would let a card hit the table first on a hand the AI meant to throw in.
+  //
+  // The `cardsPlayed === 0` guard is what makes this safe to re-run: the effect
+  // re-fires on every state change, and on a #54 resume `initialState` can drop
+  // us into a contract already under way, where the concede window has closed.
+  const foldAskedRef = useRef(false)
+  const cardsPlayed = state.log.filter((e) => e.kind === 'card-play').length
+  useEffect(() => {
+    if (foldAskedRef.current) return
+    if (state.phase !== 'playing' || cardsPlayed > 0) return
+    if (bidWinner === humanPlayer) return
+    foldAskedRef.current = true
+
+    const skill = skillForPlayer(bidWinner, humanPlayer, options)
+    if (SKILL_PARAMS[skill].foldPolicy !== 'model') return
+
+    const biddingTeam = teamOf(bidWinner)
+    if (
+      shouldConcede({
+        hand: state.hands[bidWinner],
+        trump: state.trumpSuit,
+        bid,
+        biddingMeld: meldPointsByTeam[biddingTeam],
+        defendingMeld: meldPointsByTeam[(1 - biddingTeam) as TeamId],
+      })
+    ) {
+      dispatch({ type: 'CONCEDE' })
+    }
+  }, [state, cardsPlayed, bidWinner, humanPlayer, options, bid, meldPointsByTeam])
 
   // Resolve AI turns automatically, after a brief delay so the play reads
   // as a real decision rather than an instant jump. Runs after every state

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -22,9 +22,36 @@ export type HandValuation = 'meld_only' | 'base_bid'
  */
 export type BidPolicy = 'static' | 'distilled'
 
+/**
+ * Whether an AI bid winner is asked to concede (#123).
+ *
+ *   `'never'`  play every contract out, whatever the arithmetic says. What
+ *              every level did before #123, and what `Player.decide_fold`
+ *              still does in Python for skill 1-3.
+ *   `'model'`  ask `shouldConcede` (`evaluator.ts`) in the same window the
+ *              human's fold button gets: after meld, before the first lead.
+ *
+ * Unlike `bidPolicy` this is **deliberately uniform across all five levels**,
+ * and the type exists to keep the alternative measurable rather than to give
+ * the dial another notch. The reason is that folding is not a matter of taste:
+ * conceding and being set cost the bidding team exactly the same (`-bid`, meld
+ * forfeited either way), and the only thing a fold changes is that the
+ * defenders are denied their trick points. So a fold can never beat making the
+ * contract and can never lose to being set - it is strictly dominant over a
+ * set. A weak tier declining a free improvement would not read as weak play,
+ * it would read as a bug.
+ *
+ * `'never'` is retained because `abRun.ts` needs two levels differing in
+ * exactly one field to measure this, and because the day someone wants a tier
+ * that folds *badly* the honest way to build it is a third policy that folds
+ * on the wrong hands - not a tier that cannot fold at all.
+ */
+export type FoldPolicy = 'never' | 'model'
+
 export interface SkillParams {
   readonly handValuation: HandValuation
   readonly bidPolicy: BidPolicy
+  readonly foldPolicy: FoldPolicy
 }
 
 /**
@@ -87,13 +114,19 @@ export interface SkillParams {
  *   is the measurably stronger one, so leaving the top tiers on the weaker rule
  *   would rank them below `hard`. When real rollouts land they replace this on
  *   4-5; until then it is the floor, not the ceiling.
+ *
+ * `foldPolicy` reads `'model'` on every row on purpose (#123) and is not a
+ * second dial — see `FoldPolicy` for why folding is shared competence rather
+ * than a difficulty setting. The dial this table exists to express is
+ * `bidPolicy`; a level's strength is meant to come from what it is willing to
+ * bid, not from whether it is allowed to notice a dead contract.
  */
 export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
-  easy: { handValuation: 'meld_only', bidPolicy: 'static' },
-  medium: { handValuation: 'base_bid', bidPolicy: 'static' },
-  hard: { handValuation: 'base_bid', bidPolicy: 'distilled' },
-  proficient: { handValuation: 'base_bid', bidPolicy: 'distilled' },
-  expert: { handValuation: 'base_bid', bidPolicy: 'distilled' },
+  easy: { handValuation: 'meld_only', bidPolicy: 'static', foldPolicy: 'model' },
+  medium: { handValuation: 'base_bid', bidPolicy: 'static', foldPolicy: 'model' },
+  hard: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
+  proficient: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
+  expert: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
 }
 
 /** Flat trick-point estimate for meld-only bidding (skill 1), matching


### PR DESCRIPTION
Closes #123.

`evaluator.ts`'s `shouldConcede` had **no call site**. The only concede path in
the product was the human's fold button (#83), so no AI seat ever threw in a
hand however dead the contract was. This asks it of an AI bid winner in the same
window the human gets: after meld, before the first lead.

## The design point

`foldPolicy` joins `SkillParams` and reads `'model'` on **all five rows**. It is
deliberately *not* a second dial, per the direction Paul set: bidding is where
the levels differ, folding and card play are shared competence.

The reason folding in particular belongs to shared competence is that it is not
a matter of taste. Conceding and being set cost the bidding team **exactly the
same** - `-bid`, meld forfeited either way. The only thing a fold changes is
that the defenders are denied their trick points. So a fold can never beat
making the contract and can never lose to being set: it is strictly dominant
over a set. A weak tier declining a free improvement would read as a bug, not as
weak play.

`'never'` is retained only because measuring this needs two levels differing in
exactly one field. If a tier that folds *badly* is ever wanted, the honest build
is a third policy that folds on the wrong hands - not a tier forbidden to fold.

## Measurement

500 paired deals (1000 games), identical distilled bidders, one side allowed to
concede. New `cli.ts fold` command; `installPolicies` generalised to take the
pair under test.

| seed | pairs swept (fold/no-fold/split) | p | margin per deal | 95% CI |
|---|---|---|---|---|
| 1 | 22 / 3 / 475 | 0.0002 | **+60** | +45 to +77 |
| 2 | 22 / 3 / 475 | 0.0002 | **+52** | +36 to +68 |
| 3 | 35 / 1 / 464 | <0.0001 | **+71** | +55 to +88 |

Make and set rates come out **identical on both sides** (58.8% / 41.2%) and
average bid is identical at 325 - folding converts a set into a cheaper set
rather than changing which contracts get taken, which is exactly the claimed
mechanism and a good sign the two sides differ in nothing else. Concede rate
lands at 21.4%, against 25-27% for the Python rollout tiers.

Harness self-test passes: one policy against itself splits every pair with a
paired margin of exactly zero, and folds symmetrically at 19.2% on both sides.

## Re-checking #115 under the new behaviour

#115's +227 was measured in a world with no folding at all, so it was worth
re-running now that both sides can fold. Distilled is **+234 per deal** (CI +193
to +278, p < 1e-4) - unchanged. Folding does not rescue the static bidder; it
folds *more* (25.5% vs 19.4%), which is what taking worse contracts looks like.

## Cost, and a correction to the issue

**+1.43 kB raw / +560 B gzipped** (255.11 -> 256.54 kB).

#123 claimed the model's bytes were already being paid for and only the call
site was missing. That was partly wrong: with no callers the bundler could drop
part of it, so enabling it is not free. It is still small - the decision is one
logistic evaluation per contract, against the 700 ms `AI_PLAY_DELAY_MS` the
round already waits.

## Notes for review

- `headlessGame.ts` gains the same concede window. Its docstring used to record
  that conceding was excluded *because the product did not ship it*; that
  reasoning inverts here, so leaving it out would now measure a different game
  from the one the app plays.
- The fold effect is declared **before** the AI-play effect on purpose. Both run
  in the same commit; this one dispatches CONCEDE while that one is still only
  scheduling a timer, and the re-render's cleanup clears it. The other order
  would let a card hit the table on a hand the AI meant to throw in. There is a
  test that asserts the fold lands with no timer advance at all.
- `SideStats.conceded` counts as a subset of `set`, not a third outcome, so
  "made %" keeps answering the same question it did before folding existed.
- Two `TrickPlayFlow` card-legality tests deal one card per seat - a shape the
  fold model was never fitted on and correctly reads as hopeless. They pin the
  fold off rather than contrive meld to talk the model out of it.
- Adds `profile_skills.py`, the per-skill behavioural harness behind these
  numbers: bid rate, make rate, meld, and fold quality as an AUC over how hard
  the folded contracts actually were.

## Still open

**Python skills 1-3 still never fold** (`fold_samples: 0`). This PR is the PWA
half. Closing that gap there costs real rollout time per contract, so it is left
for a separate decision rather than folded in here.

## Deploy

Merging deploys. Every AI seat on every difficulty starts conceding dead
contracts the moment this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)