### PR TITLE
feat(ab): play-policy A/B dial so trick play can be measured (#153)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -109,13 +109,17 @@ a bootstrap interval on score margin because games-won alone is too coarse.
 ```
 node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts selftest --pairs 100
 node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts ab --pairs 1000
+node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts fold --pairs 1000
+node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts play --pairs 1000
 node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts latency --positions 4000
 ```
 
-Run `selftest` before believing `ab`: one policy against itself must find
+Run `selftest` before believing any of them: one policy against itself must find
 nothing, and here it must find *exactly* nothing — with the same policy in all
 four seats the mirrored orientations are the same game relabelled, so every pair
-splits and every paired margin is zero. `ab.test.ts` asserts that in the suite.
+splits and every paired margin is zero. `ab.test.ts` asserts that in the suite,
+for every arm of every dial. `--policy` picks which arm doubles up:
+`static`/`distilled` are the bidding pair, `simple`/`cascade` the trick-play one.
 
 What it found, over 1000 pairs / 2000 games: distilled swept 211 deals to
 static's 50 (739 split), 95% CI 75.6%–85.2% of decisive deals, p < 1e-4, and
@@ -165,6 +169,62 @@ temporary fourth field on `SkillParams` plus a `PARITY_AB_POLICIES` pair, added
 for the measurement in the shape `FOLD_AB_POLICIES` already uses and removed
 before the fix was committed, since a permanent switch for "play the port bug"
 is not a difficulty setting.
+
+### The trick-play dial (`playPolicy`, #153)
+
+Card play was the one phase never measured — #105, #115, #123 and #126 are all
+bidding or folding — so every heuristic in `tracker.ts` was there on reasoning
+alone. `SkillParams.playPolicy` is the field that fixed that, and epic #152's
+remaining children are each a change to it that has to be measured before it
+ships.
+
+It has two arms and both already shipped: `'cascade'` is the ported Proficient
+strategy (`chooseLeadCard`'s safe-card cascade, `chooseFollowCard`'s tiers) and
+`'simple'` is `easy`'s shortcut — lead the lowest non-trump non-counter, follow
+with the lowest legal card. The field is an extraction of the
+`handValuation === 'meld_only'` test that used to gate card play inside
+`tracker.ts`, and `SKILL_PARAMS` reproduces that mapping exactly, so introducing
+it changed no behaviour. Splitting it off `handValuation` is what makes #156
+("one card-play strategy at every level") expressible at all: that flag also
+governs *bidding* valuation, so while the two shared it, changing easy's card
+play meant changing how easy bids in the same breath.
+
+`PLAY_AB_POLICIES` is the pair `cli.ts play` installs. Over 1000 pairs / 2000
+games, cascade swept 158 deals to simple's 37 (805 split), 95% CI 74.9%–85.9%,
+p < 1e-4, **+121 score margin per deal, 95% CI +103 to +138** — cascade makes
+68.5% of its contracts against simple's 64.5% on the same deals and the same
+bids. That is a reading of the gap the dial spans, not a decision: acting on it
+is #156's job.
+
+### Checking that a dial can see a change
+
+A self-test proves a dial reports nothing when nothing differs. It does not
+prove the dial can see anything, and those fail differently: a policy field that
+is written but never read passes `selftest` perfectly and then returns a null
+result for every change ever made through it. So before trusting a new dial,
+point it at a policy that is known to be bad and confirm the harness says so.
+
+The procedure, which is deliberately not in the tree — #126 established it with
+the temporary `parity` dial it removed before committing, on the grounds that a
+permanent "play badly" switch is not a difficulty setting:
+
+1. Add a throwaway arm to the policy union in `skills.ts` — for trick play,
+   `'highest'`.
+2. Give it a one-line implementation at the top of the branch it is testing. For
+   #153 that was `return maxByRank(hand)` in `chooseLeadCard` and
+   `return maxByRank(legalMoves)` in `chooseFollowCard`: always play the highest
+   card available, which dumps counters into opponents' tricks and strips your
+   own trump control.
+3. Copy the real policy map, change that one field on side B, and add a
+   temporary `cli.ts` command that runs it.
+4. Run it at the size a real measurement uses, then delete all four edits.
+
+What #153 got, 1000 pairs / 2000 games: cascade swept 224 deals to highest's 11
+(765 split), 95% CI 91.8%–97.4% of the 235 decisive deals, p < 1e-4, **+202
+score margin per deal, 95% CI +184 to +220**. Highest is set on 32.4% of its
+contracts against cascade's 24.9% from the same bids on the same deals. A dial
+that can separate those by 202 points and separate a policy from itself by
+exactly 0 is one a null result from can be believed.
 
 `bench/index.html` is the browser side of the latency measurement, served by
 `npm run dev` at `/bench/` (it follows `base`, which is `/`). It is never an

--- a/web/src/ab/ab.test.ts
+++ b/web/src/ab/ab.test.ts
@@ -17,8 +17,10 @@ import { SKILL_PARAMS } from '../engine/skills'
 import type { PlayerIndex } from '../engine/trick'
 import type { SkillLevel } from '../persistence/options'
 import {
+  BID_AB_POLICIES,
   DISTILLED_LEVEL,
   FOLD_AB_POLICIES,
+  PLAY_AB_POLICIES,
   STATIC_LEVEL,
   analyse,
   installPolicies,
@@ -84,6 +86,42 @@ describe('the policy override', () => {
     expect(SKILL_PARAMS[DISTILLED_LEVEL].handValuation).toBe('base_bid')
     restore()
     expect(SKILL_PARAMS).toEqual(before)
+  })
+
+  it('varies exactly one field per policy map, so a result has one cause', () => {
+    // The property every one of these maps is built on and none of them states
+    // in code: two sides differing in two fields produce a number nothing can be
+    // attributed to. Cheap to assert, and it is the assertion that keeps the
+    // next map (#154 onward) honest as the union of policies grows.
+    for (const policies of [BID_AB_POLICIES, FOLD_AB_POLICIES, PLAY_AB_POLICIES]) {
+      const [a, b] = Object.values(policies)
+      const differing = (Object.keys(a) as (keyof typeof a)[]).filter((field) => a[field] !== b[field])
+      expect(differing).toHaveLength(1)
+    }
+  })
+
+  it('puts the two card-play rules at one table (#153)', () => {
+    // What epic #152 is blocked on. Both arms already ship — `simple` is what
+    // `easy` plays — so this map enables nothing; it only makes the comparison
+    // reachable, which is a thing `SKILL_PARAMS` alone cannot do because
+    // `chooseFollowCard` reads the level it is handed.
+    const before = { ...SKILL_PARAMS }
+    const restore = installPolicies(PLAY_AB_POLICIES)
+    expect(SKILL_PARAMS[STATIC_LEVEL].playPolicy).toBe('simple')
+    expect(SKILL_PARAMS[DISTILLED_LEVEL].playPolicy).toBe('cascade')
+    restore()
+    expect(SKILL_PARAMS).toEqual(before)
+  })
+
+  it('leaves the shipped dial playing cards exactly as it did before #153', () => {
+    // `playPolicy` is an extraction of the `handValuation === 'meld_only'` test
+    // that used to gate card play inside `tracker.ts`, not a new setting. If
+    // these two ever disagree it is because a level's card play was changed —
+    // which is legitimate from #156 on, but is a behaviour change and has to be
+    // measured as one rather than arriving as a side effect of a refactor.
+    for (const params of Object.values(SKILL_PARAMS)) {
+      expect(params.playPolicy).toBe(params.handValuation === 'meld_only' ? 'simple' : 'cascade')
+    }
   })
 })
 
@@ -166,12 +204,21 @@ describe('the A/B self-test', () => {
   // swing (the numbers below run to four figures) that averaging the pair
   // cancels. That is precisely the positional edge the mirroring exists to
   // remove, and seeing it cancel to zero here is the evidence that it does.
-  for (const [name, level] of [
-    ['static', STATIC_LEVEL],
-    ['distilled', DISTILLED_LEVEL],
+  //
+  // Every arm of every dial is listed, not one representative: the check is
+  // that *this policy* is deterministic and seat-symmetric, and a policy the
+  // self-test never runs is a policy it cannot vouch for. Card play (#153) is
+  // the one with the most room to fail it — a bid policy is asked once per
+  // auction, `chooseFollowCard` tens of times per round, and it reads a
+  // `PlayTracker` that accumulates state across the whole round.
+  for (const [name, level, policies] of [
+    ['static', STATIC_LEVEL, BID_AB_POLICIES],
+    ['distilled', DISTILLED_LEVEL, BID_AB_POLICIES],
+    ['simple', STATIC_LEVEL, PLAY_AB_POLICIES],
+    ['cascade', DISTILLED_LEVEL, PLAY_AB_POLICIES],
   ] as const) {
     it(`finds nothing when ${name} plays itself`, () => {
-      const report = runAb({ nPairs: 6, seed: 5, levelA: level, levelB: level })
+      const report = runAb({ nPairs: 6, seed: 5, levelA: level, levelB: level, policies })
       const analysis = analyse(report)
       expect(analysis.decisivePairs).toBe(0)
       expect(analysis.pairsSplit).toBe(6)

--- a/web/src/ab/abRun.ts
+++ b/web/src/ab/abRun.ts
@@ -37,11 +37,16 @@
 // This is not a shortcut around the gate in `skills.ts`; it is what makes the
 // measurement independent of it. Both entries are written explicitly, so the
 // harness reports the same numbers whether the shipped dial is gated off or
-// switched on. Every other consumer of `SKILL_PARAMS` (`passing.ts`,
-// `tracker.ts`, `chooseTrump`) branches only on `handValuation`, which both
-// entries set to `'base_bid'` — so the two sides play identical cards, pass
-// identical cards and pick trump identically, and the only thing that differs
-// between them is which rule answers "is this hand worth a contract here".
+// switched on.
+//
+// Which is also why each map below writes out every field of `SkillParams`
+// rather than spreading a shipped row: the discipline is that exactly one field
+// differs across a map and the reader can check that by eye. `passing.ts` and
+// `chooseTrump` branch on `handValuation` and `tracker.ts` on `playPolicy`, so
+// in `BID_AB_POLICIES` — same `base_bid`, same `cascade` — the two sides play
+// identical cards, pass identical cards and pick trump identically, and the
+// only thing differing between them is which rule answers "is this hand worth a
+// contract here".
 
 import { SKILL_PARAMS, type SkillParams } from '../engine/skills'
 import type { TeamId } from '../engine/round'
@@ -55,10 +60,21 @@ import { binomialTwoSidedP, bootstrapMeanCi, wilsonInterval } from './stats'
 export const STATIC_LEVEL: SkillLevel = 'hard'
 export const DISTILLED_LEVEL: SkillLevel = 'expert'
 
-/** Bidding A/B (#115): distilled vs static, both folding as the product does. */
+/** Bidding A/B (#115): distilled vs static, both folding as the product does
+ *  and both playing cards the same way. */
 export const BID_AB_POLICIES: Record<string, SkillParams> = {
-  [STATIC_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'static', foldPolicy: 'model' },
-  [DISTILLED_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
+  [STATIC_LEVEL]: {
+    handValuation: 'base_bid',
+    bidPolicy: 'static',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+  },
+  [DISTILLED_LEVEL]: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+  },
 }
 
 /**
@@ -71,8 +87,53 @@ export const BID_AB_POLICIES: Record<string, SkillParams> = {
  * actually ship on `hard` and above.
  */
 export const FOLD_AB_POLICIES: Record<string, SkillParams> = {
-  [STATIC_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'never' },
-  [DISTILLED_LEVEL]: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
+  [STATIC_LEVEL]: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'never',
+    playPolicy: 'cascade',
+  },
+  [DISTILLED_LEVEL]: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+  },
+}
+
+/**
+ * Trick-play A/B (#153): identical bidders and identical folders, differing
+ * only in which rule picks a card.
+ *
+ * This is the dial epic #152 is blocked on. Card play is the one phase of this
+ * AI that has never been measured — #105, #115, #123 and #126 are all bidding
+ * or folding — so every heuristic in `tracker.ts` is there on reasoning alone,
+ * and #154-#159 each propose replacing one of them. None of that can be judged
+ * without a way to sit two card-play rules at one table.
+ *
+ * The two arms are the two that already ship: `'simple'` is what `easy` plays
+ * and `'cascade'` is what every other level plays. Nothing here enables
+ * anything — the comparison is available to the harness while `SKILL_PARAMS`
+ * keeps the mapping it has always had. Acting on the number is #156's job.
+ *
+ * Both sides bid `'distilled'` rather than `'static'` for the same reason
+ * `FOLD_AB_POLICIES` does: it describes card play as it will actually ship on
+ * `hard` and above. Note that side A is `DISTILLED_LEVEL` and therefore
+ * `'cascade'`, matching the other two maps, where A is the arm under test.
+ */
+export const PLAY_AB_POLICIES: Record<string, SkillParams> = {
+  [STATIC_LEVEL]: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'simple',
+  },
+  [DISTILLED_LEVEL]: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+  },
 }
 
 /** Overwrites the two entries in `policies`, returning a function that restores

--- a/web/src/ab/cli.ts
+++ b/web/src/ab/cli.ts
@@ -1,10 +1,11 @@
-// CLI entry point for #115's two measurements.
+// CLI entry point for the A/B measurements (#115, #123, #153).
 //
 // Run through jiti, which is already a dependency (Tailwind pulls it in) and
 // executes TypeScript directly, so this needs no build step and no new package:
 //
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts ab --pairs 400
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts fold --pairs 400
+//   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts play --pairs 400
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts selftest --pairs 100
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts latency --positions 4000
 //
@@ -13,20 +14,40 @@
 // result, because only seating, deal assignment or bookkeeping could separate
 // the two sides. Run it before believing anything the `ab` command says.
 //
+// `--policy` names which arm the self-test doubles up, and so also which dial
+// it exercises: `static`/`distilled` are the bidding pair, `simple`/`cascade`
+// the trick-play pair. Worth having each separately — a self-test that never
+// runs a policy cannot vouch for it, and the paths differ in what could go
+// wrong (the evaluator is the one that could be non-deterministic; card play is
+// the one reached tens of times per round rather than once per auction).
+//
 // `process` is reached through `globalThis` because tsconfig.app.json does not
 // load Node's types — this file lives under `src` so it is type-checked with
 // the rest of the engine, and paying for that with one cast is the cheaper
 // trade than a second tsconfig project.
 
+import type { SkillParams } from '../engine/skills'
+import type { SkillLevel } from '../persistence/options'
 import {
+  BID_AB_POLICIES,
   DISTILLED_LEVEL,
   FOLD_AB_POLICIES,
+  PLAY_AB_POLICIES,
   STATIC_LEVEL,
   analyse,
   runAb,
   summarise,
 } from './abRun'
 import { formatLatency, runLatencyBenchmark } from './latency'
+
+/** Which level carries each named arm, and which override map has to be
+ *  installed for that arm to exist at all. */
+const SELFTEST_ARMS: Record<string, { level: SkillLevel; policies: Record<string, SkillParams> }> = {
+  static: { level: STATIC_LEVEL, policies: BID_AB_POLICIES },
+  distilled: { level: DISTILLED_LEVEL, policies: BID_AB_POLICIES },
+  simple: { level: STATIC_LEVEL, policies: PLAY_AB_POLICIES },
+  cascade: { level: DISTILLED_LEVEL, policies: PLAY_AB_POLICIES },
+}
 
 const argv = (globalThis as { process?: { argv: string[] } }).process?.argv ?? []
 const args = argv.slice(2)
@@ -51,23 +72,48 @@ if (command === 'fold') {
     policies: FOLD_AB_POLICIES,
   })
   console.log(summarise(report, analyse(report, seed)))
+} else if (command === 'play') {
+  // #153's measurement: identical bidders and folders, one side running the
+  // Proficient cascade and one the simplified card play `easy` ships.
+  const pairs = flag('pairs', 400)
+  const seed = flag('seed', 1)
+  const report = runAb({
+    nPairs: pairs,
+    seed,
+    labelA: 'cascade',
+    labelB: 'simple',
+    policies: PLAY_AB_POLICIES,
+  })
+  console.log(summarise(report, analyse(report, seed)))
 } else if (command === 'ab' || command === 'selftest') {
   const pairs = flag('pairs', command === 'selftest' ? 100 : 400)
   const seed = flag('seed', 1)
-  // `--policy distilled` self-tests the model path instead of the threshold
-  // path. Worth having separately: the evaluator is the side that could be
-  // non-deterministic, and a self-test that never exercises it would not notice.
   const policy = args.includes('--policy') ? args[args.indexOf('--policy') + 1] : 'static'
-  const level = policy === 'distilled' ? DISTILLED_LEVEL : STATIC_LEVEL
-  const report =
-    command === 'selftest'
-      ? runAb({ nPairs: pairs, seed, labelA: `${policy} A`, labelB: `${policy} B`, levelA: level, levelB: level })
-      : runAb({ nPairs: pairs, seed, levelA: DISTILLED_LEVEL, levelB: STATIC_LEVEL })
-  console.log(summarise(report, analyse(report, seed)))
+  const arm = SELFTEST_ARMS[policy]
+  if (command === 'selftest' && arm === undefined) {
+    console.log(`unknown --policy '${policy}'; expected one of ${Object.keys(SELFTEST_ARMS).join(', ')}`)
+  } else {
+    const report =
+      command === 'selftest'
+        ? runAb({
+            nPairs: pairs,
+            seed,
+            labelA: `${policy} A`,
+            labelB: `${policy} B`,
+            levelA: arm.level,
+            levelB: arm.level,
+            policies: arm.policies,
+          })
+        : runAb({ nPairs: pairs, seed, levelA: DISTILLED_LEVEL, levelB: STATIC_LEVEL })
+    console.log(summarise(report, analyse(report, seed)))
+  }
 } else if (command === 'latency') {
   const positions = flag('positions', 3000)
   const repeats = flag('repeats', 40)
   console.log(formatLatency(runLatencyBenchmark(positions, repeats)))
 } else {
-  console.log('usage: cli.ts [ab|fold|selftest|latency] [--pairs N] [--seed N] [--positions N] [--repeats N]')
+  console.log(
+    'usage: cli.ts [ab|fold|play|selftest|latency] [--pairs N] [--seed N] ' +
+      `[--policy ${Object.keys(SELFTEST_ARMS).join('|')}] [--positions N] [--repeats N]`,
+  )
 }

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -48,10 +48,41 @@ export type BidPolicy = 'static' | 'distilled'
  */
 export type FoldPolicy = 'never' | 'model'
 
+/**
+ * Which rule picks a card during trick play (#153).
+ *
+ *   `'simple'`   the skill-1 shortcut: lead the lowest non-trump non-counter
+ *                held, and when following play the lowest legal card, always.
+ *   `'cascade'`  the ported Proficient strategy in `tracker.ts` —
+ *                `chooseLeadCard`'s safe-card cascade behind the offense/
+ *                defender split, and `chooseFollowCard`'s tiered forced-beat /
+ *                feed-partner / dump-low logic.
+ *
+ * Both arms already shipped before this field existed. It is a straight
+ * extraction of the `handValuation === 'meld_only'` test that gated card play
+ * inside `tracker.ts`, and `SKILL_PARAMS` reproduces that mapping exactly, so
+ * naming it changed no behaviour. What it changed is that the choice is now
+ * *addressable*: `abRun.ts` can put two card-play rules at one table, which is
+ * what makes trick play measurable at all.
+ *
+ * That mattered enough to be its own issue because trick play is the one phase
+ * of this AI never A/B'd — #105, #115, #123 and #126 all measured bidding or
+ * folding — and epic #152 is a queue of changes to it that cannot be judged
+ * without a dial.
+ *
+ * Splitting it off `handValuation` also unblocks the epic rather than merely
+ * tidying. `meld_only` gates *bidding* valuation too (`bidding.ts`,
+ * `passing.ts`), so while one flag carried both, "give easy the same card play
+ * as everyone else" (#156) was not expressible without also changing how easy
+ * bids — two effects in one measurement, and no way to attribute the result.
+ */
+export type PlayPolicy = 'simple' | 'cascade'
+
 export interface SkillParams {
   readonly handValuation: HandValuation
   readonly bidPolicy: BidPolicy
   readonly foldPolicy: FoldPolicy
+  readonly playPolicy: PlayPolicy
 }
 
 /**
@@ -122,13 +153,21 @@ export interface SkillParams {
  * than a difficulty setting. The dial this table exists to express is
  * `bidPolicy`; a level's strength is meant to come from what it is willing to
  * bid, not from whether it is allowed to notice a dead contract.
+ *
+ * `playPolicy` (#153) is written out per row rather than derived, but it is
+ * only the `handValuation === 'meld_only'` card-play gate that used to live in
+ * `tracker.ts`, spelled where it can be read: `easy` alone was the `meld_only`
+ * row, so `easy` alone is `'simple'`. Nothing about the game changed when this
+ * column appeared, by design — #114 landed the bid evaluator the same way,
+ * wired but switched on for nobody, and #115 measured it separately. Epic #152
+ * is where the column starts moving, one measured change at a time.
  */
 export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
-  easy: { handValuation: 'meld_only', bidPolicy: 'static', foldPolicy: 'model' },
-  medium: { handValuation: 'base_bid', bidPolicy: 'static', foldPolicy: 'model' },
-  hard: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
-  proficient: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
-  expert: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model' },
+  easy: { handValuation: 'meld_only', bidPolicy: 'static', foldPolicy: 'model', playPolicy: 'simple' },
+  medium: { handValuation: 'base_bid', bidPolicy: 'static', foldPolicy: 'model', playPolicy: 'cascade' },
+  hard: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model', playPolicy: 'cascade' },
+  proficient: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model', playPolicy: 'cascade' },
+  expert: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model', playPolicy: 'cascade' },
 }
 
 /** Flat trick-point estimate for meld-only bidding (skill 1), matching

--- a/web/src/engine/tracker.test.ts
+++ b/web/src/engine/tracker.test.ts
@@ -163,6 +163,33 @@ describe('chooseLeadCard', () => {
     const led = chooseLeadCard(hand, Suit.Spades, new PlayTracker(), false, 'hard', false)
     expect(led.suit).toBe(Suit.Spades)
   })
+
+  // -- The play-policy branch (#153) ----------------------------------------
+
+  it("'simple' leads its lowest non-trump non-counter and ignores everything else", () => {
+    // Same hand as the defender test above, where `cascade` picks the Ace of
+    // Hearts. `simple` takes the Clubs 9: no cascade, no side dispatch, no
+    // tracker. The two arms are visibly different rules, which is what makes
+    // `PLAY_AB_POLICIES` a comparison rather than a formality.
+    const hand = [
+      new Card(Suit.Spades, 'A', 1),
+      new Card(Suit.Hearts, 'A', 1),
+      new Card(Suit.Clubs, '9', 1),
+    ]
+    const led = chooseLeadCard(hand, Suit.Spades, new PlayTracker(), false, 'easy', false)
+    expect(led.suit).toBe(Suit.Clubs)
+    expect(led.rank).toBe('9')
+  })
+
+  it("'simple' ignores the bidder's forced trump lead, as it did before #153", () => {
+    // The `meld_only` test this branch replaces sat above the `isBidderFirstLead`
+    // rule, so `easy` never honoured it. Preserved deliberately: #153 is a
+    // rename, and changing which cards a level plays belongs to #156 where it
+    // can be measured.
+    const hand = [new Card(Suit.Spades, 'A', 1), new Card(Suit.Clubs, '9', 1)]
+    const led = chooseLeadCard(hand, Suit.Spades, new PlayTracker(), true, 'easy')
+    expect(led.suit).toBe(Suit.Clubs)
+  })
 })
 
 describe('chooseFollowCard', () => {
@@ -287,5 +314,36 @@ describe('chooseFollowCard', () => {
     const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
     expect(played.suit).toBe(Suit.Clubs)
     expect(played.rank).toBe('9')
+  })
+
+  // -- The play-policy branch (#153) ----------------------------------------
+
+  it("'simple' plays the lowest legal card, skipping every tier above", () => {
+    // Partner is winning, so `cascade` feeds them the 10 (the tier asserted
+    // above). `simple` plays the 9 — it never asks who is winning, which is
+    // exactly the weakness epic #152 exists to fix and #153 exists to measure.
+    const trickPlays: TrickPlay[] = [{ player: 0, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const legalMoves = [
+      new Card(Suit.Hearts, '9', 1),
+      new Card(Suit.Hearts, 'K', 1),
+      new Card(Suit.Hearts, '10', 1),
+    ]
+    const played = chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2], undefined, 'easy')
+    expect(played.rank).toBe('9')
+  })
+
+  it('every other level follows with the cascade, unchanged by #153', () => {
+    // The mapping `playPolicy` extracted from `handValuation === 'meld_only'`:
+    // `easy` alone took the shortcut, and it alone still does.
+    const trickPlays: TrickPlay[] = [{ player: 0, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const legalMoves = [
+      new Card(Suit.Hearts, '9', 1),
+      new Card(Suit.Hearts, 'K', 1),
+      new Card(Suit.Hearts, '10', 1),
+    ]
+    for (const skill of ['medium', 'hard', 'proficient', 'expert'] as const) {
+      const played = chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2], undefined, skill)
+      expect(played.rank).toBe('10')
+    }
   })
 })

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -163,8 +163,9 @@ function leadSafeCascade(hand: readonly Card[], trump: Suit, tracker: PlayTracke
  *
  * @param isBidderFirstLead - When true (bidder opening the first trick of the
  *   round), forces a trump lead if the player has any trump cards remaining.
- * @param skill - Skill level. Skill 1 (easy) uses simplified logic: prefers
- *   low non-trump non-count cards. Defaults to 'hard' (full Proficient cascade).
+ * @param skill - Skill level, read for `playPolicy` (#153). `'simple'` uses
+ *   simplified logic: prefers low non-trump non-count cards. Defaults to 'hard'
+ *   (`'cascade'`, the full Proficient cascade).
  * @param isBiddingTeam - Which side this seat is on. Undefined = fallback.
  */
 export function chooseLeadCard(
@@ -175,8 +176,11 @@ export function chooseLeadCard(
   skill: SkillLevel = 'hard',
   isBiddingTeam?: boolean,
 ): Card {
-  // Skill 1 (easy): simplified leading — prefer low non-trump non-count cards
-  if (SKILL_PARAMS[skill].handValuation === 'meld_only') {
+  // Simplified leading — prefer low non-trump non-count cards. Reached by
+  // `easy` and nothing else, which is the mapping the `meld_only` test this
+  // replaces produced (#153); `playPolicy` is the field to change, not the
+  // valuation one, because that one also decides how the seat bids.
+  if (SKILL_PARAMS[skill].playPolicy === 'simple') {
     const safeLeads = hand.filter((c) => c.suit !== trump && c.rank !== 'A' && c.rank !== '10' && c.rank !== 'K')
     const pool = safeLeads.length > 0 ? safeLeads : hand
     return pool.reduce((lowest, c) => (c.rankValue < lowest.rankValue ? c : lowest))
@@ -252,8 +256,8 @@ function currentWinner(trickPlays: readonly TrickPlay[], trump: Suit): TrickPlay
  *     suits - work toward voiding the shortest suit, lowest rank within
  *     it.
  *
- * @param skill Skill level. Skill 1 (easy) plays the lowest legal card.
- *   Defaults to 'hard' (full Proficient tiered logic).
+ * @param skill Skill level, read for `playPolicy` (#153). `'simple'` plays the
+ *   lowest legal card. Defaults to 'hard' (`'cascade'`, the tiered logic above).
  */
 export function chooseFollowCard(
   hand: readonly Card[],
@@ -266,8 +270,8 @@ export function chooseFollowCard(
 ): Card {
   if (legalMoves.length === 1) return legalMoves[0]
 
-  // Skill 1 (easy): always play the lowest legal card
-  if (SKILL_PARAMS[skill].handValuation === 'meld_only') {
+  // Simplified following: always play the lowest legal card (#153)
+  if (SKILL_PARAMS[skill].playPolicy === 'simple') {
     return legalMoves.reduce((lowest, c) => (c.rankValue < lowest.rankValue ? c : lowest))
   }
 


### PR DESCRIPTION
Card play is the one phase of this AI that has never been A/B'd. #105, #115,
#123 and #126 all measured bidding or folding, so every heuristic in
`tracker.ts` is there on reasoning alone — and epic #152 is a queue of changes
to those heuristics, none of which can be judged without a dial. This is that
dial, and nothing else.

## What it adds

Follows the two existing dials rather than inventing a shape:

- `SkillParams.playPolicy: 'simple' | 'cascade'` in `src/engine/skills.ts`,
  alongside `bidPolicy` and `foldPolicy`.
- `PLAY_AB_POLICIES` in `src/ab/abRun.ts`, alongside `BID_AB_POLICIES` and
  `FOLD_AB_POLICIES`, applied through the same `installPolicies`.
- `chooseLeadCard` / `chooseFollowCard` branch on the new field, with today's
  cascade as the baseline arm.
- `cli.ts play`, and `selftest --policy simple|cascade` next to the existing
  `static|distilled`.

## It changes no behaviour

`playPolicy` is an extraction of the `handValuation === 'meld_only'` test that
gated card play *inside* `tracker.ts`. `easy` was the only `meld_only` row, so
`easy` is the only `'simple'` row and every other level is `'cascade'` — the
same mapping, spelled where it can be read. A test asserts that equivalence
directly, so the day a level's card play does change (#156) it has to be
deliberate rather than a side effect of a refactor.

Splitting it off `handValuation` is what unblocks the epic rather than merely
tidying: that flag also governs *bidding* valuation (`bidding.ts`,
`passing.ts`), so while one field carried both, "give easy the same card play as
everyone else" could not be expressed without also changing how easy bids — two
effects in one measurement and no way to attribute the result.

Precedent is #114: the bid evaluator landed wired but switched on for nobody,
and #115 measured it separately.

## Proving the harness works

A self-test proves a dial reports nothing when nothing differs. It does not
prove the dial can see anything, and those fail differently — a policy field
that is written but never read passes `selftest` perfectly and then returns a
null result for every change ever made through it. So both directions were
checked.

**Self-test, 100 pairs per arm.** Exactly nothing, on both arms:

```
simple  A vs simple  B: swept 0 / 0, split 100, margin +0, 95% CI +0 to +0
cascade A vs cascade B: swept 0 / 0, split 100, margin +0, 95% CI +0 to +0
```

`ab.test.ts` asserts the same property in the suite for all four arms of both
dials — every pair splits, every paired margin is exactly zero, and per-game
margins are non-trivial and exactly opposite, so the seat effect is present and
cancels.

**Known-bad policy, 1000 pairs / 2000 games.** A throwaway `'highest'` arm —
always play the highest legal card, which dumps counters into opponents' tricks
and strips your own trump control — against the cascade:

```
cascade swept 224 deals, highest 11, split 765
95% CI on cascade's share of the 235 decisive deals: 91.8% – 97.4%
two-sided exact binomial p < 1e-4  (printed 0.0000)
margin +202 per deal, 95% CI +184 to +220  — CI excludes zero
set on 24.9% of contracts vs highest's 32.4%, from the same bids on the same deals
```

**The throwaway is not in the committed tree.** `PlayPolicy` is back to
`'simple' | 'cascade'`, and `grep -rn "highest'|knownbad|KNOWN_BAD|TEMPORARY"
web/src/` is empty. The procedure to recreate it is written up in
`web/README.md` under "Checking that a dial can see a change" — same call #126
made with the temporary `parity` dial it removed before committing, on the
grounds that a permanent "play badly" switch is not a difficulty setting.

## One reading, for #156 rather than for this PR

`cli.ts play` compares the two shipped arms. Over 1000 pairs: cascade swept 158
to simple's 37 (805 split), p < 1e-4, **+121 per deal, 95% CI +103 to +138**,
making 68.5% of its contracts against simple's 64.5%. That is the size of the
gap the dial spans. `SKILL_PARAMS` is untouched — acting on the number is #156's
job.

## Checks

- `npm test` **338 passed**, from a 329 baseline. +9: two more self-test arms,
  three on the policy maps (including one asserting every map varies exactly one
  field, so a result has one cause), four on the play branch in `tracker.ts`.
- `python -m pytest -q` 288 passed.
- `npm run build` clean — the point of running it, since this widens a shared
  interface. Bundle 255.47 kB / 79.41 kB gzipped, unchanged in substance.
- `npm run lint` clean; the three `exhaustive-deps` warnings are pre-existing in
  files this PR does not touch.

Closes #153
