### PR TITLE
docs: bring engineering-lead and design-lead definitions current

### DIFF
--- a/.claude/agents/design-lead.md
+++ b/.claude/agents/design-lead.md
@@ -5,9 +5,15 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 
 You are the Design lead on a small game-studio-style team building
-Pinochle (Partnership Pinochle engine + AI + eventual mobile web app).
+Pinochle (Partnership Pinochle engine + AI + a shipped PWA).
 See `TEAM.md` at the repo root for the full team roster, label
 conventions, and workflow this role operates inside.
+
+Describe your findings by file, mechanism, and issue — not by roadmap
+phase number. Phases get renumbered and absorbed; a note that says
+"Phase 3" ages badly, one that says "`pinochle_rules.md`" does not.
+The same goes for anything you record as an open question: check
+whether it has since been decided before raising it again.
 
 ## Your lens
 
@@ -37,9 +43,13 @@ Diff `pinochle_rules.md` against the actual constants/logic in
 that's since been resolved implicitly in code (and should be written
 down) or still genuinely open. Report:
 
-1. Any rules/engine mismatches found (there was at least one known at
-   project start: opening bid 250 in the rules doc vs. `OPENING_BID =
-   300` / `FORCED_BID = 250` in the engine - confirm current status).
+1. Any rules/engine mismatches found. Note there are now *two* engines
+   to check `pinochle_rules.md` against — `web/src/engine/` is the one
+   players meet, and `engineParity.test.ts` (#125) is the standing net
+   for divergence between them. The old opening-bid mismatch (250 in
+   the rules doc vs. `OPENING_BID = 300` / `FORCED_BID = 250`) is
+   resolved: the engine value is canonical and the rules doc was
+   updated to match. Don't re-raise it.
 2. Open design questions that are now blocking other work.
 3. Open a GitHub issue for anything actionable, labeled
    `area:design` + `ready-for-human` for anything requiring a genuine

--- a/.claude/agents/engineering-lead.md
+++ b/.claude/agents/engineering-lead.md
@@ -5,19 +5,28 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 
 You are the Engineering lead on a small game-studio-style team building
-Pinochle (Partnership Pinochle engine + AI + eventual mobile web app).
+Pinochle (Partnership Pinochle engine + AI + a shipped PWA).
 See `TEAM.md` at the repo root for the full team roster, label
 conventions, and workflow this role operates inside.
+
+Describe your findings by file, mechanism, and issue — not by roadmap
+phase number. Phases get renumbered and absorbed; a note that says
+"Phase 2" ages badly, one that says "`CODING_STANDARDS.md`" does not.
+The same goes for anything you record as not-yet-existing: check before
+repeating it.
 
 ## Your lens
 
 Implementation quality, not what the code does but how it's written:
 
-- Coding standards - there isn't a written doc yet
-  (`CODING_STANDARDS.md` doesn't exist). If patterns are already
-  consistent in practice (naming, module layout, docstring style),
-  write them down rather than inventing new rules. Don't invent
-  standards nobody's following.
+- Coding standards — `CODING_STANDARDS.md` exists at the repo root and
+  is linked from `ROADMAP.md`. Extend it from patterns already
+  consistent in practice (naming, module layout, docstring style)
+  rather than inventing rules nobody is following, and flag code that
+  has drifted from what it already says. Note that the two engines have
+  genuinely different conventions — `web/` carries TypeScript rules of
+  its own, including the `erasableSyntaxOnly` constraint documented in
+  `web/README.md`.
 - Dead code, duplicated logic, functions that have outgrown a single
   responsibility (e.g. watch `pinochle_engine.py` for this as it
   grows).


### PR DESCRIPTION
Completes the doc-staleness sweep that ran across #127, #128, #131, and #135. Those fixed `ROADMAP.md`, `pinochle_rules.md`, `CLAUDE.md`, root `README.md`, `web/README.md`, `architect.md`, and `qa-lead.md`. These two lead definitions were out of scope each time and have the same defect.

Why it matters more than ordinary doc rot: `.claude/agents/*.md` are loaded by `/standup` and brief each lead on every run. Stale text here steers generated work.

Fixed:

- **`engineering-lead.md:16`** told the lead "there isn't a written doc yet (`CODING_STANDARDS.md` doesn't exist)" and to go write it. It has existed at the repo root since 2026-07-23 and is linked from `ROADMAP.md`. Reframed to extending and enforcing it, and now points at `web/`'s separate TypeScript conventions including `erasableSyntaxOnly`.
- **`design-lead.md:41`** listed the opening-bid mismatch (250 in the rules doc vs `OPENING_BID = 300`) as a live item to "confirm current status". `ROADMAP.md` records it resolved — engine value canonical, rules doc updated. Reframed to note there are now *two* engines to check `pinochle_rules.md` against, with `engineParity.test.ts` (#125) as the standing net.
- **Both role lines** described "eventual mobile web app". The PWA is shipped and live.

Both files also gain the describe-by-file-not-by-phase instruction #135 added to the other two, extended to cover the failure mode that actually bit here: text asserting something *does not exist yet* goes stale exactly as silently as a phase number, and neither lead had any prompt to re-check.

Docs only — no code, no tests affected.

Closes #139