### PR TITLE
fix: audit every ported constant and formula against the Python reference (#126)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -69,6 +69,38 @@ of real auction positions, which is the ceiling on what the model can be
 credited with. And every seat in the harness is an AI, so this says the policy
 is stronger, not that it is a better partner for a human.
 
+### What #126 changed about those numbers
+
+The #126 audit found that `chooseBid` opened at 300 unconditionally from the
+first seat to speak, a rule the Python reference does not have (see
+`bidding.ts`). It applied to both sides of the #115 run, so the comparison was
+fair — but it meant neither policy was ever *asked* the opening question in a
+real auction, and the +227 above is the two rules judged on the defensive push
+and the raise ladder alone.
+
+Re-measured with the opening decision restored, on the same 1000 pairs:
+distilled swept 122 deals to static's 88 (790 split), p = 0.02, margin **+62
+per deal with a 95% CI of +41 to +82**. Same direction, a third of the size.
+Both sides now take fewer and better contracts (distilled 4439 at 70.8% made,
+static 5423 at 66.0%), which is what removing a rule that bought a cheap
+contract on every deal should do. `hard` and above keep `'distilled'`.
+
+The parity fix itself was A/B'd the same way, with the two ported formulas
+`legacy` on one side and `fixed` on the other, over 1000 pairs:
+
+    fixed swept 226, legacy 88 (686 split), p < 1e-4
+    margin +176 per deal, 95% CI +147 to +206
+    contracts 4998 vs 6080, made 65.1% vs 57.5%, avg bid 328 vs 315
+
+Split by fix, the bidding one carries all of it (+179, CI +150 to +209) and the
+`defenderLead` one is a null result (-3, CI -9 to +3, p = 0.85, 972 of 1000
+pairs split) — it ships as parity with the reference engine, not as a strength
+claim. The `parity` dial those runs needed is not in the tree: it was a
+temporary fourth field on `SkillParams` plus a `PARITY_AB_POLICIES` pair, added
+for the measurement in the shape `FOLD_AB_POLICIES` already uses and removed
+before the fix was committed, since a permanent switch for "play the port bug"
+is not a difficulty setting.
+
 `bench/index.html` is the browser side of the latency measurement, served by
 `npm run dev` at `/pinochle/bench/`. It is never an input to `vite build`, so it
 cannot reach a player or the PWA precache.

--- a/web/src/components/AuctionFlow.test.tsx
+++ b/web/src/components/AuctionFlow.test.tsx
@@ -278,7 +278,14 @@ describe('AuctionFlow (component)', () => {
     expect(result.hands[0].some((c) => c.suit === Suit.Hearts && c.rank === 'Q')).toBe(false)
   })
 
-  it('lets a weak-handed AI open as first bidder (partner has not yet had a turn)', () => {
+  // This case used to read "lets a weak-handed AI open as first bidder (partner
+  // has not yet had a turn)" and asserted seat 2 opening at 300 on a 3-card hand
+  // worth nothing. That is not a rule the reference engine has: it came from the
+  // `passesSoFar < 2 -> always open` branch aeb97b3 substituted for
+  // `Player.choose_bid`'s dealer-protection tier, which the #126 audit removed.
+  // The test was green throughout and documented the bug as intended behaviour —
+  // exactly the trap #118 told this audit to watch for.
+  it('passes the auction out to a forced bid when no hand justifies opening (#126)', () => {
     vi.useFakeTimers()
     const hands = buildTestHands()
     const onComplete = vi.fn()
@@ -294,44 +301,51 @@ describe('AuctionFlow (component)', () => {
       />,
     )
 
-    // Left of dealer (1) is seat 2 (Partner) — always opens as first bidder.
+    // Left of dealer (1) is seat 2 (Partner). Its ceiling is far under
+    // OPENER_THRESHOLD and its partner is not the dealer, so it passes.
     act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
-    // Bid amount visible in Scoreboard
-    expect(screen.getByText('300')).not.toBeNull()
-
-    // East (seat 3, opponent holds the bid) passes automatically — the human's turn now.
+    // East (seat 3) passes on the same reasoning — then it is the human's turn.
     act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
     expect(screen.getByRole('button', { name: 'Pass' })).not.toBeNull()
 
-    // Human (seat 0, teammate holds the bid) manually passes.
+    // The human passes too: 3 passes with nobody having bid sticks the dealer
+    // (seat 1) with FORCED_BID. Bidder (1) and partner (3) are both AI, so
+    // naming trump and the 3-card exchange need no human input.
     fireEvent.click(screen.getByRole('button', { name: 'Pass' }))
-
-    // West (seat 1, opponent holds the bid, weak hand) passes — 3 passes
-    // after a bid ends the auction. The AI bid winner (Partner) chooses trump
-    // automatically after a delay, then the AI selects pass cards.
     act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
     act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
-
-    // The human (Partner's partner) sees the pass selector to send cards to the bidder.
-    const passHeading = screen.getByRole('heading', { name: /Choose 3 cards to pass/ })
-    const passPanel = within(passHeading.closest('div') as HTMLElement)
-
-    fireEvent.click(passPanel.getByRole('img', { name: 'A of C' }))
-    fireEvent.click(passPanel.getByRole('img', { name: 'K of D' }))
-    fireEvent.click(passPanel.getByRole('img', { name: 'Q of H' }))
-    fireEvent.click(passPanel.getByRole('button', { name: 'Confirm pass' }))
-
-    // AI bidder passes 3 cards back to the human (simultaneous — already queued).
-    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
-
-    // Pass-reveal: human sees what the bidder sent back
-    expect(screen.getByText('Partner passed you 3 cards')).not.toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
 
     expect(onComplete).toHaveBeenCalledOnce()
     const result = onComplete.mock.calls[0][0] as AuctionResult
-    expect(result.bidWinner).toBe(2)
-    expect(result.bid).toBe(300)
-    expect(result.trumpSuit).toBe(Suit.Clubs)
+    expect(result.bidWinner).toBe(1)
+    expect(result.bid).toBe(FORCED_BID)
+  })
+
+  it('opens as first bidder on a hand that clears the opener threshold', () => {
+    vi.useFakeTimers()
+    const hands = buildTestHands()
+    // Seat 2 gets a full club Run plus a spare Royal Marriage: Base Bid 210,
+    // ceiling 340 at 0/0 — over OPENER_THRESHOLD (320).
+    hands[2] = [
+      ...(['A', '10', 'K', 'Q', 'J'] as const).map((r) => new Card(Suit.Clubs, r, 1)),
+      new Card(Suit.Clubs, 'K', 2),
+      new Card(Suit.Clubs, 'Q', 2),
+    ]
+    const onComplete = vi.fn()
+
+    render(
+      <AuctionFlow
+        initialHands={hands}
+        seatNames={SEAT_NAMES}
+        humanPlayer={0}
+        dealer={1}
+        scoresByTeam={SCORES}
+        onComplete={onComplete}
+      />,
+    )
+
+    // Left of dealer (1) is seat 2 (Partner), and this hand is worth a contract.
+    act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+    expect(screen.getByText('300')).not.toBeNull()
   })
 })

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -268,6 +268,28 @@ describe('chooseBid', () => {
       expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBe(OPENING_BID)
     })
 
+    it('does not open a hopeless first-bidder hand outside dealer-protection (#126)', () => {
+      // The first seat to speak (passesSoFar 0) used to open at OPENING_BID
+      // unconditionally, which made this the first thing that happened on every
+      // deal and left OPENER_THRESHOLD unreachable. `Player.choose_bid` has no
+      // such tier: with dealer-protection not applicable, the hand decides.
+      // Pinned to a 'static' level so the assertion is about the threshold rule
+      // rather than about the evaluator (#114/#115).
+      // Dealer-protection scores, but the dealer is an opponent, so the tier
+      // does not apply and a hopeless hand stays out of the auction.
+      const context = baseContext({ dealer: 1, scores: { 0: 850, 1: 400 } })
+      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
+      // Same seat, a hand whose ceiling clears the threshold: it opens.
+      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, baseContext({ dealer: 1 }), 'medium')).toBe(OPENING_BID)
+    })
+
+    it('dealer-protection does not fire when my score is too low or the opponent too close', () => {
+      const scoreTooLow = baseContext({ dealer: 2, scores: { 0: 840, 1: 400 } })
+      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, scoreTooLow, 'medium')).toBeNull()
+      const oppTooClose = baseContext({ dealer: 2, scores: { 0: 850, 1: 500 } })
+      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, oppTooClose, 'medium')).toBeNull()
+    })
+
     it('passes for a weak-handed 4th bidder when partner has already had a turn', () => {
       // 4th bidder (passesSoFar=3, dealer=player): partner has had a turn,
       // and the weak hand's ceiling (130) doesn't clear OPENER_THRESHOLD.

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -473,9 +473,15 @@ export function chooseBid(
       : staticVerdict
 
   if (!context.everBid) {
-    // If partner hasn't had their turn yet (first two bidders), always open
-    // to protect against the auction passing out cheaply.
-    if (context.passesSoFar < 2) {
+    // Dealer-protection, restored from `Player.choose_bid` by the #126 audit.
+    // This tier was dropped in aeb97b3 — the same hand-port slip that took
+    // NEAR_RUN_VALUE/NEAR_DOUBLE_PINOCHLE_VALUE to 60/60 (#118) — and replaced
+    // with "the first two seats always open at 300 regardless of hand". Since
+    // the auction starts with nobody having passed, that rule fired on the very
+    // first seat of every deal, so the opener threshold below was effectively
+    // unreachable and no opening decision was ever a hand judgement.
+    const partnerIsDealer = partner === context.dealer
+    if (partnerIsDealer && myScore >= 850 && oppScore < 500) {
       return OPENING_BID
     }
 

--- a/web/src/engine/tracker.test.ts
+++ b/web/src/engine/tracker.test.ts
@@ -132,6 +132,37 @@ describe('chooseLeadCard', () => {
     expect(led.suit).toBe(Suit.Spades)
     expect(led.rank).toBe('K')
   })
+
+  // -- Side dispatch, against `choose_lead_card`'s Python original (#126) ----
+
+  it('offense leads the trump Ace when the bidding team is on lead', () => {
+    const hand = [new Card(Suit.Spades, 'A', 1), new Card(Suit.Hearts, 'A', 1), new Card(Suit.Hearts, 'A', 2)]
+    const led = chooseLeadCard(hand, Suit.Spades, new PlayTracker(), false, 'hard', true)
+    expect(led.suit).toBe(Suit.Spades)
+    expect(led.rank).toBe('A')
+  })
+
+  it('a defender never leads trump while it holds anything else (#126)', () => {
+    // The unsecured trump Ace is the safe-card cascade's very first tier, so
+    // running the cascade over the whole hand hands it straight to the bidder's
+    // trump-draw plan. Python's `_defender_lead` restricts to non-trump before
+    // the cascade ever sees the hand, unconditionally — this used to fire only
+    // once every trump copy was accounted for.
+    const hand = [
+      new Card(Suit.Spades, 'A', 1), // trump, unsecured
+      new Card(Suit.Hearts, 'A', 1), // unsecured non-trump Ace
+      new Card(Suit.Clubs, '9', 1),
+    ]
+    const led = chooseLeadCard(hand, Suit.Spades, new PlayTracker(), false, 'hard', false)
+    expect(led.suit).not.toBe(Suit.Spades)
+    expect(led.suit).toBe(Suit.Hearts)
+  })
+
+  it('a defender leads trump only when the hand is nothing but trump', () => {
+    const hand = [new Card(Suit.Spades, 'A', 1), new Card(Suit.Spades, '9', 1)]
+    const led = chooseLeadCard(hand, Suit.Spades, new PlayTracker(), false, 'hard', false)
+    expect(led.suit).toBe(Suit.Spades)
+  })
 })
 
 describe('chooseFollowCard', () => {

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -13,6 +13,8 @@ import type { PlayerIndex, TrickPlay } from './trick'
 import { SKILL_PARAMS } from './skills'
 
 const POINT_RANKS = new Set(['A', '10', 'K'])
+/** 6 ranks x 2 copies, matching Python's `TOTAL_TRUMP_COPIES`. `chooseFollowCard`
+ *  calls trump "secure" once this many copies are accounted for. */
 const TOTAL_TRUMP_COPIES = 12
 
 /** Tracks cards played so far this round, across all 4 hands. */
@@ -71,30 +73,6 @@ function isUnsecuredAce(card: Card, hand: readonly Card[], tracker: PlayTracker)
 }
 
 /**
- * Choose what to lead when you have control. Priority:
- *   0. Bidder's first lead (#82) — must lead trump if any is held
- *   1. Unsecured trump Ace
- *   2. Other unsecured Aces (longest suit first)
- *   3. Safe cards, cascading top-down by rank (longest suit first within a rank)
- *   4. Junk lead (non-point, non-trump) to surrender - shortest suit first
- *   5. Non-point trump as a last resort before giving up a point card
- *
- * @param isBidderFirstLead - When true (bidder opening the first trick of the
- *   round), forces a trump lead if the player has any trump cards remaining.
- * @param skill - Skill level. Skill 1 (easy) uses simplified logic: prefers
- *   low non-trump non-count cards. Defaults to 'hard' (full Proficient cascade).
- */
-/** True when every trump card (all 12 copies across all 4 players) has
- * been accounted for — either in hand or already played — meaning no unseen
- * trump remains that could beat a non-trump lead. Ported from the Python
- * reference's `_trump_fully_accounted`. */
-function trumpFullyAccounted(hand: readonly Card[], trump: Suit, tracker: PlayTracker): boolean {
-  const playedTrump = RANKS.reduce((sum, r) => sum + tracker.playedCount(trump, r), 0)
-  const handTrump = suitLength(hand, trump)
-  return playedTrump + handTrump >= TOTAL_TRUMP_COPIES
-}
-
-/**
  * Offense trump lead: when the bidding team is leading, draw trump by
  * leading the trump Ace if held. Without a trump Ace, abandon the aggressive
  * trump-draw plan and lead non-trump conservatively.
@@ -108,16 +86,25 @@ function offenseTrumpLead(hand: readonly Card[], trump: Suit, tracker: PlayTrack
 }
 
 /**
- * Defending team lead: avoid leading trump whenever possible. If trump is
- * fully accounted for (no unseen trump remains), lead any non-trump card.
- * Otherwise prefer safe non-trump leads over trump leads.
+ * Defending team lead: never lead trump — it helps the bidder consolidate
+ * control — so run the safe-card cascade over the non-trump cards only.
+ * Trump is led only when the hand is entirely trump, i.e. there is no other
+ * legal lead at all.
+ *
+ * Corrected by the #126 audit. This used to avoid trump only when every trump
+ * copy was already accounted for, and otherwise ran the cascade over the whole
+ * hand — which leads an unsecured trump Ace, the cascade's very first tier. It
+ * had borrowed `_trump_fully_accounted` from Python's `choose_expert_lead_card`
+ * — a function belonging to the expert tier this engine does not port, where
+ * that predicate gates a different rule entirely (endgame sequencing: hold
+ * trump back so one is still in hand to win trick 12's +10 bonus). Python's
+ * `_defender_lead` has no such condition: with `rollout_evaluator=None`, the
+ * only mode reachable from the ported Proficient `choose_lead_card`, it
+ * restricts to non-trump unconditionally.
  */
 function defenderLead(hand: readonly Card[], trump: Suit, tracker: PlayTracker): Card {
   const nonTrump = hand.filter((c) => c.suit !== trump)
-  const trumpCards = hand.filter((c) => c.suit === trump)
-  if (trumpCards.length > 0 && nonTrump.length > 0 && trumpFullyAccounted(hand, trump, tracker)) {
-    return leadSafeCascade(nonTrump, trump, tracker)
-  }
+  if (nonTrump.length > 0) return leadSafeCascade(nonTrump, trump, tracker)
   return leadSafeCascade(hand, trump, tracker)
 }
 
@@ -166,6 +153,20 @@ function leadSafeCascade(hand: readonly Card[], trump: Suit, tracker: PlayTracke
   return hand.reduce((lowest, c) => (RANK_VALUE[c.rank] < RANK_VALUE[lowest.rank] ? c : lowest))
 }
 
+/**
+ * Choose what to lead when you have control. Priority, matching Python's
+ * `choose_lead_card`:
+ *   0. Bidder's first lead (#82) — must lead trump if any is held
+ *   1. When the side is known: the bidding team draws trump
+ *      (`offenseTrumpLead`), the defending team avoids it (`defenderLead`)
+ *   2. Otherwise the safe-card cascade (`leadSafeCascade`)
+ *
+ * @param isBidderFirstLead - When true (bidder opening the first trick of the
+ *   round), forces a trump lead if the player has any trump cards remaining.
+ * @param skill - Skill level. Skill 1 (easy) uses simplified logic: prefers
+ *   low non-trump non-count cards. Defaults to 'hard' (full Proficient cascade).
+ * @param isBiddingTeam - Which side this seat is on. Undefined = fallback.
+ */
 export function chooseLeadCard(
   hand: readonly Card[],
   trump: Suit,
@@ -297,7 +298,7 @@ export function chooseFollowCard(
     if (tracker !== undefined) {
       const playedTrump = RANKS.reduce((sum, r) => sum + tracker.playedCount(trump, r), 0)
       const handTrump = suitLength(hand, trump)
-      trumpSecure = playedTrump + handTrump >= 12
+      trumpSecure = playedTrump + handTrump >= TOTAL_TRUMP_COPIES
     }
     if (trumpSecure) return minByRank(legalMoves)
 


### PR DESCRIPTION
The sweep #118 left open. Every ported constant in `web/src/engine/` and every
formula that consumes one, diffed against `pinochle_engine.py`.

**64 constants and formula rules checked. Every numeric constant matches** —
the two #118 fixed included, so its hypothesis that "the port was done by hand
and there may be more" is right about the *port* but wrong about the constants
specifically. **Two formulas that consume them had drifted**, both fixed here,
and one of them came in on the very same commit (`aeb97b3`) that took
`NEAR_RUN_VALUE`/`NEAR_DOUBLE_PINOCHLE_VALUE` to 60/60.

## The two divergences

### 1. `chooseBid`'s opening tier — port bug, fixed

`aeb97b3` deleted `Player.choose_bid`'s dealer-protection tier and substituted
`passesSoFar < 2 -> always open at OPENING_BID`. Python has no such rule.

| | `pinochle_engine.py` | `bidding.ts` before |
|---|---|---|
| tier 1 | partner is dealer AND `my_score >= 850` AND `opp_score < 500` -> open | *(deleted)* |
| tier 1' | — | `passesSoFar < 2` -> open, whatever the hand is |
| tier 2 | `passes_so_far == 2` -> open cheap (score > 800 gates on the threshold) | same |
| tier 3 | `ceiling >= OPENER_THRESHOLD` -> open, else pass | same |

An auction begins with nobody having passed, so `passesSoFar < 2` fired on the
first seat to speak on *every* deal. The auction therefore always opened at 300,
`everBid` was true for everyone after that, and tiers 2 and 3 — the entire
opening judgement, `OPENER_THRESHOLD` included — were unreachable in a real
game. `#114`'s evaluator was never consulted about an opening bid either.

Three things say this was a slip rather than a decision: `chooseBid`'s own JSDoc
still listed dealer-protection as tier 1, `bidding.ts`'s module header still
advertised "dealer protection" as one of the auction rules it wraps, and
`AuctionContext.dealer` was left as a required field that nothing read. Issue
#76, the change this arrived in, is a display-only issue ("purely a display
gap").

### 2. `defenderLead` — port bug, fixed, null result

Ported with a condition Python's `_defender_lead` does not have:

```ts
// before
if (trumpCards.length > 0 && nonTrump.length > 0 && trumpFullyAccounted(...)) {
  return leadSafeCascade(nonTrump, trump, tracker)   // avoid trump
}
return leadSafeCascade(hand, trump, tracker)          // ...otherwise don't
```

The cascade's first tier is the unsecured trump Ace, so a defender holding one
led it — straight into the bidder's draw-trump plan, which is the one thing the
defender rule exists to prevent. Its own docstring said "avoid leading trump
whenever possible", which is what Python does and what the code did not.

`_trump_fully_accounted` belongs to `choose_expert_lead_card` in Python, an
expert-tier function this engine does not port, and there it gates a completely
different rule (endgame sequencing — hold trump back so one is still in hand to
win trick 12's +10 bonus). `TOTAL_TRUMP_COPIES` now names the `12` in
`chooseFollowCard`'s trump-secure check instead, which is where Python uses that
count.

### A green test that encoded the bug

`AuctionFlow.test.tsx`'s "lets a weak-handed AI open as first bidder (partner has
not yet had a turn)" asserted seat 2 opening at 300 on a 3-card hand worth
nothing, and passed for the whole time the rule was wrong. Exactly the failure
#118 told this audit to watch for, one level up from a constant. Replaced with a
pass-out-to-forced-bid case plus an opens-when-it-is-worth-it case. No `*.test.ts`
was found asserting a wrong *constant* — `bidding.test.ts`'s parity block already
pins 120/225/20/400 literally since #118, and nothing covered `defenderLead` at
all.

## Measurement

Per project policy. Harness `selftest` first: one policy against itself, 100
pairs, every pair split and every paired margin exactly zero.

The two fixes `legacy` on one side and `fixed` on the other, 1000 paired deals x
2 seat orientations, both sides `distilled`/`model` so only the ported formulas
differ:

```
fixed swept 226, legacy swept 88, split 686
95% CI on fixed's share of 314 decisive deals: 66.8% - 76.7%, p < 1e-4
margin +176 per deal, 95% CI +147 to +206
contracts 4998 vs 6080   made 65.1% vs 57.5%   avg bid 328 vs 315
```

A replicate at seed 7 agrees: +178, CI +148 to +207, 229-90.

Split by fix:

| fix | margin/deal | 95% CI | p | decisive pairs |
|---|---|---|---|---|
| `chooseBid` opener | **+179** | +150 to +209 | <1e-4 | 313 |
| `defenderLead` | -3 | -9 to +3 | 0.85 | 28 of 1000 |

So the bidding fix carries all of it, and `defenderLead` is a **null result** —
it ships as parity with the reference engine, not as a strength claim. It bites
on 2.8% of deals, which is about how often a defender is on lead holding an
unsecured trump Ace.

The mechanism is legible in the descriptives: the legacy side takes 1082 more
contracts and makes 7.6 points fewer of them per hundred. Buying a 300 contract
on every deal regardless of the cards is a losing habit.

### What this does to #115's numbers

The bug applied to both sides of #115's run, so that comparison was fair — but
neither policy was ever *asked* the opening question, so its +227 measured the
defensive push and the raise ladder alone. Re-run with the opening decision
restored, same 1000 pairs:

```
distilled swept 122, static 88, split 790, p = 0.02
margin +62 per deal, 95% CI +41 to +82
```

Same direction, a third of the size. `hard` and above keep `'distilled'`.
`web/README.md` records both.

The `parity` dial these runs needed is deliberately **not** in the diff: a
temporary fourth field on `SkillParams` plus a `PARITY_AB_POLICIES` pair, in the
shape `FOLD_AB_POLICIES` already uses, added for the measurement and removed
before the fix was committed. `FoldPolicy` keeps its losing option because
`'never'` is a legitimate tier behaviour; "play the port bug" is not a
difficulty setting.

## Full audit

Python is authoritative throughout (`CLAUDE.md`). "Matches" means the value and
the formula reading it both agree with the reference.

### `melds.ts` — `score_melds` and its constant block

| constant | Python | TS | verdict |
|---|---|---|---|
| `RUN_VALUE` | 150 | 150 | matches |
| `DOUBLE_RUN_VALUE` | 1500 | 1500 | matches |
| `ROYAL_MARRIAGE_VALUE` | 40 | 40 | matches |
| `COMMON_MARRIAGE_VALUE` | 20 | 20 | matches |
| `DIX_VALUE` | 10 | 10 | matches |
| `PINOCHLE_SINGLE_VALUE` | 40 | 40 | matches |
| `PINOCHLE_DOUBLE_VALUE` | 300 | 300 | matches |
| `AROUND_VALUES` | A 100 / K 80 / Q 60 / J 40 | same | matches |
| `AROUND_DOUBLE_MULTIPLIER` | 10 | 10 | matches |
| `RUN_RANKS` | `(A, 10, K, Q, J)` | same order | matches |
| double-replaces-single at `count == 2` | all 4 meld families | same | matches |
| common marriage sums non-trump suits then multiplies once | yes | yes | matches |

`extractMeldCards` is a display-only addition with no Python counterpart — not a
port, nothing to diff.

### `card.ts`

| constant | Python | TS | verdict |
|---|---|---|---|
| `RANKS` | `9, J, Q, K, 10, A` | same order | matches |
| `RANK_VALUE` | index into `RANKS` | same | matches |
| suit order | `S, D, C, H` (enum order) | `SUITS` same | matches — decides `bestBaseBid` ties |
| `GAME_WIN_SCORE` | 1000 | 1000 | matches |
| `GAME_LOSE_SCORE` | -1000 | -1000 | matches |
| `OPENING_BID` | 300 | 300 | matches |
| `FORCED_BID` | 250 | 250 | matches |
| deck | 48 cards, 2 copies, 12 per hand | same | matches |

### `bidding.ts` — the valuation layer, everything feeding `bestBaseBid`

| constant / rule | Python | TS | verdict |
|---|---|---|---|
| `NEAR_RUN_VALUE` | 120 | 120 | matches (fixed in #118) |
| `NEAR_DOUBLE_PINOCHLE_VALUE` | 225 | 225 | matches (fixed in #118) |
| `ACE_VALUE` | 20 | 20 | matches |
| `PARTNER_ESTIMATE_RANGE` | `(50, 100)` | `[50, 100]` | matches — unused on both sides |
| `MAX_BID_DEFAULT` | 400 | 400 | matches |
| `MAX_BID_MELD_THRESHOLD` | 300 | 300 | matches |
| `OPENER_THRESHOLD` | 320 | 320 | value matches; consuming formula **was a port bug** |
| `DEFENSIVE_PUSH_FLOOR` | 200 | 200 | matches |
| near-run trigger | `run_count == 0` and exactly 1 missing rank | same | matches |
| near-double-pinochle trigger | `total_pieces == 3` | same | matches |
| extra Royal Marriage only when a run exists | `royal_count == 2` -> 40 | same | matches |
| Dix counted once in `breakdown`, once in `total` | yes | yes | matches |
| 3-different-aces bonus | 60 for H/C trump, 50 for D/S | same | matches |
| competitive adj | +160 / +100 / +130 | same | matches |
| behind-600 trigger | `opp - mine >= 600` | same | matches |
| close-out trigger | `mine >= 1000-300` and `opp <= 1000-500` | same | matches |
| double-payoff shape | missing only trump A, aces in other 3 suits | same | matches |
| `max_bid` uncap | `actual_meld > 300` -> None | -> `null` | matches |
| `best_base_bid` search | all 4 suits, strict `>` keeps the first | `best === null \|\| capped > best.total` | matches (equivalent — the ceiling is never below 100) |

### `bidding.ts` — the auction wrapper

| rule | Python | TS | verdict |
|---|---|---|---|
| dealer-protection 850 / 500 | present | **missing** | **port bug — restored** |
| `passesSoFar < 2` -> always open | absent | **present** | **port bug — removed** |
| 3rd-bidder-opens-cheap, `my_score > 800` gate | present | present | matches |
| partner bid twice -> back off | `>= 2` | `>= 2` | matches |
| partner raised over my bid -> need 340 | 340 | 340 | matches |
| partner has bid -> relax ceiling to 330 | 330 | 330 | matches |
| defensive push at `current_bid <= 300` | present | present | matches |
| `meldOnlyBid` | meld + 60 +/- 30 uniform | same | matches |
| 321 floor once partner has passed | absent | present | **deliberate** (#93/#95) — commented in place |
| `worthContract` -> distilled evaluator | absent | present | **deliberate** (#114/#115) — commented in place |

### `tracker.ts` — `PlayTracker`, `choose_lead_card`, `choose_follow_card`

| constant / rule | Python | TS | verdict |
|---|---|---|---|
| `POINT_RANKS` | `{A, 10, K}` | same | matches |
| `TOTAL_TRUMP_COPIES` | 12 | 12 | value matches; **was applied where Python does not** |
| `is_safe` | every higher rank accounted `>= 2` | same | matches |
| `is_unsecured_ace` | exactly 1 in hand, 0 played | same | matches |
| safe-card cascade, 5 tiers + tie-breaks | trump A -> other A by suit length -> safe by rank -> junk -> junk trump -> lowest | same | matches |
| bidder's first lead (#82) | unsecured trump A -> any trump A -> highest trump | same | matches |
| `_offense_trump_lead` | trump A unconditionally, else non-trump cascade | same | matches |
| `_defender_lead` | non-trump cascade unconditionally | conditional on trump being fully accounted | **port bug — fixed** |
| follow: forced beat -> cheapest winner | present | present | matches |
| follow: partner winning -> feed highest K/10 | present | present | matches |
| follow: trump-secure at 12 accounted | `>= 12` | `>= TOTAL_TRUMP_COPIES` | matches |
| follow: sluff by (suit length, rank) | present | present | matches |
| easy lead / follow | low non-trump non-count / lowest legal | same | matches |

### `passing.ts` — `_partner_pass_selection` / `_bidder_pass_selection`

| constant / rule | Python | TS | verdict |
|---|---|---|---|
| `PASS_COUNT` | 3 | 3 | matches |
| partner tiers, D/S and H/C | 7 tiers incl. void opportunity | same order | matches |
| trump A/10/J sort order | `{A:0, 10:1, J:2}` | same | matches |
| non-trump aces, non-duplicate first | `0 if count == 1 else 1` | same | matches |
| bidder tiers, D/S and H/C | 9 tiers incl. the QS/JD pro move | same order | matches |
| H/C pro move | queens-around AND pinochle AND a run card | same | matches |
| D/S pro move | duplicate AS/AD only | same | matches |
| `_find_void_opportunity` | non-trump, fits the slots, nothing protected, no Ace, largest first | same | matches |
| `_breaks_marriage` / `_breaks_around` | same predicates | same | matches |
| `_easy_card_worth` | trump +5, A/10/K +2, Q/J +1 | same | matches |

### `trick.ts` / `round.ts` / `game.ts` / `misdeal.ts`

| constant / rule | Python | TS | verdict |
|---|---|---|---|
| trick points | 10 each for A/10/K | same | matches |
| last-trick bonus | +10 on overall trick 11 (0-indexed) | `LAST_TRICK_BONUS` on trick 12 of 12 | matches |
| tricks per round | 12 | `TRICK_COUNT` 12 | matches |
| legal moves: follow, beat, trump-if-void, beat-trump, sluff | 5 rules | same | matches |
| winner ties | first copy played wins (`max` keeps first maximal) | `reduce`, strict `>` | matches |
| seating | 0&2 vs 1&3 | `teamOf` / `partnerOf` | matches |
| contract check | total < bid -> `-bid`, defenders keep theirs | same | matches |
| game end | bust at -1000 beats reaching +1000; bidding team wins a shared crossing | same | matches |
| `MISDEAL_NINE_THRESHOLD` | 5 (`pinochle_rules.md`, `human_play.py`) | 5 | matches |

### `skills.ts` / `evaluator.ts` / `evaluatorModel.ts` / `names.ts`

| constant | Python | TS | verdict |
|---|---|---|---|
| `MELD_ONLY_TRICK_ESTIMATE` | 60 (`EASY_FLAT_TRICK_ESTIMATE`) | 60 | matches |
| `MELD_ONLY_BID_NOISE` | 30 (`EASY_BID_NOISE`) | 30 | matches |
| `SKILL_PARAMS` rows | `GENERAL_STRATEGY_SKILL_PARAMS` 1-5 | 5 named levels, no rollout params | **deliberate** — the browser has no rollout budget; documented at length in `skills.ts` |
| sigmoid clamp | `+/-30` in `fit_evaluator._sigmoid` | `LOGIT_CLAMP` 30 | matches |
| model weights / intercepts / thresholds | `rollout_evaluator.json` | generated by `export_evaluator.py` | matches — `test_export_evaluator.py` fails the Python suite on drift |
| fold ceiling computed at 0/0, not the live score | label was measured score-blind | same | **deliberate** — commented in `evaluator.ts` |
| `NAME_POOL` | 200 names | 200 names | matches — diffed element by element |

`teamNames.ts` is a curated list from #73 with no Python counterpart — not a
port, nothing to diff.

## Tests

- `python -m pytest -q` — **269 passed** (unchanged; nothing here touches Python)
- `npm test` — **309 passed** (303 before, +7 new, -1 replaced)
- `npm run build` — clean, 256.43 kB / 79.56 kB gzipped

Closes #126
