### PR TITLE
docs: the app is live on Netlify; record that merging does not ship

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -37,12 +37,19 @@ Cross-cutting technical structure, not any single feature:
 - PWA and build structure, per `web/vite.config.ts` (the `base` path,
   `vite-plugin-pwa`'s manifest and Workbox service worker). Flag
   anything that would break the build or the app-shell precache.
-  **The app is not hosted anywhere** — GitHub is source control only by
-  decision (2026-08-01), so there is no deploy pipeline and "shipped"
-  means merged. Do not propose work that assumes a live URL, and do not
-  re-add a deploy workflow without Paul asking for one. If a host is
-  ever chosen, `base` must match the path it serves from, and a host
-  that cannot set COOP/COEP headers rules out multi-threaded Wasm.
+  The app is hosted on **Netlify**, live at
+  <https://pinochle-house-rulez.netlify.app>, configured by `netlify.toml`.
+  **Deploys are manual and merging does not ship** — the repo is
+  deliberately not git-connected (GitHub is source control only, decided
+  2026-08-01). Do not re-add a deploy workflow or wire up continuous
+  deployment without Paul asking; that is the coupling #141 removed.
+  When judging whether a change reached players, check the deployed
+  asset hash, not whether the PR merged.
+  Two things that must move together: `base` in `vite.config.ts` and the
+  manifest's `id`/`start_url`/`scope` — #141 changed one and not the
+  other, which left an installed app launching into a 404 and was
+  invisible until #143 caught it. COOP/COEP are available on Netlify if
+  multi-threaded Wasm is ever wanted; they are off deliberately.
 - Dev specs / conventions that don't obviously belong to Design or QA.
 
 Explicitly not your lens: game rules/balance (Design), coding style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,11 @@ Partnership Pinochle, in two implementations that are not peers:
 
 - **`web/` — the TypeScript PWA, and the product.** React + TS + Vite +
   Tailwind. The rules engine is `web/src/engine/`. New player-visible
-  work lands here. **Not currently hosted anywhere** — GitHub holds the
-  code only, and there is no deploy pipeline. Run it locally with
-  `npm run dev`. A change is shipped when it is merged, not deployed.
+  work lands here. Live at <https://pinochle-house-rulez.netlify.app>.
+  **Merging does not ship.** GitHub is source control only; the repo is
+  deliberately not git-connected to Netlify. Deploys are manual — build
+  `web/`, then `npx netlify deploy --prod` from the repo root. Assume a
+  merged change is *not* live unless someone deployed it.
 - **`pinochle_engine.py` — Python, the reference implementation *and*
   the AI-research and measurement harness.** Both roles are live. It
   implements the same rules end-to-end, it is what the TS port is

--- a/README.md
+++ b/README.md
@@ -1,22 +1,40 @@
 # Pinochle
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/8da01171-1d8b-4cbe-849e-4ef994fc0b68/deploy-status)](https://app.netlify.com/projects/pinochle-house-rulez/deploys)
+
 A Partnership Pinochle game, built from scratch: a TypeScript PWA, plus
 a Python reference implementation that doubles as the AI-research and
 measurement harness.
 
 ## Status
 
+**Play it: <https://pinochle-house-rulez.netlify.app>**
+
 The PWA in [`web/`](web/) is the product — a complete game against three
 AI opponents: deal, misdeal, auction, trump, 3-card pass, meld, trick
 play, round scoring, and multi-round games to ±1000, across five
-difficulty levels, with local autosave across a page reload.
+difficulty levels, with local autosave across a page reload. On a phone
+it installs to the home screen and launches full-screen.
 
-**It is not currently hosted anywhere.** GitHub holds the code only —
-there is no deploy pipeline and no public URL. Run it locally with
-`npm run dev` in [`web/`](web/); see [`web/README.md`](web/README.md).
-The manifest and service worker are still built, so the app stays
-installable from wherever it is eventually served — but "Add to Home
-Screen" needs a real host, so it is unavailable until there is one.
+**Deploys are manual, and merging does not ship.** GitHub is source
+control only — the repo is deliberately not connected to Netlify's git
+integration (see [`netlify.toml`](netlify.toml) and the 2026-08-01
+decision in [`ROADMAP.md`](ROADMAP.md)). A merged PR is not live until
+someone builds and deploys:
+
+```
+cd web && npm ci && npm run build
+cd .. && npx netlify deploy --prod
+```
+
+Run the deploy from the repo root — `publish` in `netlify.toml` resolves
+relative to that file. To run the app locally instead, `npm run dev` in
+[`web/`](web/); see [`web/README.md`](web/README.md).
+
+The badge above reports the last deploy Netlify processed. Since nothing
+builds on their servers it is a thin signal — it says an upload
+succeeded, not that `main` is live. Compare the deployed asset hash
+against a local build if you need to know what is actually out there.
 
 The Python side has two live roles: it is the reference implementation
 the TypeScript port is checked against, *and* the harness all the AI
@@ -47,8 +65,8 @@ is where the next round of strategy work will run. See
 ## Contents
 
 - [`web/`](web/) — **the product**: the React + TypeScript + Vite +
-  Tailwind PWA. Run locally; not currently hosted. Has its own
-  [`web/README.md`](web/README.md). Inside it:
+  Tailwind PWA, deployed to <https://pinochle-house-rulez.netlify.app>.
+  Has its own [`web/README.md`](web/README.md). Inside it:
   - `src/engine/` — the TypeScript rules engine, split one file per
     concern (`card.ts`, `melds.ts`, `bidding.ts`, `passing.ts`,
     `trick.ts`, `tracker.ts`, `round.ts`, `game.ts`, `misdeal.ts`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,18 +40,33 @@ Stack: **React + TypeScript + Vite + Tailwind CSS**, PWA via
 polished UI without heavy build overhead, and first-class PWA tooling on
 top of Vite.
 
-**Hosting: none, by decision (2026-08-01).** The app was served from
-GitHub Pages from 2026-07-31; Paul removed that deployment the next day,
-scoping GitHub to source control only. There is no deploy pipeline and
-no public URL — run it locally with `npm run dev`. "Shipped" in this
-document therefore means *merged to `main`*, not deployed.
+**Hosting: Netlify, manual deploys (2026-08-01).** Live at
+<https://pinochle-house-rulez.netlify.app>.
 
-Choosing a host is deliberately left open. Two constraints for whoever
-picks one up: `base` in `web/vite.config.ts` is `/` and must match the
-path the build is served under, and a host that cannot set COOP/COEP
-response headers rules out `SharedArrayBuffer`, and so rules out
-multi-threaded WebAssembly if browser-side rollouts are ever attempted
-(see Open questions).
+Two moves in one day, and the reasoning matters more than the dates. The
+app was served from GitHub Pages from 2026-07-31; Paul removed that
+deployment the next day (#141), scoping GitHub to source control only.
+It moved to Netlify hours later (#143/#144) for a specific reason: the
+alternative on the table was mailing a single self-contained HTML file,
+and that does not work on iOS — Quick Look does not execute JavaScript.
+Reliable `localStorage` and Add to Home Screen both require a real
+`https` origin, which is what hosting actually buys here. Sharing was
+never the constraint; persistence was.
+
+**Merging does not ship.** The repo is deliberately *not* connected to
+Netlify's git integration — that would rebuild the coupling #141
+removed, in a different service. Deploys are manual from a locally built
+`web/dist` (`npx netlify deploy --prod` from the repo root; see
+`netlify.toml`). "Shipped" in this document means merged to `main`; a
+change reaches players only when someone deploys.
+
+Two standing constraints: `base` in `web/vite.config.ts` must match the
+path the build is served under — and the manifest's `id`/`start_url`/
+`scope` must move with it, which #143 caught after #141 missed it and
+left an installed app launching into a 404. Second, COOP/COEP headers
+would be needed for `SharedArrayBuffer` and multi-threaded WebAssembly;
+Netlify *can* set them (GitHub Pages could not), and they are off
+because nothing needs them yet (see Open questions).
 
 1. **Decisions** — done. Opening-bid mismatch resolved (engine value,
    300 min / 250 forced, is canonical; `pinochle_rules.md` updated to

--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -168,9 +168,10 @@ There are two implementations of the rules above, and they are not
 peers:
 
 - **TypeScript, `web/src/engine/` — the shipped one.** The PWA is the
-  product, and a rule that is wrong here is wrong for players. It is not
-  currently hosted anywhere — GitHub holds the code only — so "shipped"
-  means merged to `main`, not deployed.
+  product, and a rule that is wrong here is wrong for players. It is live
+  at <https://pinochle-house-rulez.netlify.app>, but deploys are manual —
+  merging to `main` does not publish anything, so a rules fix reaches
+  players only once someone deploys.
 - **Python, `pinochle_engine.py` — the reference implementation, and
   the research harness.** It implements all of the above end-to-end and
   is tested (deal integrity, legal-move filtering, meld edge cases,

--- a/web/README.md
+++ b/web/README.md
@@ -1,9 +1,10 @@
 # Pinochle — web client
 
 The product — React + TypeScript + Vite + Tailwind CSS. A complete game
-against three AI opponents. **Not currently hosted anywhere**: GitHub holds
-the code only, there is no deploy pipeline, and there is no public URL. Run
-it locally with `npm run dev`.
+against three AI opponents. Live at
+<https://pinochle-house-rulez.netlify.app>. Run it locally with
+`npm run dev`; **deploys are manual and merging does not ship** — see
+"PWA / deployment" below.
 
 The rules engine (`src/engine/`) is a TypeScript port of the Python
 reference implementation (`../pinochle_engine.py`). Both sides are active
@@ -184,12 +185,17 @@ input to `vite build`, so it cannot reach a player or the PWA precache.
   `public/apple-touch-icon.png` are placeholder icons (solid color, generated
   programmatically) — swap for real art whenever it exists; they just need to
   keep the same filenames/sizes referenced in `vite.config.ts`.
-- **There is no automatic deploy pipeline, and no site yet.** The app was
-  served from GitHub Pages from 2026-07-31 until 2026-08-01, when that was
-  removed by decision — GitHub is source control only and `.github/` no
-  longer exists. What replaces it is a *manual* target, described next: the
-  config is committed, but no Netlify site exists yet (#144), so there is
-  still no public URL.
+- **There is no automatic deploy pipeline.** The app was served from GitHub
+  Pages from 2026-07-31 until 2026-08-01, when that was removed by decision
+  — GitHub is source control only and `.github/` no longer exists. It now
+  lives on Netlify at <https://pinochle-house-rulez.netlify.app>, deployed
+  manually. **A merged PR is not live.** To check what is actually deployed,
+  compare the asset hash in the served `index.html` against a local build:
+
+  ```
+  curl -s https://pinochle-house-rulez.netlify.app/ | grep -o 'src="/assets/[^"]*"'
+  grep -o 'src="/assets/[^"]*"' dist/index.html
+  ```
 - **Deploying to Netlify (manual).** `netlify.toml` at the repo root sets
   `publish = "web/dist"` and nothing else build-related. The repo is
   deliberately **not** connected to Netlify's git integration — a


### PR DESCRIPTION
Site is up: **<https://pinochle-house-rulez.netlify.app>**

Updates the six docs that said the app was not hosted anywhere — true for a few hours between #141 removing GitHub Pages and #144 creating the Netlify site.

## The point that actually matters

**Deploys are manual, so merging to `main` no longer ships.** Under GitHub Pages a merge deployed itself. Under Netlify-without-a-git-connection it does not, and from the repo side a stale live build looks identical to a current one. That inversion is the thing most likely to bite, so every doc states it plainly rather than just naming the host.

`README.md` and `web/README.md` also give the check for what is *actually* deployed:

```
curl -s https://pinochle-house-rulez.netlify.app/ | grep -o 'src="/assets/[^"]*"'
grep -o 'src="/assets/[^"]*"' dist/index.html
```

## Why hosting came back

`ROADMAP.md` records the reasoning, because "removed hosting, then added hosting the same day" reads like a reversal without it. The alternative on the table was mailing a single self-contained HTML file, and that does not work on iOS — Quick Look does not execute JavaScript. Reliable `localStorage` and Add to Home Screen both require a real `https` origin. **Sharing was never the constraint; persistence was.**

The GitHub decision is unchanged and restated: source control only, no git integration, no workflow.

## architect.md

Gains the pairing #141 got wrong: `base` in `vite.config.ts` and the manifest's `id`/`start_url`/`scope` must move together. #141 changed one and not the other, leaving an installed app launching into a 404 — invisible in a browser tab, which is why it survived until #143 caught it. Also told to judge "did this reach players" by the deployed asset hash rather than by the PR being merged.

## Badge

Added to `README.md` as requested, with a caveat: it reports the last deploy Netlify processed, not whether `main` is live. Nothing builds on their servers, so it is a thinner signal than a CI badge appears to be.

Docs only — no code, no tests affected.