### PR TITLE
Make the web build deployable to Netlify (manual deploys, no git connection)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,99 @@
+# Netlify configuration for the Pinochle PWA.
+#
+# Deploys are MANUAL, from a locally prebuilt directory. This repo is
+# deliberately NOT connected to Netlify's git integration: GitHub is source
+# control only (decided 2026-08-01, #141, which removed the GitHub Pages
+# workflow and the `.github/` directory). A push-triggered build configured
+# here would rebuild exactly the coupling that decision removed, in a
+# different service.
+#
+#     cd web
+#     npm ci && npm run build       # built locally on Node 24
+#     cd ..
+#     npx netlify deploy --prod     # uploads web/dist exactly as built
+#
+# Run the deploy from the repo root — `publish` below is resolved relative to
+# this file, so invoking the CLI from `web/` would look for `web/web/dist`.
+#
+# There is deliberately no `command` and no NODE_VERSION here. Netlify never
+# runs a build for this repo, so build settings would be dead config whose
+# only real effect is to imply that it does.
+
+[build]
+  publish = "web/dist"
+
+# ---------------------------------------------------------------------------
+# Redirects — intentionally none.
+# ---------------------------------------------------------------------------
+# In particular there is no SPA fallback (`/* /index.html 200`). That rule is
+# standard Netlify boilerplate for client-side routers, and this app has no
+# router: nothing imports `react-router` and nothing calls `pushState` /
+# `replaceState`. Every real URL is a file that exists in `web/dist`, so the
+# fallback would only convert genuine 404s into a silent 200 serving the app
+# shell. Add one if and when a router lands, not before.
+
+# ---------------------------------------------------------------------------
+# Security headers
+# ---------------------------------------------------------------------------
+# The build is self-contained: no backend, no outbound requests, no forms, no
+# third-party scripts or fonts, no `eval`. That makes a strict allowlist CSP
+# cheap to hold, so it lists exactly what the bundle uses rather than starting
+# permissive. `frame-ancestors 'none'` is what X-Frame-Options would do, so
+# that header is not duplicated.
+#
+# `style-src 'self'` (no 'unsafe-inline') is safe here because the build emits
+# no inline `<style>` blocks and no `style="..."` attributes. `useDraggable.ts`
+# does write `element.style.*` at runtime, but that is the CSSOM, which CSP
+# does not govern — only style attributes parsed from markup are.
+#
+# NOT set: Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy. Netlify
+# *can* set them where GitHub Pages could not, and they are the prerequisite
+# for SharedArrayBuffer and therefore for multi-threaded WebAssembly. Nothing
+# here uses either today, and COEP breaks cross-origin subresources, so they
+# stay off until browser-side rollouts for skills 4-5 (ROADMAP Phase 3)
+# actually need them.
+
+[[headers]]
+  for = "/*"
+
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; manifest-src 'self'; worker-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "no-referrer"
+    Permissions-Policy = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), microphone=(), payment=(), usb=()"
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+# Vite fingerprints everything under /assets/, so those URLs are immutable by
+# construction and can be cached hard.
+
+[[headers]]
+  for = "/assets/*"
+
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# The service worker is the one file that must never be served stale: it is
+# how every other file gets updated. `vite-plugin-pwa` runs `registerType:
+# 'autoUpdate'`, so a cached `sw.js` would pin a device to an old build with
+# no way to recover short of clearing site data. This matches Netlify's
+# current default rather than relying on it staying the default.
+
+[[headers]]
+  for = "/sw.js"
+
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/registerSW.js"
+
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/manifest.webmanifest"
+
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"

--- a/web/README.md
+++ b/web/README.md
@@ -166,8 +166,8 @@ before the fix was committed, since a permanent switch for "play the port bug"
 is not a difficulty setting.
 
 `bench/index.html` is the browser side of the latency measurement, served by
-`npm run dev` at `/pinochle/bench/`. It is never an input to `vite build`, so it
-cannot reach a player or the PWA precache.
+`npm run dev` at `/bench/` (it follows `base`, which is `/`). It is never an
+input to `vite build`, so it cannot reach a player or the PWA precache.
 
 ## Notes
 
@@ -184,17 +184,59 @@ cannot reach a player or the PWA precache.
   `public/apple-touch-icon.png` are placeholder icons (solid color, generated
   programmatically) — swap for real art whenever it exists; they just need to
   keep the same filenames/sizes referenced in `vite.config.ts`.
-- **There is no deploy pipeline.** The app was served from GitHub Pages from
-  2026-07-31 until 2026-08-01, when that was removed by decision — GitHub is
-  source control only. `.github/workflows/` no longer exists.
+- **There is no automatic deploy pipeline, and no site yet.** The app was
+  served from GitHub Pages from 2026-07-31 until 2026-08-01, when that was
+  removed by decision — GitHub is source control only and `.github/` no
+  longer exists. What replaces it is a *manual* target, described next: the
+  config is committed, but no Netlify site exists yet (#144), so there is
+  still no public URL.
+- **Deploying to Netlify (manual).** `netlify.toml` at the repo root sets
+  `publish = "web/dist"` and nothing else build-related. The repo is
+  deliberately **not** connected to Netlify's git integration — a
+  push-triggered build would recreate the coupling that removing GitHub
+  Pages took out. Netlify never builds this repo; you build locally and
+  upload the result:
+
+  ```
+  cd web && npm ci && npm run build
+  cd .. && npx netlify deploy --prod     # uploads web/dist as-is
+  ```
+
+  Run the deploy from the **repo root** — `publish` resolves relative to
+  `netlify.toml`, so running it from `web/` looks for `web/web/dist`. For the
+  same reason there is no `command` and no `NODE_VERSION` in that file: they
+  would be dead config implying a build that never happens. Node 24 locally.
+- **No SPA fallback redirect, on purpose.** `netlify.toml` sets no redirects.
+  The usual `/* /index.html 200` rule exists for client-side routers, and
+  this app has none — nothing imports `react-router`, nothing calls
+  `pushState`. Every real URL is a file in `dist/`, so the rule would only
+  turn genuine 404s into a 200 serving the app shell. Add it when a router
+  lands, not before.
 - `base` in `vite.config.ts` is `/`. If the build is ever served under a
   subpath (a project page at `example.com/pinochle/`, say), set `base` to
   that subpath or the built asset URLs will not resolve. This is the single
-  most common way a working build serves a blank page.
-- Whoever picks a host should know: a static host that cannot set COOP/COEP
-  response headers rules out `SharedArrayBuffer`, and therefore rules out
-  multi-threaded WebAssembly. Single-threaded Wasm is unaffected. GitHub
-  Pages cannot set headers; Cloudflare Pages and Netlify can. Only matters
-  if browser-side rollouts are ever attempted for skills 4–5.
+  most common way a working build serves a blank page. **The manifest's
+  `id` / `start_url` / `scope` have to move with it** — they were left at
+  the old GitHub Pages `/pinochle/` path after `base` went back to `/`, which
+  meant an installed app launched into a 404 and the page at `/` fell outside
+  its own manifest scope. Fixed in #143; the failure is invisible in a
+  browser tab and only shows up once the app is installed.
+- **Security headers** are set in `netlify.toml` for `/*`: a strict
+  allowlist CSP (the bundle has no backend, no outbound requests, no forms,
+  no third-party scripts and no `eval`, so `'unsafe-inline'` is not needed
+  anywhere), plus `X-Content-Type-Options`, `Referrer-Policy`, and a
+  `Permissions-Policy` denying device APIs the game never uses. Hashed
+  `/assets/*` are cached immutably; `sw.js` is explicitly
+  `max-age=0, must-revalidate`, since a stale service worker would pin a
+  device to an old build.
+- Whoever maintains the host should know: a static host that cannot set
+  COOP/COEP response headers rules out `SharedArrayBuffer`, and therefore
+  rules out multi-threaded WebAssembly. Single-threaded Wasm is unaffected.
+  GitHub Pages could not set headers — **Netlify can**, via the `[[headers]]`
+  block already in `netlify.toml`. They are deliberately left off: nothing
+  uses either today, and COEP breaks cross-origin subresources for no gain.
+  Turn them on only if browser-side rollouts are attempted for skills 4–5.
 - To check the production build locally: `npm run build && npm run preview`,
-  then open the printed local URL.
+  then open the printed local URL. Note that `preview` does **not** apply
+  `netlify.toml`'s headers — it serves the files without them, so a CSP
+  problem will not reproduce there.

--- a/web/bench/index.html
+++ b/web/bench/index.html
@@ -1,8 +1,9 @@
 <!doctype html>
 <!--
-  Dev-only latency bench for #115. Served by `npm run dev` at
-  /pinochle/bench/; never an input to `vite build`, so it cannot reach a
-  player or the PWA precache. See src/ab/benchPage.ts.
+  Dev-only latency bench for #115. Served by `npm run dev` at /bench/
+  (it follows `base` in vite.config.ts, which is `/`); never an input to
+  `vite build`, so it cannot reach a player or the PWA precache.
+  See src/ab/benchPage.ts.
 -->
 <html lang="en">
   <head>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -21,12 +21,20 @@ export default defineConfig({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.svg', 'apple-touch-icon.png'],
       manifest: {
-        id: '/pinochle/',
+        // `id`, `start_url`, and `scope` must track `base` above. They were
+        // left at the GitHub Pages project-page path (`/pinochle/`) when that
+        // deploy was removed and `base` went back to `/`, which pointed an
+        // installed app at a URL the build does not contain: tapping the home
+        // screen icon loaded `/pinochle/` and 404'd, and the document at `/`
+        // sat outside the declared scope, so browsers declined to install it
+        // at all. The service worker registers at `/` either way, so the two
+        // disagreed. If `base` ever changes, change these with it.
+        id: '/',
         name: 'Pinochle',
         short_name: 'Pinochle',
         description: 'Partnership Pinochle — play against AI opponents.',
-        start_url: '/pinochle/',
-        scope: '/pinochle/',
+        start_url: '/',
+        scope: '/',
         display: 'standalone',
         orientation: 'portrait',
         theme_color: '#14532d',


### PR DESCRIPTION
Makes the `web/` build deployable to Netlify as a static site, so the game has a
real `https` origin an iPhone can actually run.

## `netlify.toml`

```toml
[build]
  publish = "web/dist"
```

and nothing else build-related. **No git connection, no build command, no
`NODE_VERSION`.** GitHub was scoped to source control only on 2026-08-01 (#141,
which removed `.github/`); a push-triggered build configured here would rebuild
that same coupling in a different service. Netlify never builds this repo — you
build locally on Node 24 and upload the result:

```
cd web && npm ci && npm run build
cd .. && npx netlify deploy --prod
```

`NODE_VERSION` is deliberately omitted rather than pinned: the issue said to pin
it *if* a build step is configured, and none is, so it would be dead config
whose only real effect is to imply Netlify builds this repo. The local Node
version is recorded in a comment and in `web/README.md` instead.

**No redirects — including no SPA fallback.** Verified rather than assumed:
`grep` for `react-router`, `pushState`, `replaceState`, `history.*` and
`window.location` across `web/src` and `web/index.html` returns zero hits. Every
real URL is a file in `dist/`, so `/* /index.html 200` would only convert genuine
404s into a 200 serving the app shell.

**Headers.** A strict allowlist CSP on `/*` — the bundle has no backend, no
outbound requests, no forms, no third-party scripts/fonts and no `eval`, so no
directive needs `'unsafe-inline'`. Plus `X-Content-Type-Options`,
`Referrer-Policy`, and a `Permissions-Policy` denying device APIs the game never
uses. `frame-ancestors 'none'` covers what `X-Frame-Options` would, so that
header is not duplicated. Hashed `/assets/*` cache immutably; `sw.js` is pinned
to `must-revalidate` so a cached service worker cannot strand a device on an old
build under `registerType: 'autoUpdate'`.

`style-src 'self'` holds even though `useDraggable.ts` writes `element.style.*`
at runtime — CSP governs style attributes parsed from markup, not the CSSOM.

**COOP/COEP left off**, as instructed. Netlify *can* set them where GitHub Pages
could not, and they gate `SharedArrayBuffer` and multi-threaded Wasm, but nothing
uses either today and COEP breaks cross-origin subresources. Recorded in
`web/README.md` as available for the skills 4–5 rollout work.

## One thing outside the brief — please look at this

The brief listed the PWA manifest as already verified and not to be touched. It
builds correctly, but it does **not** work on a root-served origin, so I fixed it
in a separate commit (`01370ae`) that can be dropped cleanly if you disagree.

The manifest still declared `id`, `start_url` and `scope` as `/pinochle/` — the
GitHub Pages project-page path — after that deploy was removed and `base` went
back to `/`. `registerSW.js` registers the service worker at scope `/`
regardless, so the two disagreed. From the built output, before the fix:

```
manifest.webmanifest   start_url "/pinochle/"  scope "/pinochle/"  id "/pinochle/"
registerSW.js          register('/sw.js', { scope: '/' })
GET /pinochle/         404          # not a path the build contains
```

That breaks precisely the flow this issue exists to enable: `start_url` 404s when
the installed home-screen icon is tapped, and the document at `/` sits outside the
declared scope, so browsers decline to install it at all. Neither symptom shows up
in an ordinary browser tab — the app loads fine at `/` — which is why it survived
#141.

Fixing the manifest is the right repair; a `/pinochle/*` redirect would paper over
stale config with routing. After the fix, measured in-browser: `id`/`start_url`/
`scope` all `/`, document in scope, `start_url` resolving to the app root, service
worker active at `/`.

The same stale `/pinochle/` path appeared in two docs describing the dev-only
latency bench (`npm run dev` serves it at `/bench/`); corrected in the same commit.

## Verification

`npm install` + `npm run build` produces a complete static site — `index.html`,
hashed `assets/`, `manifest.webmanifest`, `sw.js`, `workbox-*.js`, `registerSW.js`
and all icons, 15 precache entries. All asset URLs are root-relative
(`/assets/index-*.js`, `/manifest.webmanifest`, `/favicon.svg`).

Beyond `npm run preview` (which serves the files but does **not** apply
`netlify.toml`, so a CSP problem cannot reproduce there), I served `web/dist`
through a local server that parses the header rules straight out of the committed
`netlify.toml`, so what was tested is the real file rather than a retyped copy:

- App boots and plays a full auction — deal, meld, bidding UI — with the CSP applied.
- **Zero console messages**, so zero CSP violations.
- Tailwind stylesheet loads and applies (48 rules) under `style-src 'self'`.
- Service worker registers and goes active at scope `/` under `worker-src 'self'`.
- All 15 precache entries fetch 200; nothing blocked.
- `/pinochle/` returns 404, confirming no SPA fallback is masking anything.

**An actual Netlify deploy is untested** — there is no account or site yet (#144).
Everything above is local verification.

## Docs

Only `web/README.md`'s "PWA / deployment" section (plus the one stale bench path).
The "not currently hosted anywhere" statements in `README.md`, `CLAUDE.md`,
`pinochle_rules.md`, `ROADMAP.md`, `.claude/agents/architect.md` and
`web/README.md`'s intro are **left alone** — no site exists yet, so they are still
true, and no placeholder URL is written anywhere. `architect.md`'s "do not re-add
a deploy workflow without Paul asking" line is untouched and still holds: this is
a manual upload, not a workflow.

## Tests

- `python -m pytest -q` — **288 passed**
- `npm test` in `web/` — **325 passed** (38 files)
- `npm run lint` — 3 `exhaustive-deps` warnings, all pre-existing in files this PR
  does not touch.

Closes #143
