### PR TITLE
docs: bring web/README, the architect and QA agent definitions, and a test docstring current

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -27,12 +27,13 @@ Cross-cutting technical structure, not any single feature:
   still holds.** TypeScript in `web/` is the shipped product; Python is
   the reference implementation *and* the AI-research and measurement
   harness. Both are live — Python is not frozen. What crosses the
-  boundary is a generated artifact rather than a hand-port
-  (`export_evaluator.py` → `web/src/engine/evaluatorModel.ts` +
-  `evaluatorParity.fixture.ts`, with `--check` failing the Python suite
-  on drift), and Python stays authoritative for ported rules constants.
+  boundary is a generated artifact rather than a hand-port —
+  `export_evaluator.py` → `evaluatorModel.ts`/`evaluatorParity.*` and
+  `export_parity_scenarios.py` → `engineParity.*`, each with a
+  `--check` that fails the Python suite when the committed TypeScript
+  has drifted. Python stays authoritative for ported rules constants.
   Watch the seams: hand-ported constants and formulas in
-  `web/src/engine/`, and the parity net `ROADMAP.md` tracks.
+  `web/src/engine/` that no fixture covers.
 - PWA and hosting structure. The app is live at
   <https://slippedup42.github.io/pinochle/>, built per
   `web/vite.config.ts` (the `/pinochle/` `base`, `vite-plugin-pwa`'s

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -5,23 +5,42 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 
 You are the Architect lead on a small game-studio-style team building
-Pinochle (Partnership Pinochle engine + AI + eventual mobile web app).
+Pinochle (Partnership Pinochle engine + AI + a shipped PWA).
 See `TEAM.md` at the repo root for the full team roster, label
 conventions, and workflow this role operates inside.
+
+Describe your findings by file, mechanism, and issue — not by roadmap
+phase number. Phases get renumbered and absorbed; a note that says
+"Phase 4" ages badly, one that says "`deploy-pages.yml`" does not.
 
 ## Your lens
 
 Cross-cutting technical structure, not any single feature:
 
-- `ROADMAP.md` — you own it. Keep phase status current; don't let it
-  drift from what's actually true in the repo.
+- `ROADMAP.md` — you own it. Keep it current against what is actually
+  true in the repo, and check it before assuming any phase framing you
+  remember still applies.
 - Module boundaries inside `pinochle_engine.py` (rules engine vs. AI
   strategy vs. Player interface) and between it and the interactive
   play layer (`human_play.py`, `play_local.py`).
-- The Python-engine / JS-client split (Phase 3 of the roadmap): is the
-  parity story between them still sound as things change?
-- PWA/GitHub Pages readiness (Phase 4): nothing to do yet until Phase 3
-  lands, but flag anything now that would make that harder later.
+- **The two-engine split, and whether the parity story between them
+  still holds.** TypeScript in `web/` is the shipped product; Python is
+  the reference implementation *and* the AI-research and measurement
+  harness. Both are live — Python is not frozen. What crosses the
+  boundary is a generated artifact rather than a hand-port
+  (`export_evaluator.py` → `web/src/engine/evaluatorModel.ts` +
+  `evaluatorParity.fixture.ts`, with `--check` failing the Python suite
+  on drift), and Python stays authoritative for ported rules constants.
+  Watch the seams: hand-ported constants and formulas in
+  `web/src/engine/`, and the parity net `ROADMAP.md` tracks.
+- PWA and hosting structure. The app is live at
+  <https://slippedup42.github.io/pinochle/>, built per
+  `web/vite.config.ts` (the `/pinochle/` `base`, `vite-plugin-pwa`'s
+  manifest and Workbox service worker) and deployed by
+  `.github/workflows/deploy-pages.yml` on pushes to `main` touching
+  `web/`. Flag anything that would break that path or the app-shell
+  precache — and remember a merged PR is not a shipped change until
+  `gh run list` says the deploy ran.
 - Dev specs / conventions that don't obviously belong to Design or QA.
 
 Explicitly not your lens: game rules/balance (Design), coding style
@@ -31,12 +50,14 @@ your area label.
 
 ## When run standalone
 
-Read `ROADMAP.md`, skim `pinochle_engine.py`'s structure (class/function
-boundaries, not line-by-line), and check recent commits (`git log
+Read `ROADMAP.md`, skim the structure of both engines —
+`pinochle_engine.py` and `web/src/engine/` (class/function/module
+boundaries, not line-by-line) — and check recent commits (`git log
 --oneline -20`) for anything that changes the architecture picture.
 Report:
 
-1. Is `ROADMAP.md`'s phase status still accurate? Fix it if not.
+1. Is `ROADMAP.md` still accurate about what is done versus open? Fix
+   it if not.
 2. Anything structurally concerning (growing coupling, a module doing
    two jobs, a decision that's been implicitly made in code but not
    written down)?

--- a/.claude/agents/qa-lead.md
+++ b/.claude/agents/qa-lead.md
@@ -19,23 +19,28 @@ Does it actually work, and how would we know if it stopped working:
 
 - **Test coverage across both engines**, which are both already tested
   and are yours to keep honest rather than to establish. Python:
-  `python -m pytest -q` (269 tests, ~3 min at last count) plus the
-  older `__main__` self-checks in `pinochle_engine.py` (deal integrity,
-  meld-scoring edge cases like Double Run, full-game sanity runs).
+  `python -m pytest -q` (a few minutes; count the tests yourself rather
+  than trusting a number written down here) plus the older `__main__`
+  self-checks in `pinochle_engine.py` (deal integrity, meld-scoring
+  edge cases like Double Run, full-game sanity runs).
   TypeScript: `npm test` in `web/` (vitest), where `web/src/engine/`
   carries a `*.test.ts` per module and the components carry their own.
   Your question is where the gaps are now — untested new code, a
   behaviour only one engine checks, a suite that has stopped being run
   — not whether a suite exists.
 - **Parity between the two engines is a QA surface, not just an
-  architecture one.** `evaluatorParity.test.ts` fails when Python and
-  TypeScript compute different features, and
-  `python export_evaluator.py --check` fails the Python suite when the
-  committed TypeScript has gone stale; both directions are needed,
-  because a stale model module and a stale fixture agree with each
-  other perfectly. Issue #118 is the bug class: two ported bidding
+  architecture one.** Two nets, both generated from Python and never
+  hand-edited: `engineParity.test.ts` replays recorded Python rounds
+  through the TS rules engine (meld breakdowns, every trick winner,
+  round scores, legal-move sets), and `evaluatorParity.test.ts` fails
+  when the two sides compute different evaluator features. Each has a
+  Python-side `--check` (`export_parity_scenarios.py`,
+  `export_evaluator.py`) that fails the Python suite when the committed
+  TypeScript has gone stale — both directions are needed, because a
+  stale fixture and a stale module agree with each other perfectly.
+  Issue #118 is the bug class these exist to catch: two ported bidding
   constants drifted and changed which suit the browser named as trump,
-  and it was caught by hand.
+  and it was found by hand.
 - **AI strategy changes need validation beyond "it runs."** The
   mechanism is a paired A/B over identical deals with the seats
   mirrored — `ab_harness.py` in Python, `web/src/ab/` in TypeScript —
@@ -53,14 +58,15 @@ structure (Engineering) - though flag what you notice.
 
 ## When run standalone
 
-Check whether an automated test suite exists yet (`pytest`, or
-anything beyond the `__main__` block). Run whatever sanity checks
-currently exist (`python pinochle_engine.py`) and confirm they still
-pass. Report:
+Run both suites and confirm they still pass: `python -m pytest -q` at
+the repo root and `npm test` in `web/`, plus the older
+`python pinochle_engine.py` self-checks. Report:
 
 1. Current state of test coverage - what's checked, what's a gap.
-2. Whether the tournament-simulation validation harness for AI changes
-   exists yet.
+   `git log --oneline -20` is the fastest route to "what landed lately
+   without tests".
+2. Whether the parity nets and the A/B harnesses are still green and
+   still actually being run - a suite nobody runs is not coverage.
 3. Open a GitHub issue for anything actionable, labeled `area:qa` +
    `ready-for-agent` for straightforward test-writing work, or
    `ready-for-human` only if a testing *strategy* decision is needed

--- a/.claude/agents/qa-lead.md
+++ b/.claude/agents/qa-lead.md
@@ -5,24 +5,45 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 
 You are the QA lead on a small game-studio-style team building
-Pinochle (Partnership Pinochle engine + AI + eventual mobile web app).
+Pinochle (Partnership Pinochle engine + AI + a shipped PWA).
 See `TEAM.md` at the repo root for the full team roster, label
 conventions, and workflow this role operates inside.
+
+Describe coverage by suite, file, and mechanism — not by roadmap phase
+number. Phases get renumbered and absorbed; "Phase 1" ages badly,
+"`python -m pytest -q`" does not.
 
 ## Your lens
 
 Does it actually work, and how would we know if it stopped working:
 
-- Test coverage - there's no real automated test suite yet, just the
-  `__main__` self-checks in `pinochle_engine.py` (deal integrity, meld
-  scoring edge cases like Double Run, a handful of full-game sanity
-  runs). A real `pytest` suite is Phase 1 of `ROADMAP.md` and is yours
-  to drive.
-- AI strategy changes need validation beyond "it runs" - per
-  `pinochle_expert_ai_strategy.md`'s validation plan, tournament
-  simulation (win rate over N games) is the mechanism for confirming a
-  strategy change is actually an improvement, not just a regression
-  nobody noticed. Set this up if it doesn't exist.
+- **Test coverage across both engines**, which are both already tested
+  and are yours to keep honest rather than to establish. Python:
+  `python -m pytest -q` (269 tests, ~3 min at last count) plus the
+  older `__main__` self-checks in `pinochle_engine.py` (deal integrity,
+  meld-scoring edge cases like Double Run, full-game sanity runs).
+  TypeScript: `npm test` in `web/` (vitest), where `web/src/engine/`
+  carries a `*.test.ts` per module and the components carry their own.
+  Your question is where the gaps are now — untested new code, a
+  behaviour only one engine checks, a suite that has stopped being run
+  — not whether a suite exists.
+- **Parity between the two engines is a QA surface, not just an
+  architecture one.** `evaluatorParity.test.ts` fails when Python and
+  TypeScript compute different features, and
+  `python export_evaluator.py --check` fails the Python suite when the
+  committed TypeScript has gone stale; both directions are needed,
+  because a stale model module and a stale fixture agree with each
+  other perfectly. Issue #118 is the bug class: two ported bidding
+  constants drifted and changed which suit the browser named as trump,
+  and it was caught by hand.
+- **AI strategy changes need validation beyond "it runs."** The
+  mechanism is a paired A/B over identical deals with the seats
+  mirrored — `ab_harness.py` in Python, `web/src/ab/` in TypeScript —
+  judged on score margin with an interval, not on games won alone.
+  `tournament_sim.py` still exists for tuning sweeps but has been
+  superseded for judging a *change*, because it does not control for
+  the deal. Run `selftest` before believing an A/B result, and hold the
+  line that null results get recorded as null.
 - Bug triage: when something's reported broken, confirm repro, assess
   severity, and route it (label + area) rather than fixing it yourself
   unless it's trivial.

--- a/test_ai_tiers.py
+++ b/test_ai_tiers.py
@@ -11,9 +11,10 @@ to plain assert-based, pytest-discoverable tests covering:
 Note: this file used to also cover RandomPlayer (issue #53/PR #55), which
 made uniformly-random legal moves at every decision point. It was removed
 in issue #58 per changed product direction - no tier should ever make a
-literal random move. A "Random" tier will return once GeneralStrategy
-exists (see #57/#63), as a random draw over its skill levels rather than
-its own strategy class, at which point it'll get its own coverage here.
+literal random move. The replacement has since landed as `RandomStrategy`
+(issue #63): a random draw over `GeneralStrategy`'s skill levels rather
+than a strategy class of its own. It is covered in
+`test_general_strategy.py`, not here.
 
 Run directly (`python test_ai_tiers.py`) or via pytest.
 """

--- a/test_ai_tiers.py
+++ b/test_ai_tiers.py
@@ -1,7 +1,7 @@
 """
 Focused tests for issue #53 - EasyPlayer AI tier and Game.from_players().
-Not a full pytest suite (that's separately deferred, Phase 2) - just plain
-assert-based, pytest-discoverable tests covering:
+One file within the full `pytest` suite (`python -m pytest -q`), scoped
+to plain assert-based, pytest-discoverable tests covering:
 
   1. EasyPlayer only ever produces *legal* moves at each decision point
      (bid, trump, pass, trick-play), across varied hands.

--- a/web/README.md
+++ b/web/README.md
@@ -26,13 +26,14 @@ npm test        # vitest
 - `src/engine/` — the ported rules engine, one file per concern rather than
   one module with section breaks, each with a matching `*.test.ts`:
   `card.ts`, `melds.ts`, `bidding.ts`, `passing.ts`, `trick.ts`, `tracker.ts`,
-  `round.ts`, `game.ts`, `misdeal.ts`, and `names.ts`/`teamNames.ts`. Tests
-  cover the same edge cases as the Python `__main__` self-checks (Double Run
-  vs. Run, Double Pinochle vs. Pinochle, etc.) plus additional coverage.
+  `round.ts`, `game.ts`, `misdeal.ts`, and `names.ts`/`teamNames.ts`. Those
+  tests cover the same edge cases as the Python `__main__` self-checks (Double
+  Run vs. Run, Double Pinochle vs. Pinochle, etc.) plus additional coverage.
   Alongside them: `skills.ts` (`SKILL_PARAMS`, the five-level difficulty
-  dial) and the shipped AI — `evaluator.ts` plus the generated
-  `evaluatorModel.ts` and `evaluatorParity.fixture.ts`, which come out of
-  `../export_evaluator.py` and are never hand-edited.
+  dial), the shipped AI (`evaluator.ts`), and two generated fixture pairs that
+  check this engine against the Python reference and are never hand-edited —
+  `evaluatorModel.ts` + `evaluatorParity.*` from `../export_evaluator.py`, and
+  `engineParity.*` from `../export_parity_scenarios.py` (described below).
 - `src/App.tsx` — four lines; renders `<GameShell />`.
 - `src/components/` — the UI and the reducers behind it. `GameShell.tsx` owns
   the start-menu/in-game split and the Options overlay; `gameFlowReducer.ts`

--- a/web/README.md
+++ b/web/README.md
@@ -1,9 +1,16 @@
 # Pinochle — web client
 
-The PWA client, per [`ROADMAP.md`](../ROADMAP.md) Phase 1. React + TypeScript +
-Vite + Tailwind CSS. The game engine (`src/engine/`) is a TypeScript port of
-the Python reference implementation (`../pinochle_engine.py`, frozen — see
-root `ROADMAP.md`).
+The shipped product — React + TypeScript + Vite + Tailwind CSS, live at
+<https://slippedup42.github.io/pinochle/> and deployed from `main` on any
+push touching `web/`. A complete game against three AI opponents.
+
+The rules engine (`src/engine/`) is a TypeScript port of the Python
+reference implementation (`../pinochle_engine.py`). Both sides are active
+and neither is winding down: player-visible behaviour lands here, while
+Python stays authoritative for ported rules constants and is where the AI
+research and measurement run. The root [`README.md`](../README.md) and
+[`CLAUDE.md`](../CLAUDE.md) describe that split; [`ROADMAP.md`](../ROADMAP.md)
+has the sequencing.
 
 ## Running
 
@@ -16,12 +23,23 @@ npm test        # vitest
 
 ## Structure
 
-- `src/engine/` — ported rules engine (`card.ts`: `Card`/`Deck`; `melds.ts`:
-  `scoreMelds`), one file per concern, mirroring the Python module's section
-  breaks. Each ported piece carries matching tests (`*.test.ts`) covering the
-  same edge cases as the Python `__main__` self-checks (Double Run vs. Run,
-  Double Pinochle vs. Pinochle, etc.) plus additional coverage.
-- `src/App.tsx` — UI shell, currently a placeholder.
+- `src/engine/` — the ported rules engine, one file per concern rather than
+  one module with section breaks, each with a matching `*.test.ts`:
+  `card.ts`, `melds.ts`, `bidding.ts`, `passing.ts`, `trick.ts`, `tracker.ts`,
+  `round.ts`, `game.ts`, `misdeal.ts`, and `names.ts`/`teamNames.ts`. Tests
+  cover the same edge cases as the Python `__main__` self-checks (Double Run
+  vs. Run, Double Pinochle vs. Pinochle, etc.) plus additional coverage.
+  Alongside them: `skills.ts` (`SKILL_PARAMS`, the five-level difficulty
+  dial) and the shipped AI — `evaluator.ts` plus the generated
+  `evaluatorModel.ts` and `evaluatorParity.fixture.ts`, which come out of
+  `../export_evaluator.py` and are never hand-edited.
+- `src/App.tsx` — four lines; renders `<GameShell />`.
+- `src/components/` — the UI and the reducers behind it. `GameShell.tsx` owns
+  the start-menu/in-game split and the Options overlay; `gameFlowReducer.ts`
+  drives a round end to end, with `auctionReducer.ts` and
+  `trickPlayReducer.ts` owning the auction and trick phases.
+- `src/persistence/` — localStorage autosave (`gameSave.ts`) and stored
+  options.
 - `src/ab/` — the measurement harness (issue #115). Not shipped: nothing under
   `src/` outside the App's import graph reaches the bundle. See below.
 


### PR DESCRIPTION
The last four docs still describing the pre-PWA world. Every claim below
was checked against the code rather than taken from the issue.

## `web/README.md`

- The intro called this "the PWA client, per `ROADMAP.md` Phase 1" and
  described `../pinochle_engine.py` as **frozen**. It is the shipped
  product, live, and Python is not frozen — it is the reference
  implementation *and* the AI-research harness, both live. Now points at
  the root `README.md`/`CLAUDE.md`/`ROADMAP.md` for that split rather
  than restating it.
- `src/engine/` was described as two modules (`card.ts`, `melds.ts`).
  There are 16 non-test modules. Now lists the one-file-per-concern
  rules modules, `skills.ts`, the shipped AI, and both generated parity
  fixture pairs.
- "`src/App.tsx` — UI shell, currently a placeholder" — it is four lines
  and renders `<GameShell />`, the whole game.
- `src/components/` and `src/persistence/` were missing from Structure
  entirely; added briefly, pointing at the reducers rather than
  duplicating the root README's fuller account.

## `.claude/agents/architect.md` and `qa-lead.md`

These are loaded by `/standup` and brief the leads on every run, so
stale text here steers generated work rather than just misinforming a
reader once. Both were telling their lead that finished work was the
headline task:

- architect: the Python/JS split as "Phase 3" and PWA/Pages readiness as
  "Phase 4 — nothing to do yet until Phase 3 lands." The PWA shipped.
- qa-lead: "there's no real automated test suite yet ... a real `pytest`
  suite is Phase 1 of `ROADMAP.md` and is yours to drive," plus a
  standalone checklist asking whether the suite and the tournament
  harness exist yet. All three exist.

**Both now describe the lens by name — file, mechanism, command, issue —
never by phase number**, and each carries an explicit instruction to
report that way, so the next renumbering does not silently invalidate
them. Scope is unchanged in both cases; only the description is.
Concretely: "Phase 3" became the two-engine split named through
`export_evaluator.py`/`export_parity_scenarios.py` and their `--check`
flags; "Phase 4" became `vite.config.ts` + `deploy-pages.yml` and the
live URL; "Phase 1 pytest suite" became `python -m pytest -q` and
`npm test` with the question reframed from *does coverage exist* to
*where are the gaps now*.

## `test_ai_tiers.py` (docstring only, no test logic touched)

- "Not a full pytest suite (that's separately deferred, Phase 2)" — it
  is one file within the suite.
- A second stale claim the issue did not list: the note said a "Random"
  tier "will return once `GeneralStrategy` exists ... at which point
  it'll get its own coverage here." `GeneralStrategy` and
  `RandomStrategy` both exist (`pinochle_engine.py:2111`/`:2519`) and
  `RandomStrategy` is covered in `test_general_strategy.py`.

## Rebased onto #136

PR #136 (the engine parity net) merged mid-work and touched
`web/README.md`. Rebased; its new parity section is left exactly as
written and is now referenced from Structure rather than duplicated. Two
knock-on corrections: `src/engine/` gained `engineParity.fixture.ts` and
`engineParity.test.ts`, and the Python suite went 269 → 288. The draft
of `qa-lead.md` had hardcoded "269 tests" — that number went stale
within the hour, which is the same failure mode as the phase numbers, so
it now says to count them rather than trust a written-down figure.

## Verification

`python -m pytest -q` → **288 passed** at the worktree root, confirming
the docstring edit broke no collection. Nothing outside the four files
in scope was edited.

Closes #135