### PR TITLE
fix(ai): feed partner the lowest counter, not the highest (#154)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -196,6 +196,50 @@ p < 1e-4, **+121 score margin per deal, 95% CI +103 to +138** — cascade makes
 bids. That is a reading of the gap the dial spans, not a decision: acting on it
 is #156's job.
 
+### Feeding partner the lowest counter (#154)
+
+The first change measured through that dial, and the smallest in epic #152.
+`chooseFollowCard`'s partner-is-winning tier called `maxByRank` on the King/10 it
+was about to donate, so it threw the **10** and kept the King. A, 10 and K are
+each worth exactly 10 points (`pinochle_rules.md:140`), so both cards bank the
+same score and the only difference is which one is left in hand — and the 10
+loses to nothing but an Ace. It is now `minByRank`, in `feedPartner`.
+
+The open question was the Ace. The tier deliberately skips it (`avoid donating a
+live Ace unless forced`), but "play your lowest legal point" read literally
+orders K → 10 → A, which puts the Ace in when it is the only counter held. So
+three arms were run rather than two — identical bidders, identical folders,
+differing only in this tier:
+
+| over 5000 pairs / 10 000 games | margin per deal | 95% CI | swept | p |
+| --- | --- | --- | --- | --- |
+| lowest **excl. A** vs old `maxByRank` | **+3.55** | +2.05 to +5.16 | 28–11 | 0.010 |
+| lowest **incl. A** vs old `maxByRank` | +0.41 | −1.73 to +2.54 | 44–38 | 0.58 |
+| lowest **excl. A** vs lowest **incl. A** | **+3.55** | +2.02 to +5.09 | 30–16 | 0.054 |
+
+Repeated on a second seed: +3.31 (+1.75 to +4.97), +0.43 (−1.73 to +2.60) and
++3.06 (+1.43 to +4.71). **The exclusion shipped.** The including-A variant is a
+null against the *old* behaviour and loses to the exclusion by very nearly the
+whole size of the fix — donating the Ace gives back everything spending the King
+wins, which is the thing reasoning could not settle. #101 is the precedent for
+recording that as a result rather than re-running until it moves.
+
+Two things worth carrying forward. The effect is real but two orders of magnitude
+below the dial's own span (#153's +121, #115's +227), because the tier only fires
+when partner is winning, the trick is not a forced beat, and two counters are
+legal — so at 1000 pairs the same comparison reads +2.67 with a CI of +0.51 to
++4.92 and a sign test of p = 1.0 on two decisive deals. 1000 pairs is the wrong
+size for the rest of #152's children; 5000 is. And games-won is useless at this
+scale: 4961 of 5000 pairs split even where the margin interval is clean, which is
+exactly the null this project has been burned by before and the reason margin is
+the headline number.
+
+The three-arm comparison needed a throwaway `'feed-high'` / `'feed-low-ace'` pair
+on the `PlayPolicy` union plus a temporary `cli.ts feed` command, added in the
+shape the section below describes and deleted before the fix was committed — the
+same call #126 and #153 made, since a permanent "feed the wrong card" switch is
+not a difficulty setting.
+
 ### Checking that a dial can see a change
 
 A self-test proves a dial reports nothing when nothing differs. It does not

--- a/web/src/engine/tracker.test.ts
+++ b/web/src/engine/tracker.test.ts
@@ -210,7 +210,7 @@ describe('chooseFollowCard', () => {
     expect(played.rank).toBe('10')
   })
 
-  it('feeds partner the highest King/10 when partner is winning and not every card is a forced beat', () => {
+  it('feeds partner the lowest King/10 when partner is winning and not every card is a forced beat', () => {
     // Partner (player 0) is winning with a Queen; the 9 doesn't beat it, so
     // this isn't a forced beat - falls through to the feed-partner tier.
     const trickPlays: TrickPlay[] = [{ player: 0, card: new Card(Suit.Hearts, 'Q', 1) }]
@@ -221,12 +221,28 @@ describe('chooseFollowCard', () => {
     ]
     const hand = legalMoves
     const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
-    expect(played.rank).toBe('10') // 10 outranks King, so it's the bigger feed
+    // #154: King and 10 bank the same 10 points, so spend the King and keep the
+    // 10 - it loses only to an Ace and often takes a later trick outright. This
+    // asserted the 10 until #154 swapped it.
+    expect(played.rank).toBe('K')
   })
 
   it('feeding partner with no King/10 available plays the lowest card instead (avoid donating a live Ace)', () => {
     const trickPlays: TrickPlay[] = [{ player: 0, card: new Card(Suit.Hearts, 'Q', 1) }]
     const legalMoves = [new Card(Suit.Hearts, '9', 1), new Card(Suit.Hearts, 'J', 1)]
+    const hand = legalMoves
+    const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('9')
+  })
+
+  it('feeding partner holds the Ace back when it is the only counter, donating junk instead', () => {
+    // The measured half of #154. "Play your lowest legal point" read literally
+    // orders K -> 10 -> A, which puts the Ace in here for 10 points. That variant
+    // ran as its own arm over 5000 paired deals: a null against the pre-#154
+    // behaviour and 3.6 points a deal behind this one, so the Ace stays home.
+    // The trick pays the same 10 either way; the boss of a suit does not.
+    const trickPlays: TrickPlay[] = [{ player: 0, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const legalMoves = [new Card(Suit.Hearts, '9', 1), new Card(Suit.Hearts, 'A', 1)]
     const hand = legalMoves
     const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
     expect(played.rank).toBe('9')
@@ -319,7 +335,7 @@ describe('chooseFollowCard', () => {
   // -- The play-policy branch (#153) ----------------------------------------
 
   it("'simple' plays the lowest legal card, skipping every tier above", () => {
-    // Partner is winning, so `cascade` feeds them the 10 (the tier asserted
+    // Partner is winning, so `cascade` feeds them the King (the tier asserted
     // above). `simple` plays the 9 — it never asks who is winning, which is
     // exactly the weakness epic #152 exists to fix and #153 exists to measure.
     const trickPlays: TrickPlay[] = [{ player: 0, card: new Card(Suit.Hearts, 'Q', 1) }]
@@ -343,7 +359,7 @@ describe('chooseFollowCard', () => {
     ]
     for (const skill of ['medium', 'hard', 'proficient', 'expert'] as const) {
       const played = chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2], undefined, skill)
-      expect(played.rank).toBe('10')
+      expect(played.rank).toBe('K')
     }
   })
 })

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -215,6 +215,33 @@ function maxByRank(cards: readonly Card[]): Card {
 }
 
 /**
+ * Partner is winning and you cannot take the trick off them: bank a counter
+ * into it, and make it the **cheapest** one you hold (#154).
+ *
+ * A, 10 and K are worth exactly 10 points each (`pinochle_rules.md:140`), so
+ * which counter goes in does not change what the trick pays — only what is left
+ * in hand afterwards. The K is therefore strictly the one to spend: it banks the
+ * same 10 while the 10 it keeps is beaten by nothing but an Ace and will often
+ * take a later trick outright. This used to be `maxByRank`, which threw the 10
+ * and kept the K — identical points for a worse hand, on every deal.
+ *
+ * The Ace stays out of it, so a hand holding an Ace and no other counter donates
+ * junk rather than the boss of the suit. That exclusion is measured, not
+ * assumed. A literal reading of the rule — "play your lowest legal point" —
+ * orders K -> 10 -> A and would put the Ace in, and #154 ran that variant as its
+ * own arm. Over 5000 paired deals it is a null against the old `maxByRank`
+ * (+0.4 per deal, 95% CI -1.7 to +2.5, p = 0.58) and loses to this one by
+ * +3.6 per deal (95% CI +2.0 to +5.1) — donating the Ace gives back the whole
+ * gain of spending the King. Both results reproduce on a second seed. See
+ * `web/README.md`.
+ */
+function feedPartner(legalMoves: readonly Card[]): Card {
+  const counters = legalMoves.filter((c) => c.rank === 'K' || c.rank === '10')
+  if (counters.length > 0) return minByRank(counters)
+  return minByRank(legalMoves) // no cheap counter — donate junk, not a live Ace
+}
+
+/**
  * Who's currently winning the trick-in-progress: highest trump if any
  * trump has been played, else highest card of the lead suit. Ties go to
  * whichever copy was played first (`reduce` only replaces the running
@@ -240,9 +267,10 @@ function currentWinner(trickPlays: readonly TrickPlay[], trump: Suit): TrickPlay
  *       1. Forced beat (every legal card already beats the current
  *          winner) - play the lowest one that still wins, saving bigger
  *          cards for later.
- *       2. Partner is currently winning - feed them points: the highest
- *          King/10 available, or (if none) the lowest card, to avoid
- *          donating a live Ace unless forced.
+ *       2. Partner is currently winning - feed them points: the lowest
+ *          King/10 available (#154 - every counter pays 10, so spend the
+ *          weakest), or (if none) the lowest card, to avoid donating a
+ *          live Ace unless forced.
  *       3. Otherwise - play the lowest non-point card, falling back to
  *          the lowest legal card if only point cards are available.
  *   - Forced to play trump (void in the lead suit):
@@ -286,11 +314,7 @@ export function chooseFollowCard(
     const forcedBeat = winner !== undefined && legalMoves.every((c) => c.rankValue > winner.card.rankValue)
     if (forcedBeat) return minByRank(legalMoves)
 
-    if (partnerWinning) {
-      const feedCards = legalMoves.filter((c) => c.rank === 'K' || c.rank === '10')
-      if (feedCards.length > 0) return maxByRank(feedCards)
-      return minByRank(legalMoves) // avoid donating a live Ace unless forced
-    }
+    if (partnerWinning) return feedPartner(legalMoves)
 
     const nonPoints = legalMoves.filter((c) => !POINT_RANKS.has(c.rank))
     if (nonPoints.length > 0) return minByRank(nonPoints)


### PR DESCRIPTION
`chooseFollowCard`'s partner-is-winning tier called `maxByRank` on the counter it
was about to donate, so it threw the **10** and kept the King. A, 10 and K are
each worth exactly 10 points (`pinochle_rules.md:140`), so both cards bank the
same score and the only thing that differs is what is left in hand — and the 10
loses to nothing but an Ace, so it often takes a later trick outright. There is
no hand on which throwing it was right.

The tier moves into a named `feedPartner` helper and calls `minByRank`. The
sibling forced-donation path was already `minByRank`; only this branch was
inverted.

## The Ace question, measured

The tier deliberately skips the Ace (`avoid donating a live Ace unless forced`),
but "play your lowest legal point" read literally orders K → 10 → A, which puts
the Ace in when it is the only counter held. That is arguable both ways, so it
was run as its own arm rather than decided by reasoning. Three arms, identical
bidders and folders, differing only in this tier:

| over 5000 pairs / 10 000 games | margin per deal | 95% CI | swept | p |
| --- | --- | --- | --- | --- |
| lowest **excl. A** vs old `maxByRank` | **+3.55** | +2.05 to +5.16 | 28–11 | 0.010 |
| lowest **incl. A** vs old `maxByRank` | +0.41 | −1.73 to +2.54 | 44–38 | 0.58 |
| lowest **excl. A** vs lowest **incl. A** | **+3.55** | +2.02 to +5.09 | 30–16 | 0.054 |

Reproduced on a second seed: +3.31 (+1.75 to +4.97), +0.43 (−1.73 to +2.60) and
+3.06 (+1.43 to +4.71). Same direction, same conclusion.

**The exclusion ships.** The including-A variant is a null against the *old*
behaviour and sits ~3.5 points a deal behind the exclusion — donating the Ace
gives back essentially the entire gain of spending the King. #101 is the
precedent for recording that as a result rather than re-running until it moves.

Self-test first, as required: `selftest --pairs 100 --policy cascade` split all
100 pairs with every paired margin exactly 0, and the temporary `feed-high` arm
against itself did the same.

## Two notes for the rest of #152

- **1000 pairs is too small for this epic.** The effect here is real but two
  orders of magnitude under the dial's span (#153's +121, #115's +227), because
  the tier only fires when partner is winning, the trick is not a forced beat,
  and two counters are legal. At 1000 pairs the headline comparison reads +2.67
  (CI +0.51 to +4.92) on two decisive deals. 5000 is the size that resolves it.
- **Games-won is useless at this scale** — 4961 of 5000 pairs split even where
  the margin interval is clean. Margin is the number to read.

## Temporary code

The three-arm run needed a throwaway `'feed-high'` / `'feed-low-ace'` pair on the
`PlayPolicy` union, a branch in `feedPartner`, and temporary `cli.ts feed` /
`feedprobe` commands. All four are gone from this branch — `skills.ts` and
`cli.ts` are byte-identical to `main`. Same call #126 and #153 made: a permanent
"feed the wrong card" switch is not a difficulty setting.

`feedprobe` existed to prove each arm was actually read before trusting any
number from it, since a policy field written but never read passes `selftest`
perfectly and then returns null forever:

```
cascade        {9,K,10,A} -> K    {9,A} -> 9
feed-high      {9,K,10,A} -> 10   {9,A} -> 9
feed-low-ace   {9,K,10,A} -> K    {9,A} -> A
```

## Checks

- `npm test` — 339 passed (338 on `main`; +1 for the new Ace-exclusion case)
- `python -m pytest -q` — 288 passed
- `npm run build` — clean; `npm run lint` — only the three pre-existing
  `exhaustive-deps` warnings in `AuctionFlow.tsx` / `TrickPlayFlow.tsx`
- `pinochle_engine.py` is untouched. It carries the same `max(feed_cards, ...)`,
  but `engineParity.test.ts` compares rules, not AI decisions — divergence in
  choice is by design there — and this issue scopes to `tracker.ts`.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
