### PR TITLE
docs: bring ROADMAP.md current with what actually shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,9 +5,19 @@ or priorities shift. Other team-lead agents should treat this as the
 top-level source of truth for sequencing; individual specs (rules, AI
 strategy) live in their own docs and are linked from here.
 
-**Mission shift (2026-07-10):** short runway — getting an installable
-PWA in front of players is now the priority, ahead of Expert-tier AI
-and Python-side hardening. Everything below is reordered around that.
+**Current focus (2026-08-01): port fidelity.** The game is built, live,
+and played by a distilled AI. The open work is proving the TypeScript
+engine still agrees with the Python reference it was ported from — the
+parity net (Phase 1.6, #125) and the constant-by-constant audit (#126).
+That is the whole near-term queue; Phases 2 and 4 are the backlog behind
+it.
+
+**Mission shift (2026-07-10) — satisfied.** The short-runway call was to
+get an installable PWA in front of players ahead of Expert-tier AI and
+Python-side hardening. It worked, and then some: the PWA was playable
+within two days, and the AI work happened anyway (Phase 3) rather than
+waiting behind it. Kept here because it explains why the phases are
+ordered the way they are, not because it is still a live constraint.
 
 ## Phase 0 — Rules engine + Proficient AI (Python) — done
 
@@ -18,90 +28,228 @@ and Python-side hardening. Everything below is reordered around that.
   bidding, category-split passing strategy, card-counting trick play.
 - Interactive human-play layer: chat-resumable (`human_play.py`) and
   standalone terminal (`play_local.py`).
-- This is now a **frozen reference implementation** for the JS port,
-  not an active development target — see the open question at the
-  bottom on its long-term role.
+- Python's role is **settled, and it is not "frozen"** — see
+  [Settled questions](#settled-questions). It is the reference
+  implementation the TS port is checked against, and the platform all
+  the AI research runs on. Every result in Phase 3 was produced here.
 
-## Phase 1 — PWA critical path (current focus)
+## Phase 1 — PWA critical path — shipped (1.6 open)
 
 Stack: **React + TypeScript + Vite + Tailwind CSS**, PWA via
 `vite-plugin-pwa` (manifest + service worker), hosted on GitHub Pages
 via GitHub Actions. Chosen for a modern, polished UI without heavy
 build overhead, and first-class PWA tooling on top of Vite.
 
-1. **Decisions** (unblock the port)
-   - Opening-bid mismatch resolved: engine value (300 min /
-     250 forced) is canonical; `pinochle_rules.md` updated to match.
-   - Stack locked (above).
-2. **Rules engine port to TS** — the critical-path item; no JS/TS
-   exists yet.
-   - Core data model, deal, meld scoring
-   - Bidding + 3-card pass
-   - Trick-taking + round/game scoring
-3. **Port Proficient-tier AI to TS** — needed so a solo player has
-   3 AI opponents/partner to play against; this is the actual product.
-4. **Minimal playable UI** — table layout, card rendering, bid/pass/
-   trick-play interaction flows, score/win-loss screens. Scoped to
-   *playable*, not fully polished — see Phase 4.
-5. **PWA shell** — manifest, icons, service worker (offline shell
-   caching), GitHub Pages deploy pipeline, verify "Add to Home Screen"
-   on iOS Safari end-to-end.
-6. **Correctness net** — seeded-scenario parity checks between the
-   Python and TS engines (same deal in → same meld scores / trick
-   winners / final score out). Lighter than a full test suite; exists
-   to catch port bugs, not to be exhaustive.
+Live at <https://slippedup42.github.io/pinochle/>. Built 2026-07-10/11;
+actually reachable at that URL since 2026-07-31, when GitHub Pages was
+enabled for the repo — the deploy workflow had been green-lighting
+builds into a Pages site that did not exist, and every push-triggered
+run failed at "Set up Pages" until someone looked. Worth remembering:
+a merged PR is not a shipped change until `gh run list` says so.
 
-## Phase 2 — Post-MVP hardening (deferred until the PWA ships)
+1. **Decisions** — done. Opening-bid mismatch resolved (engine value,
+   300 min / 250 forced, is canonical; `pinochle_rules.md` updated to
+   match). Stack locked (above).
+2. **Rules engine port to TS** — done. `web/src/engine/` holds the core
+   data model, deal, meld scoring, bidding, the 3-card pass,
+   trick-taking, and round/game scoring, one file per concern with
+   matching `*.test.ts`.
+3. **Proficient-tier AI in TS** — done, and since superseded at `hard`
+   and above by the distilled evaluator (Phase 3).
+4. **Minimal playable UI** — done: table layout, card rendering,
+   bid/pass/trick-play flows, round-summary and win/loss screens, AI
+   skill selection, auction history, fold button. Scoped to *playable*;
+   the fuller treatment is Phase 4.
+5. **PWA shell** — done: manifest, icons, service worker (Workbox
+   `generateSW` app-shell precache), GitHub Pages deploy pipeline.
+   Icons are programmatic placeholders (#129).
+6. **Correctness net** — **open, tracked as #125.** Seeded-scenario
+   parity between the Python and TS rules engines: pin the deal *and*
+   the decisions in a committed fixture, replay the recorded play
+   through the TS engine, assert agreement on meld scores, every trick
+   winner, and the final round score. Note the two constraints recorded
+   on the issue — the PRNGs differ, so do not seed both sides and
+   compare; and AI *decisions* are meant to diverge (Python rolls out,
+   TS `hard`+ runs the distilled evaluator), so only the rules engine is
+   under test. #118 is the bug class this exists to catch: two ported
+   bidding constants had silently drifted from the reference and changed
+   which suit the browser names as trump. It was found by hand.
 
-Everything here is real and tracked, just not on the critical path:
+   Alongside it, #126 audits every ported constant and formula in
+   `web/src/engine/` against the Python reference — the one-time sweep
+   for drift that already happened, where #125 is the standing net.
 
-- Full automated `pytest` suite for the Python engine.
-- Tournament-simulation harness (win-rate validation for AI strategy
-  changes).
-- Split `pinochle_engine.py` into rules-engine and AI-strategy modules
-  — low value while the Python engine is a frozen reference rather
-  than something actively extended.
-- Engineering polish: dedupe win-condition logic (`Game.play` vs.
-  `play_local.py`), explicit sync note between `Round` and
-  `InteractiveRound`.
-- Design doc fixes: document Double Run meld, document the misdeal
-  reshuffle house rule (and wire it into AI-only games), refresh
-  `pinochle_rules.md`'s stale Implementation Notes, write up AI
-  strategy open question 6.
+## Phase 2 — Post-MVP hardening
 
-## Phase 3 — Expert-tier AI
+Most of this is now done. What shipped:
 
-- Implement Monte Carlo determinization + rollout per
-  `pinochle_expert_ai_strategy.md`: bid-time EV, return-pass knapsack
-  triage, trick-play lookahead, auto-SET pruning.
-- Validate as a separate strategy module (`ExpertPlayer`) so Proficient
-  stays the control group; win-rate tournament sim (Expert vs.
-  Proficient) is both the acceptance test and the ongoing regression
-  check.
-- Deliberately behind the PWA MVP and Phase 2 hardening — this was
-  the previous roadmap's near-term focus; it no longer is.
+- **Full `pytest` suite** — 269 tests, `python -m pytest -q`, ~3 min.
+- **Tournament-simulation harness** — `tournament_sim.py` (+
+  `test_tournament_sim.py`), issue #64: batch-runs N full games between
+  two team configs, alternating seats to cancel positional bias.
+  Superseded for AI-change validation by the paired A/B harness
+  (`ab_harness.py`, #105), which controls for the deal as well.
+- **Double Run meld documented** — `pinochle_rules.md:79`, including
+  that it replaces the single Run rather than doubling it.
+- **Misdeal reshuffle house rule documented** — `pinochle_rules.md:28`.
+- **`pinochle_rules.md`'s Implementation Notes refreshed** — #128.
+- **AI strategy open question 6 written up** — and in fact all of
+  `pinochle_expert_ai_strategy.md` Section 9 is resolved, each with a
+  pointer to the child issue of #57 that resolved it.
+
+What is still open:
+
+- Split `pinochle_engine.py` (~2,900 lines) into rules-engine and
+  AI-strategy modules. This got *more* valuable, not less: the old
+  reason to skip it was that Python was a frozen reference, and it
+  isn't. The rollout, win-probability, dataset, fitting, and export
+  layers already live in their own modules; the engine file is the
+  remaining lump.
+- Dedupe win-condition logic: `Game.play` (`pinochle_engine.py:2857`)
+  and `play_local.py:130` each implement the bust/over check
+  independently. They share the constants, not the logic.
+- An explicit "changes to `Round` must be mirrored here" note on
+  `InteractiveRound` — its docstring explains *how* it differs from
+  `Round`, not that it has to be kept in step with it.
+
+Deliberately **not** doing:
+
+- Wiring the misdeal reshuffle into Python AI-only games. The house
+  rule is honoured everywhere a player meets it — `web/src/engine/`
+  implements the eligibility check and the redeal loop, and the TS
+  headless harness redeals too. The gap is Python-side only:
+  `Round.run()` goes straight from deal to bidding, and
+  `InteractiveRound._check_misdeal` is the sole implementation. Closing
+  it would invalidate every historical Python tuning baseline for a
+  rule the shipped game already follows. Frozen on purpose; see #128.
+
+## Phase 3 — Measured-EV AI, and distilling it into the browser — done
+
+This is what the original "Phase 3 — Expert-tier AI" turned into, and
+it did not wait behind Phase 2 the way the previous roadmap said it
+would. `pinochle_expert_ai_strategy.md`'s core architecture —
+determinization + rollout — is implemented and shipped; the strategy
+doc is a spec that has been built, not a plan.
+
+**The reframe (epic #106):** a threshold is a human's compressed guess
+about a distribution; a rollout measures that distribution directly.
+Fold is the cleanest case, because one side is exact —
+`EV(fold) = -bid`, against the average scored outcome of playing on —
+so nothing in the decision is a tuned constant.
+
+Python side, `pinochle_rollout.py` + `win_probability.py`:
+
+- Monte Carlo determinization + rollout, bid-time EV, return-pass
+  triage, and the exact auto-SET guard (`#57`, issues #59–#65).
+- **#105** — paired A/B harness (`ab_harness.py`): identical deals,
+  seats mirrored, significance over pairs, split pairs discarded, an
+  interval on score margin rather than games-won alone. Nothing else
+  in this phase could have been shown to be an improvement without it.
+- **#100** — fold by expected value rather than a non-loser threshold.
+- **#101** — determinization constrained to the observed auction.
+  Shipped **disabled**: no measurable difference. Recording null
+  results as null was the right call and is the local precedent.
+- **#102** — rollout objective switchable to P(win the game) rather
+  than points, via a 20×20 score-bucket table tabulated from self-play
+  (`win_probability.py`).
+- **#103** — `EV(pass)` modelled as a real rollout instead of a flat
+  zero.
+
+Browser side, epic **#104** (#112 → #115), strictly sequential:
+
+- Full rollouts cannot run on a phone — 150 samples × a 12-trick
+  playout × each candidate bid × 4 suits, inside a React render loop.
+  So: do the expensive thinking offline and ship the conclusion.
+  Generate labelled rollout data (`generate_rollout_dataset.py`), fit a
+  small model to it (`fit_evaluator.py`), export it as typed TS
+  (`export_evaluator.py` → `evaluatorModel.ts`), and have `bidding.ts`
+  consult that instead of `OPENER_THRESHOLD = 320` and friends.
+- **#115** measured it and switched it on for `hard`/`proficient`/
+  `expert`: **+227 score margin per deal** (95% CI +198 to +257,
+  p < 1e-4) over 1000 paired deals, at **+872 B gzipped** and a p95 of
+  495 µs per decision in mobile Chrome — against the 600 ms the auction
+  already waits before each AI bid. The mechanism is that
+  `DEFENSIVE_PUSH_FLOOR = 200` buys a great many cheap contracts the
+  model declines: a third fewer contracts taken, 63.7% made against
+  54.6%.
+- `easy` and `medium` keep the thresholds on purpose — the evaluator
+  distils *skill 5*, so wiring it into `easy` would delete the tier
+  rather than calibrate it.
+- **#95** ("AI underbids, avg 307 vs the 320 floor") was resolved here
+  rather than fixed: under a measured-EV AI, average bid is an output,
+  not a target. It was closed against games won.
+
+**#123** — the fold model wired at **all five** skill levels. Bidding
+is the skill dial; folding is shared competence, because conceding and
+being set cost the bidding team exactly the same (`-bid`, meld
+forfeited) and a fold only denies the defenders their trick points — it
+is strictly dominant over a set, so no tier has a reason to decline it.
+This deliberately reverses `pinochle_engine.py:1970`'s rule that the
+static-vs-rollout switch moves together across all decision points.
+
+**Measurement infrastructure that came with it** — `web/src/ab/`:
+`headlessGame.ts` plays complete games with the same reducers and AI
+entry points the UI calls, minus React and the delays; `abRun.ts` pairs
+them the way `ab_harness.py` does; `stats.ts` is a direct port of its
+three statistics; `bench/index.html` is the browser side of the latency
+measurement. None of it reaches the bundle. Run `selftest` before
+believing `ab`: one policy against itself must find *exactly* nothing,
+and `ab.test.ts` asserts that.
+
+What is left of the Expert tier:
+
+- Real rollouts in the browser for skills 4–5, via a Web Worker. #104's
+  original mapping assumed the top tiers would have them; in the
+  browser they do not, so the distilled evaluator is currently their
+  floor rather than their ceiling.
+- The evaluator only governs the opening decision and the defensive
+  push. The ordinary raise ladder and the 330/340 constants in
+  `chooseBid` are untouched, and the two policies differ on 6.5% of
+  real auction positions — that is the ceiling on what any of this can
+  be credited with.
+- Every seat in every A/B is an AI. The results show the policy is
+  stronger, **not** that it is a better partner for a human. Measuring
+  that needs a different harness.
 
 ## Phase 4 — UI/UX polish
 
-- Once the MVP UI (Phase 1.4) is proven playable, invest in the fuller
-  "modern and pretty" treatment: table layout refinement, animations,
+- The MVP UI is proven playable, so the fuller "modern and pretty"
+  treatment is now unblocked: table layout refinement, animations,
   responsive/mobile-first interaction details. Not yet scoped in
   detail.
+- **#129** — the PWA ships programmatic placeholder icons (solid
+  colour). Real art needs to keep the same filenames and sizes that
+  `vite.config.ts` references. Blocked on a human, not an agent.
 
 ## Tooling & process (parallel track, not phase-gated)
 
 See [TEAM.md](TEAM.md) for the full roster, label conventions, and
 workflow — team-lead agents (architect, design, engineering, QA), the
-`/standup` and `/work-queue` commands, and epic lifecycle rules are all
-live.
+`/standup`, `/work-queue`, and `/human-queue` commands, and epic
+lifecycle rules are all live.
 
-- Coding standards, design specs, dev specs — owned by the relevant
-  lead per `TEAM.md`; locations TBD as they're written.
+- [CODING_STANDARDS.md](CODING_STANDARDS.md) covers naming, module
+  layout, and docstring style. Design and dev specs beyond that are
+  still written per-issue rather than as standing documents.
+
+## Settled questions
+
+- **Python vs TypeScript.** Resolved by practice, not by decree:
+  **TypeScript is what ships; Python is the reference implementation
+  and the AI-research and measurement harness.** Both are active. The
+  earlier framing — Python as a frozen reference that Phase 2/3 might
+  one day revisit — is wrong in both halves: Phase 3 ran entirely in
+  Python (rollouts, the win-probability table, dataset generation,
+  model fitting), and nothing about that is winding down. What crosses
+  the boundary is an *artifact*, not a port: `export_evaluator.py`
+  generates `evaluatorModel.ts` and a parity fixture, and `--check`
+  fails the Python suite if the committed TS has drifted. Expensive
+  thinking in Python, cheap conclusions in the browser.
 
 ## Open questions
 
-- Python-vs-JS engine: the mission shift answers this for the near
-  term — Python is the frozen reference implementation while JS
-  becomes the primary, shipped engine. Whether Python stays useful
-  long-term as an AI-research/tournament-simulation harness (once
-  Phase 2/3 revisit it) is still open.
+- Do skills 4–5 eventually get real rollouts in the browser (Web
+  Worker), or does the distilled evaluator stay the top tier? Cost is
+  the whole question and it has not been measured.
+- Is a stronger AI a better *opponent and partner* for a human? Every
+  measurement so far is AI-vs-AI, which cannot answer it.


### PR DESCRIPTION
`ROADMAP.md` had not been touched since before the PWA shipped, and was wrong in
both directions - it listed finished work as pending and pointed the reader at a
phase that was done. Every claim below was checked against the repo rather than
taken from the issue.

## Verified before changing anything

| Claim | Verdict |
|---|---|
| PWA live at slippedup42.github.io/pinochle | Live. Only the 2026-07-31 `workflow_dispatch` run is green; every earlier push run failed at "Set up Pages" because Pages was not enabled yet. |
| Phase 1 items 1-5 shipped | Yes - `web/src/engine/` (port), the UI flows, `vite-plugin-pwa`, `deploy-pages.yml`. |
| Phase 1.6 still open | Yes, and it is #125. Kept, with #125's two design constraints summarized so nobody restarts it by seeding both engines. |
| `pytest` suite exists and passes | 269 passed in 194s. |
| `tournament_sim.py` exists | Yes, plus `test_tournament_sim.py` (#64). |
| Double Run documented | `pinochle_rules.md:79`. |
| Misdeal house rule documented | `pinochle_rules.md:28`. |
| Implementation Notes refreshed | Shipped in #128. |
| AI strategy open question 6 | Resolved in the spec - all of Section 9 is, in fact. |

Still genuinely open in Phase 2, so kept: splitting `pinochle_engine.py`
(~2,900 lines), the duplicated win-condition check (`pinochle_engine.py:2857`
vs `play_local.py:130`), and a keep-in-step note on `InteractiveRound`.

## What changed

**Phase 1** is "shipped (1.6 open)" rather than "current focus", with a note
that the app was only reachable from 2026-07-31 - a merged PR was not a shipped
change until `gh run list` said so.

**Phase 2** records its finished items as finished rather than deleting them
silently, and gains a "deliberately not doing" entry: the Python-side misdeal
gap is a considered freeze, not a backlog item. The rule is honoured everywhere
a player meets it (`web/src/engine/misdeal.ts` and the redeal loop); closing the
Python gap would invalidate every historical tuning baseline.

**Phase 3** was "Expert-tier AI, deliberately behind the PWA MVP", which is not
how it played out - it is now the phase that describes the work actually done:
epic #106's measured-EV reframe, #105's paired A/B harness, #100-#103 (including
#101 shipping *disabled* on a null result), epic #104's distillation
(#112-#115), the fold model at all five levels (#123), and the `src/ab/`
harness. The measured result is stated with its interval (+227 margin/deal, 95%
CI +198 to +257, +872 B gzipped, p95 495us in mobile Chrome) and with all three
bounds carried forward: no Web Worker rollouts for skills 4-5, only 6.5% of
auction positions affected, and every seat in every A/B an AI.

**Open questions** - the Python-vs-JS question is answered, in a new "Settled
questions" section: TypeScript ships, Python is the reference implementation and
the AI-research/measurement harness, and what crosses the boundary is a
generated artifact (`export_evaluator.py --check` fails the Python suite on
drift). The old "frozen reference" framing was wrong in both halves. Two
questions the work has *not* settled remain listed as open.

**Current focus** is now port fidelity - #125 and #126 - stated at the top.

## Scope

`ROADMAP.md` only. Three stale references outside it were found and left alone;
they are reported separately rather than fixed here.

Closes #127
