### PR TITLE
Hide opponents' card fans permanently and remove the toggle (#142)

### DIFF
--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -246,7 +246,6 @@ export function AuctionFlow({
       overlay={overlay}
       logPanel={logPanel}
       onOpenMenu={onOpenMenu}
-      hideOpponentCards={options.hideOpponentCards}
     />
   )
 }

--- a/web/src/components/GameFlow.tsx
+++ b/web/src/components/GameFlow.tsx
@@ -175,7 +175,6 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
         teamNames={state.teamNames}
         dealer={state.dealer}
         onOpenMenu={onOpenMenu}
-        options={options}
         onComplete={handleMeldComplete}
         onConcede={handleMeldConcede}
       />
@@ -267,7 +266,6 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
       state={tableState}
       overlay={overlay}
       onOpenMenu={onOpenMenu}
-      hideOpponentCards={options.hideOpponentCards}
     />
   )
 }

--- a/web/src/components/GameShell.test.tsx
+++ b/web/src/components/GameShell.test.tsx
@@ -128,11 +128,13 @@ describe('GameShell', () => {
     expect(Deck.prototype.deal).toHaveBeenCalledTimes(2)
   })
 
-  it('toggling "Hide opponent cards" in Options affects the next game rendered', async () => {
+  // #142: opponents' fans used to be an Options toggle. They are now
+  // unconditionally hidden, so there is no setting and no way back to them.
+  it('never renders opponents’ card fans, and offers no option to show them', async () => {
     mockDeal()
     render(<GameShell />)
     fireEvent.click(screen.getByRole('button', { name: 'Options' }))
-    fireEvent.click(screen.getByLabelText('Hide opponent cards'))
+    expect(screen.queryByLabelText('Hide opponent cards')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'Done' }))
 
     fireEvent.click(screen.getByRole('button', { name: 'New Game' }))

--- a/web/src/components/MeldFlow.tsx
+++ b/web/src/components/MeldFlow.tsx
@@ -3,7 +3,6 @@ import { type Suit, sortHandForDisplay } from '../engine/card'
 import { extractMeldCards, type MeldCardsResult } from '../engine/melds'
 import { teamOf, type Hands, type TeamId } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
-import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { PlayingCard } from './PlayingCard'
 import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
@@ -20,7 +19,6 @@ export interface MeldFlowProps {
   teamNames?: Record<TeamId, string>
   dealer: PlayerIndex
   onOpenMenu?: () => void
-  options?: GameOptions
   onComplete: (meldPointsByTeam: Record<TeamId, number>) => void
   onConcede?: () => void
 }
@@ -102,7 +100,6 @@ export function MeldFlow({
   teamNames = DEFAULT_TEAM_NAMES,
   dealer,
   onOpenMenu,
-  options = DEFAULT_OPTIONS,
   onComplete,
   onConcede,
 }: MeldFlowProps) {
@@ -206,7 +203,6 @@ export function MeldFlow({
       state={tableState}
       overlay={overlay}
       onOpenMenu={onOpenMenu}
-      hideOpponentCards={options.hideOpponentCards}
       exposeCards
     />
   )

--- a/web/src/components/OptionsPanel.test.tsx
+++ b/web/src/components/OptionsPanel.test.tsx
@@ -6,32 +6,40 @@ import { OptionsPanel } from './OptionsPanel'
 afterEach(cleanup)
 
 describe('OptionsPanel', () => {
-  it('reflects the current options in the two checkboxes', () => {
+  it('reflects the current options in the checkboxes and selects', () => {
     render(
       <OptionsPanel
-        options={{ hideOpponentCards: true, showBaseBidHint: false, opponentSkill: 'proficient', teammateSkill: 'hard', showMeldHint: false, hideTrickLog: true }}
+        options={{ showBaseBidHint: false, opponentSkill: 'proficient', teammateSkill: 'hard', showMeldHint: true, hideTrickLog: true }}
         onChange={() => {}}
         onClose={() => {}}
       />,
     )
-    expect((screen.getByLabelText('Hide opponent cards') as HTMLInputElement).checked).toBe(true)
     expect((screen.getByLabelText('Show base-bid hint') as HTMLInputElement).checked).toBe(false)
+    expect((screen.getByLabelText('Show meld breakdown') as HTMLInputElement).checked).toBe(true)
     expect((screen.getByLabelText('Opponents') as HTMLSelectElement).value).toBe('proficient')
     expect((screen.getByLabelText('Teammate') as HTMLSelectElement).value).toBe('hard')
   })
 
-  it('calls onChange with the hideOpponentCards toggle flipped, leaving the other field alone', () => {
+  // #142 removed the "Hide opponent cards" toggle — opponents' fans are now
+  // hidden unconditionally, so the panel must not offer a way back.
+  it('has no "Hide opponent cards" toggle', () => {
+    render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={() => {}} onClose={() => {}} />)
+    expect(screen.queryByLabelText('Hide opponent cards')).toBeNull()
+    expect(screen.queryByText(/hide opponent/i)).toBeNull()
+  })
+
+  it('calls onChange with the showMeldHint toggle flipped, leaving the other fields alone', () => {
     const onChange = vi.fn()
     render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={onChange} onClose={() => {}} />)
-    fireEvent.click(screen.getByLabelText('Hide opponent cards'))
-    expect(onChange).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS, hideOpponentCards: true, showBaseBidHint: true })
+    fireEvent.click(screen.getByLabelText('Show meld breakdown'))
+    expect(onChange).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS, showMeldHint: true, showBaseBidHint: true })
   })
 
   it('calls onChange with the showBaseBidHint toggle flipped', () => {
     const onChange = vi.fn()
     render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={onChange} onClose={() => {}} />)
     fireEvent.click(screen.getByLabelText('Show base-bid hint'))
-    expect(onChange).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS, hideOpponentCards: false, showBaseBidHint: false })
+    expect(onChange).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS, showBaseBidHint: false })
   })
 
   it('calls onClose from the Done button', () => {

--- a/web/src/components/OptionsPanel.tsx
+++ b/web/src/components/OptionsPanel.tsx
@@ -26,14 +26,6 @@ export function OptionsPanel({ options, onChange, onClose }: OptionsPanelProps) 
           <label className="flex items-center gap-2">
             <input
               type="checkbox"
-              checked={options.hideOpponentCards}
-              onChange={(e) => onChange({ ...options, hideOpponentCards: e.target.checked })}
-            />
-            Hide opponent cards
-          </label>
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
               checked={options.showBaseBidHint}
               onChange={(e) => onChange({ ...options, showBaseBidHint: e.target.checked })}
             />

--- a/web/src/components/Seat.test.tsx
+++ b/web/src/components/Seat.test.tsx
@@ -15,22 +15,34 @@ function opponentSeat(cardCount: number): SeatState {
 }
 
 describe('Seat', () => {
-  it('renders a face-down fan for an AI seat by default', () => {
+  // #142: the face-down fan is gone unconditionally — there is no prop that
+  // brings it back. Name and card count stay: the count is public
+  // information players use to track how many tricks are left.
+  it('renders no face-down fan for an AI seat, keeping its name and card count', () => {
     render(<Seat seat={opponentSeat(3)} position="left" isHuman={false} isBidWinner={false} isDealer={false} />)
-    expect(screen.getAllByLabelText('face-down card')).toHaveLength(3)
-    expect(screen.getByText('West')).not.toBeNull()
-  })
-
-  it('omits the face-down fan when hideOpponentHand is set (Options toggle, #54)', () => {
-    render(<Seat seat={opponentSeat(3)} position="left" isHuman={false} isBidWinner={false} isDealer={false} hideOpponentHand />)
     expect(screen.queryAllByLabelText('face-down card')).toHaveLength(0)
-    // The seat label/count stays visible — only the card fan is hidden.
     expect(screen.getByText('West')).not.toBeNull()
+    expect(screen.getByText('3 cards')).not.toBeNull()
   })
 
-  it('never hides the human seat, regardless of hideOpponentHand', () => {
+  it('still renders the human seat’s real hand face-up', () => {
     const humanSeat: SeatState = { player: 0, name: 'You', hand: [new Card(Suit.Hearts, 'A', 1)] }
-    render(<Seat seat={humanSeat} position="bottom" isHuman isBidWinner={false} isDealer={false} hideOpponentHand />)
+    render(<Seat seat={humanSeat} position="bottom" isHuman isBidWinner={false} isDealer={false} />)
     expect(screen.getByLabelText('A of H')).not.toBeNull()
+  })
+
+  // Meld is public information in Pinochle — it is laid down for everyone to
+  // see — so exposeCards must keep showing an AI seat's cards face-up even
+  // though the face-down fan is gone (#142).
+  it('exposes a non-human seat’s cards face-up when exposeCards is set (meld phase)', () => {
+    const meldSeat: SeatState = {
+      player: 1,
+      name: 'West',
+      hand: [new Card(Suit.Hearts, 'K', 1), new Card(Suit.Hearts, 'Q', 1)],
+    }
+    render(<Seat seat={meldSeat} position="left" isHuman={false} isBidWinner={false} isDealer={false} exposeCards />)
+    expect(screen.getByLabelText('K of H')).not.toBeNull()
+    expect(screen.getByLabelText('Q of H')).not.toBeNull()
+    expect(screen.queryAllByLabelText('face-down card')).toHaveLength(0)
   })
 })

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -1,5 +1,5 @@
 import type { Card } from '../engine/card'
-import { type Rank, sortHandForDisplay, Suit } from '../engine/card'
+import { sortHandForDisplay } from '../engine/card'
 import { PlayingCard } from './PlayingCard'
 import type { SeatPosition, SeatState } from './tableTypes'
 
@@ -15,20 +15,12 @@ export interface SeatProps {
    * Omit entirely to render the hand as plain, non-interactive cards (the
    * auction phases, or any AI seat). */
   playable?: { legalCards: readonly Card[]; onPlay: (card: Card) => void }
-  /** Options toggle (#54): when true, an AI seat renders only its name/card
-   * count — the face-down fan is skipped entirely to save screen space.
-   * No-op for the human seat, which always renders its real hand. */
-  hideOpponentHand?: boolean
   /** Meld phase (#??): when true, a non-human seat renders its cards face-up
-   * (meld cards laid on the table) instead of face-down or hidden. */
+   * (meld cards laid on the table) instead of just its name/card count. Meld
+   * is public information in Pinochle — it is laid down for everyone to see —
+   * so this is a rules requirement, not a display preference. */
   exposeCards?: boolean
 }
-
-// Placeholder face used for AI seats' face-down fan. The suit/rank props
-// are required by PlayingCard but are never rendered when faceDown is
-// set, so these values are arbitrary — no hidden information leaks here.
-const FACE_DOWN_SUIT: Suit = Suit.Spades
-const FACE_DOWN_RANK: Rank = '9'
 
 const POSITION_LAYOUT: Record<SeatPosition, string> = {
   bottom: 'flex-col items-center',
@@ -38,12 +30,14 @@ const POSITION_LAYOUT: Record<SeatPosition, string> = {
 }
 
 /**
- * One seat at the table. The human seat renders its full hand face-up
- * with the real `PlayingCard` component; AI seats render a face-down fan
- * sized to their card count — never the actual cards, since an AI's hand
- * is hidden information from the human player's point of view.
+ * One seat at the table. The human seat renders its full hand face-up with
+ * the real `PlayingCard` component. AI seats render no fan at all (#142) —
+ * just the name and card count in the header, which is the public
+ * information a player needs to track how many tricks are left. The one
+ * exception is `exposeCards` during the meld phase, where an AI's cards are
+ * laid face-up because meld is public.
  */
-export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable, hideOpponentHand, exposeCards }: SeatProps) {
+export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable, exposeCards }: SeatProps) {
   return (
     <div className={`flex gap-1 ${POSITION_LAYOUT[position]}`}>
       <div className="flex items-center gap-2 text-sm font-medium">
@@ -109,19 +103,7 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
             </div>
           ))}
         </div>
-      ) : hideOpponentHand ? null : (
-        <div className="flex overflow-x-auto px-2">
-          {seat.hand.map((_, i) => (
-            <PlayingCard
-              key={i}
-              suit={FACE_DOWN_SUIT}
-              rank={FACE_DOWN_RANK}
-              faceDown
-              className={`-ml-14 first:ml-0 ${i % 2 === 0 ? '-rotate-6' : 'rotate-6'}`}
-            />
-          ))}
-        </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -19,17 +19,12 @@ export interface TableProps {
    * started. Rendered as a small corner button; omitted entirely (no
    * button) when not provided. */
   onOpenMenu?: () => void
-  /** Options toggle (#54): when true, don't render the West/Partner/East
-   * face-down card fans at all — just the seat label and board, to save
-   * screen space. UI-only preference, not game state, so it lives here
-   * rather than on TableState. */
-  hideOpponentCards?: boolean
   /** 1-based trick number for display (e.g. "Trick 3 of 12"). Omitted outside
    * trick-play so TrickArea doesn't show a counter during the auction/meld
    * phases. */
   trickNumber?: number
   /** Meld phase: when true, non-human seats render their cards face-up (meld
-   * cards on the table) instead of face-down or hidden. */
+   * cards on the table) instead of just their name and card count. */
   exposeCards?: boolean
 }
 
@@ -46,7 +41,7 @@ const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
  * and trick-play controls (separate issues) will mount into this shell,
  * most likely inside/near the human seat and the TrickArea respectively.
  */
-export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards, trickNumber, exposeCards }: TableProps) {
+export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, exposeCards }: TableProps) {
   const { onMouseDown, onMouseMove, onMouseUp } = useDraggable()
 
   useEffect(() => {
@@ -109,7 +104,6 @@ export function Table({ state, overlay, logPanel, onOpenMenu, hideOpponentCards,
               isBidWinner={seat.player === bidWinner}
               isDealer={seat.player === state.dealer}
               playable={seat.player === humanPlayer ? humanPlayable : undefined}
-              hideOpponentHand={hideOpponentCards}
               exposeCards={seat.player !== humanPlayer ? exposeCards : undefined}
             />
           </div>

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -303,7 +303,6 @@ export function TrickPlayFlow({
           </div>
         }
         onOpenMenu={onOpenMenu}
-        hideOpponentCards={options.hideOpponentCards}
         trickNumber={state.trickNumber + 1}
       />
     </div>

--- a/web/src/persistence/options.test.ts
+++ b/web/src/persistence/options.test.ts
@@ -11,8 +11,8 @@ describe('options persistence', () => {
   })
 
   it('round-trips a saved options value', () => {
-    saveOptions({ hideOpponentCards: true, showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', showMeldHint: false, hideTrickLog: true })
-    expect(loadOptions()).toEqual({ hideOpponentCards: true, showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', showMeldHint: false, hideTrickLog: true })
+    saveOptions({ showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', showMeldHint: false, hideTrickLog: true })
+    expect(loadOptions()).toEqual({ showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', showMeldHint: false, hideTrickLog: true })
   })
 
   it('falls back to DEFAULT_OPTIONS on corrupt JSON', () => {
@@ -21,13 +21,13 @@ describe('options persistence', () => {
   })
 
   it('fills in missing/malformed fields from DEFAULT_OPTIONS rather than failing outright', () => {
-    window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ hideOpponentCards: true }))
+    window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ showMeldHint: true }))
     const loaded = loadOptions()
-    expect(loaded.hideOpponentCards).toBe(true)
+    expect(loaded.showMeldHint).toBe(true)
     expect(loaded.showBaseBidHint).toBe(true)
     expect(loaded.opponentSkill).toBe('hard')
     expect(loaded.teammateSkill).toBe('hard')
-    expect(loaded.showMeldHint).toBe(false)
+    expect(loaded.hideTrickLog).toBe(true)
 
     window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ opponentSkill: 42 }))
     const loaded2 = loadOptions()
@@ -35,5 +35,23 @@ describe('options persistence', () => {
 
     window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ showBaseBidHint: 'nope' }))
     expect(loadOptions()).toEqual(DEFAULT_OPTIONS)
+  })
+
+  // #142 removed `hideOpponentCards`, but the storage key is deliberately NOT
+  // bumped: a new key would reset everyone's surviving preferences (the skill
+  // levels especially). The leftover key must simply be ignored.
+  it('ignores a leftover hideOpponentCards key without disturbing the other saved preferences', () => {
+    window.localStorage.setItem(
+      'pinochle:options:v1',
+      JSON.stringify({ hideOpponentCards: true, opponentSkill: 'expert', teammateSkill: 'easy', showBaseBidHint: false }),
+    )
+    const loaded = loadOptions()
+    expect(loaded).toEqual({
+      ...DEFAULT_OPTIONS,
+      opponentSkill: 'expert',
+      teammateSkill: 'easy',
+      showBaseBidHint: false,
+    })
+    expect('hideOpponentCards' in loaded).toBe(false)
   })
 })

--- a/web/src/persistence/options.ts
+++ b/web/src/persistence/options.ts
@@ -11,10 +11,6 @@ const OPTIONS_KEY = 'pinochle:options:v1'
 export type SkillLevel = 'easy' | 'medium' | 'hard' | 'proficient' | 'expert'
 
 export interface GameOptions {
-  /** Hide the West/Partner/East face-down card fans (Seat.tsx) entirely —
-   * just player + board, to save screen space. Off (fans shown) by
-   * default, matching current behavior before this option existed. */
-  readonly hideOpponentCards: boolean
   /** Show BiddingControls' "Your hand suggests up to N" hint during the
    * human's bidding turn. On by default, matching current behavior. */
   readonly showBaseBidHint: boolean
@@ -33,7 +29,6 @@ export interface GameOptions {
 }
 
 export const DEFAULT_OPTIONS: GameOptions = {
-  hideOpponentCards: false,
   showBaseBidHint: true,
   opponentSkill: 'hard',
   teammateSkill: 'hard',
@@ -56,10 +51,13 @@ export function loadOptions(): GameOptions {
     if (!raw) return DEFAULT_OPTIONS
     const parsed: unknown = JSON.parse(raw)
     if (typeof parsed !== 'object' || parsed === null) return DEFAULT_OPTIONS
-    const { hideOpponentCards, showBaseBidHint, opponentSkill, teammateSkill, showMeldHint, hideTrickLog } = parsed as Partial<GameOptions>
+    // Destructures only the fields it knows about, so keys left behind by
+    // removed options (`hideOpponentCards`, dropped in #142) are ignored
+    // rather than migrated. That is why OPTIONS_KEY is *not* bumped when an
+    // option goes away: a new key would silently reset every player's
+    // surviving preferences — the skill levels especially.
+    const { showBaseBidHint, opponentSkill, teammateSkill, showMeldHint, hideTrickLog } = parsed as Partial<GameOptions>
     return {
-      hideOpponentCards:
-        typeof hideOpponentCards === 'boolean' ? hideOpponentCards : DEFAULT_OPTIONS.hideOpponentCards,
       showBaseBidHint: typeof showBaseBidHint === 'boolean' ? showBaseBidHint : DEFAULT_OPTIONS.showBaseBidHint,
       opponentSkill: parseSkill(opponentSkill, DEFAULT_OPTIONS.opponentSkill),
       teammateSkill: parseSkill(teammateSkill, DEFAULT_OPTIONS.teammateSkill),


### PR DESCRIPTION
AI seats no longer render a face-down fan under any circumstance, and the Options panel no longer has a switch for it.

## What the option actually was

`hideOpponentCards` was a **screen-space** setting, not a visibility one — AI seats rendered a *face-down* fan either way, so no card values were ever exposed by it. The toggle picked between the face-down fan (`false`, the old default) and name + card count only (`true`). This PR makes the `true` layout permanent and unconditional and deletes the setting.

**AI seats still show name + card count.** The count is public information players use to track how many tricks remain.

## Changes

| File | Change |
| --- | --- |
| `web/src/persistence/options.ts` | Drop `hideOpponentCards` from `GameOptions`, `DEFAULT_OPTIONS`, and the `loadOptions` parse |
| `web/src/components/OptionsPanel.tsx` | Remove the "Hide opponent cards" checkbox |
| `web/src/components/Seat.tsx` | Remove `hideOpponentHand`, the face-down fan branch, and the `FACE_DOWN_SUIT` / `FACE_DOWN_RANK` placeholder-face constants |
| `web/src/components/Table.tsx` | Remove the `hideOpponentCards` prop and its hand-off to `Seat` |
| `AuctionFlow.tsx`, `GameFlow.tsx`, `MeldFlow.tsx`, `TrickPlayFlow.tsx` | Remove the four `hideOpponentCards={options.hideOpponentCards}` call sites |

`MeldFlow`'s `options` prop had no other reader once that line went, so it is removed too (interface, destructure, and `GameFlow`'s pass) rather than left to trip `noUnusedLocals`. No behaviour rides on it — `showMeldHint` was already unwired there before this PR.

## `exposeCards` is untouched

`Seat.tsx`'s `exposeCards` looks similar but does something different: it lays a non-human seat's cards **face-up during meld**, because meld is public information in Pinochle — you lay it down and everyone sees it. Removing it would have been a rules change, not a UI change. It still works, and `Seat.test.tsx` now has a test pinning that behaviour, which it did not have before.

Scope note, per the issue's flagged assumption: "permanently hidden" here means the face-down fan during auction and trick play. Meld stays visible when laid down. Hiding opponents' meld would be a rules change and needs its own decision.

## Persistence — storage key deliberately unchanged

`OPTIONS_KEY` stays `pinochle:options:v1`. Verified in the code rather than assumed: `loadOptions` destructures named fields off the parsed object, so a `hideOpponentCards` key left in an existing save is simply never read. Bumping the key would have silently reset every player's *other* preferences — the skill levels especially — which is a worse bug than the one it would avoid. There is a comment on the destructure recording this, plus a test that seeds a leftover key alongside custom skill levels and asserts the survivors come back intact.

## Tests

- **Python: 288 passed** (unchanged — this PR is web-only).
- **Web: 327 passed, up from 325.** Two net additions:
  - `OptionsPanel.test.tsx` +1 — a regression guard asserting the panel offers no "Hide opponent cards" control. The two existing toggle tests were rewritten onto surviving options rather than deleted (the `hideOpponentCards` flip test became a `showMeldHint` flip test, which had no coverage before), so the "flipping one field leaves the others alone" coverage survives.
  - `options.test.ts` +1 — the leftover-key test described above. The partial-object test was reseeded onto a surviving field.
  - `Seat.test.tsx` is net zero: the "renders a face-down fan by default" and "omits it when `hideOpponentHand` is set" pair collapsed into one inverted test ("renders no fan, keeps name and card count"), and the slot freed up went to the new `exposeCards` meld test.
  - `GameShell.test.tsx` net zero: the "toggling Hide opponent cards affects the next game" test became "never renders opponents' fans, and offers no option to show them".
- `npm run build` (`tsc -b && vite build`) is clean, which matters here since a field was removed from a shared interface.
- `npm run lint` reports the same 3 pre-existing `exhaustive-deps` warnings as `main` — verified against a stashed baseline, nothing new.

Closes #142
