### PR TITLE
Remove the dead showMeldHint option (#148)

### DIFF
--- a/web/src/components/MeldFlow.test.tsx
+++ b/web/src/components/MeldFlow.test.tsx
@@ -60,6 +60,31 @@ describe('MeldFlow', () => {
     expect(within(them).queryByText(/You/)).toBeNull()
   })
 
+  // #148: `showMeldHint` was an Options toggle meant to gate this breakdown,
+  // but it was never wired — the breakdown always rendered. Since the option
+  // defaulted to *off*, honouring it would have hidden from every player what
+  // they can already see, so the option was deleted and the display kept.
+  // MeldFlow takes no `options` prop at all now: there is nothing to gate on.
+  it('shows every seat’s melds by name, points and cards, ungated by any option', () => {
+    renderMeld()
+
+    // Each seat holds K♥/Q♥ with hearts trump — one Royal Marriage, 40 points.
+    for (const name of ['Us meld', 'Them meld']) {
+      const column = screen.getByRole('region', { name })
+      const labels = within(column).getAllByText('Royal Marriage')
+
+      // Both of the column's seats name the meld...
+      expect(labels).toHaveLength(2)
+      // ...and show its point value right alongside the name.
+      for (const label of labels) {
+        expect(label.parentElement?.textContent).toContain('40')
+      }
+      // ...and the actual cards that make the meld up.
+      expect(within(column).getAllByLabelText('K of H')).toHaveLength(2)
+      expect(within(column).getAllByLabelText('Q of H')).toHaveLength(2)
+    }
+  })
+
   it('renders meld cards at the compact size so four seats fit on screen (#94)', () => {
     renderMeld()
     const cards = screen.getAllByRole('img').filter((el) => el.closest('section[aria-label$="meld"]'))

--- a/web/src/components/OptionsPanel.test.tsx
+++ b/web/src/components/OptionsPanel.test.tsx
@@ -9,13 +9,14 @@ describe('OptionsPanel', () => {
   it('reflects the current options in the checkboxes and selects', () => {
     render(
       <OptionsPanel
-        options={{ showBaseBidHint: false, opponentSkill: 'proficient', teammateSkill: 'hard', showMeldHint: true, hideTrickLog: true }}
+        options={{ showBaseBidHint: false, opponentSkill: 'proficient', teammateSkill: 'hard', hideTrickLog: false }}
         onChange={() => {}}
         onClose={() => {}}
       />,
     )
     expect((screen.getByLabelText('Show base-bid hint') as HTMLInputElement).checked).toBe(false)
-    expect((screen.getByLabelText('Show meld breakdown') as HTMLInputElement).checked).toBe(true)
+    // The trick-log checkbox is phrased positively, so it reads the inverse of the field.
+    expect((screen.getByLabelText('Show trick-play log') as HTMLInputElement).checked).toBe(true)
     expect((screen.getByLabelText('Opponents') as HTMLSelectElement).value).toBe('proficient')
     expect((screen.getByLabelText('Teammate') as HTMLSelectElement).value).toBe('hard')
   })
@@ -28,11 +29,21 @@ describe('OptionsPanel', () => {
     expect(screen.queryByText(/hide opponent/i)).toBeNull()
   })
 
-  it('calls onChange with the showMeldHint toggle flipped, leaving the other fields alone', () => {
+  // #148 removed the "Show meld breakdown" toggle. It gated nothing: MeldFlow
+  // renders the per-meld breakdown unconditionally (see MeldFlow.test.tsx), so
+  // honouring the off-by-default option would have *hidden* what players
+  // already see. The panel must not offer the dead control again.
+  it('has no "Show meld breakdown" toggle', () => {
+    render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={() => {}} onClose={() => {}} />)
+    expect(screen.queryByLabelText('Show meld breakdown')).toBeNull()
+    expect(screen.queryByText(/meld/i)).toBeNull()
+  })
+
+  it('calls onChange with the trick-log toggle flipped, leaving the other fields alone', () => {
     const onChange = vi.fn()
     render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={onChange} onClose={() => {}} />)
-    fireEvent.click(screen.getByLabelText('Show meld breakdown'))
-    expect(onChange).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS, showMeldHint: true, showBaseBidHint: true })
+    fireEvent.click(screen.getByLabelText('Show trick-play log'))
+    expect(onChange).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS, hideTrickLog: false, showBaseBidHint: true })
   })
 
   it('calls onChange with the showBaseBidHint toggle flipped', () => {

--- a/web/src/components/OptionsPanel.tsx
+++ b/web/src/components/OptionsPanel.tsx
@@ -34,14 +34,6 @@ export function OptionsPanel({ options, onChange, onClose }: OptionsPanelProps) 
           <label className="flex items-center gap-2">
             <input
               type="checkbox"
-              checked={options.showMeldHint}
-              onChange={(e) => onChange({ ...options, showMeldHint: e.target.checked })}
-            />
-            Show meld breakdown
-          </label>
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
               checked={!options.hideTrickLog}
               onChange={(e) => onChange({ ...options, hideTrickLog: !e.target.checked })}
             />

--- a/web/src/persistence/options.test.ts
+++ b/web/src/persistence/options.test.ts
@@ -11,8 +11,8 @@ describe('options persistence', () => {
   })
 
   it('round-trips a saved options value', () => {
-    saveOptions({ showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', showMeldHint: false, hideTrickLog: true })
-    expect(loadOptions()).toEqual({ showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', showMeldHint: false, hideTrickLog: true })
+    saveOptions({ showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', hideTrickLog: true })
+    expect(loadOptions()).toEqual({ showBaseBidHint: false, opponentSkill: 'easy', teammateSkill: 'expert', hideTrickLog: true })
   })
 
   it('falls back to DEFAULT_OPTIONS on corrupt JSON', () => {
@@ -21,13 +21,12 @@ describe('options persistence', () => {
   })
 
   it('fills in missing/malformed fields from DEFAULT_OPTIONS rather than failing outright', () => {
-    window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ showMeldHint: true }))
+    window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ hideTrickLog: false }))
     const loaded = loadOptions()
-    expect(loaded.showMeldHint).toBe(true)
+    expect(loaded.hideTrickLog).toBe(false)
     expect(loaded.showBaseBidHint).toBe(true)
     expect(loaded.opponentSkill).toBe('hard')
     expect(loaded.teammateSkill).toBe('hard')
-    expect(loaded.hideTrickLog).toBe(true)
 
     window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ opponentSkill: 42 }))
     const loaded2 = loadOptions()
@@ -37,13 +36,21 @@ describe('options persistence', () => {
     expect(loadOptions()).toEqual(DEFAULT_OPTIONS)
   })
 
-  // #142 removed `hideOpponentCards`, but the storage key is deliberately NOT
-  // bumped: a new key would reset everyone's surviving preferences (the skill
-  // levels especially). The leftover key must simply be ignored.
-  it('ignores a leftover hideOpponentCards key without disturbing the other saved preferences', () => {
+  // #142 removed `hideOpponentCards` and #148 removed `showMeldHint`, but the
+  // storage key is deliberately NOT bumped: a new key would reset everyone's
+  // surviving preferences (the skill levels especially). Leftover keys from
+  // both removals must simply be ignored, including in the same payload — a
+  // save written before either removal carries both.
+  it('ignores leftover keys from removed options without disturbing the other saved preferences', () => {
     window.localStorage.setItem(
       'pinochle:options:v1',
-      JSON.stringify({ hideOpponentCards: true, opponentSkill: 'expert', teammateSkill: 'easy', showBaseBidHint: false }),
+      JSON.stringify({
+        hideOpponentCards: true,
+        showMeldHint: true,
+        opponentSkill: 'expert',
+        teammateSkill: 'easy',
+        showBaseBidHint: false,
+      }),
     )
     const loaded = loadOptions()
     expect(loaded).toEqual({
@@ -53,5 +60,6 @@ describe('options persistence', () => {
       showBaseBidHint: false,
     })
     expect('hideOpponentCards' in loaded).toBe(false)
+    expect('showMeldHint' in loaded).toBe(false)
   })
 })

--- a/web/src/persistence/options.ts
+++ b/web/src/persistence/options.ts
@@ -18,10 +18,6 @@ export interface GameOptions {
   readonly opponentSkill: SkillLevel
   /** AI skill level for the human's teammate (#79). */
   readonly teammateSkill: SkillLevel
-  /** Show the per-card meld breakdown list in MeldFlow. Off by default
-   * (just shows total points) — players who want to verify the AI's meld
-   * detection can turn it on. */
-  readonly showMeldHint: boolean
   /** Hide the trick-play event log (card plays, trick winners). Default on
    * (#81) so the table is less cluttered; turn off to see every play logged
    * in the right-hand panel. The bid/auction history is always shown. */
@@ -32,7 +28,6 @@ export const DEFAULT_OPTIONS: GameOptions = {
   showBaseBidHint: true,
   opponentSkill: 'hard',
   teammateSkill: 'hard',
-  showMeldHint: false,
   hideTrickLog: true,
 }
 
@@ -52,16 +47,16 @@ export function loadOptions(): GameOptions {
     const parsed: unknown = JSON.parse(raw)
     if (typeof parsed !== 'object' || parsed === null) return DEFAULT_OPTIONS
     // Destructures only the fields it knows about, so keys left behind by
-    // removed options (`hideOpponentCards`, dropped in #142) are ignored
-    // rather than migrated. That is why OPTIONS_KEY is *not* bumped when an
-    // option goes away: a new key would silently reset every player's
-    // surviving preferences — the skill levels especially.
-    const { showBaseBidHint, opponentSkill, teammateSkill, showMeldHint, hideTrickLog } = parsed as Partial<GameOptions>
+    // removed options (`hideOpponentCards`, dropped in #142; `showMeldHint`,
+    // dropped in #148) are ignored rather than migrated. That is why
+    // OPTIONS_KEY is *not* bumped when an option goes away: a new key would
+    // silently reset every player's surviving preferences — the skill levels
+    // especially.
+    const { showBaseBidHint, opponentSkill, teammateSkill, hideTrickLog } = parsed as Partial<GameOptions>
     return {
       showBaseBidHint: typeof showBaseBidHint === 'boolean' ? showBaseBidHint : DEFAULT_OPTIONS.showBaseBidHint,
       opponentSkill: parseSkill(opponentSkill, DEFAULT_OPTIONS.opponentSkill),
       teammateSkill: parseSkill(teammateSkill, DEFAULT_OPTIONS.teammateSkill),
-      showMeldHint: typeof showMeldHint === 'boolean' ? showMeldHint : DEFAULT_OPTIONS.showMeldHint,
       hideTrickLog: typeof hideTrickLog === 'boolean' ? hideTrickLog : DEFAULT_OPTIONS.hideTrickLog,
     }
   } catch {


### PR DESCRIPTION
`showMeldHint` is gone: the field, the `DEFAULT_OPTIONS` entry, the `loadOptions` parse, the Options checkbox, and its docstring. **The meld breakdown itself is untouched and still renders for every player.**

## Why delete rather than wire it up

The issue body proposed wiring it up; its comment corrects that, and this PR follows the correction.

The feature the option was meant to gate already shipped, always-on. `MeldGroupList` (`MeldFlow.tsx:26`) renders each meld's name, its points, and the actual cards, and the team column calls it with no gate on any option:

```tsx
{md.groups.length > 0 ? (
  <MeldGroupList groups={md.groups} />
) : (
  <p ...>No melds</p>
)}
```

`DEFAULT_OPTIONS.showMeldHint` was `false`. So honouring the option would have **hidden the breakdown by default** — stripping information every player currently sees, to respect a preference nobody was ever able to set. That is a regression dressed as a bug fix. The gate goes; the display stays.

The docstring ("Off by default (just shows total points) — players who want to verify the AI's meld detection can turn it on") described an intent the implementation overtook, so it goes with the field.

## Changes

| File | Change |
| --- | --- |
| `web/src/persistence/options.ts` | Drop `showMeldHint` from `GameOptions`, `DEFAULT_OPTIONS`, and the `loadOptions` parse (destructure + defaulting line) |
| `web/src/components/OptionsPanel.tsx` | Remove the "Show meld breakdown" checkbox |

`MeldFlow.tsx` is **not** in that table, deliberately. No production file read the option, so nothing needed re-threading — the removal never reaches the rendering path.

## Persistence — storage key deliberately unchanged

`OPTIONS_KEY` stays `pinochle:options:v1`, per #142's precedent. Confirmed in the code rather than assumed: `loadOptions` destructures named fields off the parsed object, so a `showMeldHint` key left in an existing save is simply never read. Bumping the key would silently reset every player's surviving preferences — the skill levels especially — which is a far worse bug than the one it would avoid.

The comment on the destructure now records both removals (#142 and #148), and #142's leftover-key test was **extended rather than duplicated**: it seeds `hideOpponentCards` *and* `showMeldHint` in one payload (which is what a save written before either removal actually looks like) alongside custom skill levels, and asserts the survivors come back intact and neither dead key appears on the result.

## Tests

- **Python: 288 passed** (unchanged — this PR is web-only).
- **Web: 329 passed, up from 327.** Two net additions, no deletions:
  - `MeldFlow.test.tsx` +1 — the point of the PR, pinned: for both team columns, each of the two seats names its meld ("Royal Marriage"), shows the point value alongside the name, and shows the cards making it up. The suite had layout and card-size coverage but nothing asserting the breakdown's *content*, which is exactly the behaviour this issue is about keeping. Verified it is a real guard by stubbing out the `MeldGroupList` call site — the test fails, then passes again on restore.
  - `OptionsPanel.test.tsx` +1 — a regression guard asserting the panel offers no "Show meld breakdown" control, mirroring #142's `hideOpponentCards` guard.
  - The reassigned tests were updated, not deleted. #142 had rewritten `OptionsPanel.test.tsx`'s flip test onto `showMeldHint` precisely because it lacked coverage; it now flips `hideTrickLog` instead, preserving the "flipping one field leaves the others alone" assertion on a surviving option (and picking up the one remaining checkbox that had no flip test). The "reflects the current options" and `options.test.ts` partial-object cases were likewise reseeded onto surviving fields.
- `npm run build` (`tsc -b && vite build`) is clean, which matters here since a field was removed from a shared interface.
- `npm run lint` reports the same 3 pre-existing `exhaustive-deps` warnings as `main` — nothing new.

Closes #148
