### PR TITLE
chore: gitignore .netlify/ CLI scratch state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ venv/
 .pytest_cache/
 *.egg-info/
 game_state.pkl
+
+# Netlify CLI scratch state, written on every `netlify deploy`. Local
+# artifact only — the committed config is the root `netlify.toml`.
+.netlify/


### PR DESCRIPTION
`netlify deploy` writes a `.netlify/` directory into the repo root on every run. It is local build/deploy state, not configuration — the committed config is the root `netlify.toml`.

Now that deploys are routine it would otherwise show as untracked noise in every `git status`.

One line in `.gitignore`, no code.