### PR TITLE
fix(ui): fit the table to a phone in portrait (#161)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -230,6 +230,39 @@ exactly 0 is one a null result from can be believed.
 `npm run dev` at `/bench/` (it follows `base`, which is `/`). It is never an
 input to `vite build`, so it cannot reach a player or the PWA precache.
 
+## Portrait fit (#161)
+
+The game has to fit a phone in portrait with no scrolling, and that is a
+measurement rather than a look. `layout/index.html` + `src/layout/layoutProbe.tsx`
+is the harness, served by `npm run dev` at `/layout/` on the same dev-only terms
+as `bench/` above — not a `vite build` input, so it cannot reach a player.
+
+`/layout/` loads every phase (auction, pass, meld, trick play, round summary,
+game over) at every target viewport in an exactly-sized iframe and prints
+`scrollHeight - innerHeight` and `scrollWidth - innerWidth` for each.
+Non-positive is a pass. `/layout/?frame=1&phase=meld` renders one phase alone,
+which is also the quickest way to look at a phase without playing to it.
+
+Three things about it are load-bearing:
+
+- **An iframe, not a resized window.** A desktop browser cannot produce a 390px
+  viewport by resizing — that is what a phone's device pixel ratio hides. The
+  iframe gives its document exactly the width it is handed. Frame mode also
+  hides scrollbars, since desktop scrollbars take ~15px of layout width and a
+  phone's overlay scrollbars take none.
+- **`?insets=1`.** `env(safe-area-inset-*)` is always 0 in a browser tab, so the
+  under-the-notch case an installed instance actually gets is invisible by
+  default. That flag overrides the `--safe-*` variables in `index.css` with an
+  iPhone-14-Pro-class portrait inset set, which is the real height budget.
+- **The panel columns.** Overlays are `position: fixed` and so contribute
+  nothing to document overflow — a modal taller than the screen would be
+  clipped and unreachable while still measuring 0. The probe reports the
+  overlay panel's own rect against the viewport for that reason.
+
+Targets: 390x844 (the reported device), 360x640 (small Android), 430x932 (Pro
+Max), each with and without insets. Landscape is not a target — the manifest is
+`orientation: portrait` — but it stays usable, scrolling ~20-95px at 844x390.
+
 ## Notes
 
 - TypeScript is configured with `erasableSyntaxOnly`, so no `enum` or

--- a/web/layout/index.html
+++ b/web/layout/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<!--
+  Dev-only portrait-fit probe for #161. Served by `npm run dev` at /layout/
+  (it follows `base` in vite.config.ts, which is `/`); never an input to
+  `vite build` — Vite's build input is the root index.html alone — so it
+  cannot reach a player or the PWA precache. Same arrangement as bench/.
+  See src/layout/layoutProbe.tsx.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pinochle — portrait fit probe (#161)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/layout/layoutProbe.tsx"></script>
+  </body>
+</html>

--- a/web/src/components/MeldFlow.test.tsx
+++ b/web/src/components/MeldFlow.test.tsx
@@ -90,8 +90,9 @@ describe('MeldFlow', () => {
     const cards = screen.getAllByRole('img').filter((el) => el.closest('section[aria-label$="meld"]'))
     expect(cards.length).toBeGreaterThan(0)
     for (const card of cards) {
-      expect(card.className).toContain('w-9')
-      expect(card.className).not.toContain('w-20')
+      // `sm`, per PlayingCard's CARD_SIZES — 28px since #161's sizing pass.
+      expect(card.className).toContain('w-7')
+      expect(card.className).not.toContain('w-16')
     }
   })
 

--- a/web/src/components/PlayingCard.test.tsx
+++ b/web/src/components/PlayingCard.test.tsx
@@ -26,9 +26,15 @@ describe('PlayingCard', () => {
   })
 
   // #94: width used to be passed via className, where Tailwind resolved the
-  // conflict with the base `w-20` by stylesheet order — so `w-6` lost and meld
+  // conflict with the base width by stylesheet order — so `w-6` lost and meld
   // cards silently rendered full size. Width now comes from `size` alone, so
   // exactly one width utility is ever emitted.
+  //
+  // The values are #161's ~20% reduction (lg 80 -> 64, md 60 -> 48, sm 36 ->
+  // 28), which is what makes a 12-card hand fit a phone. They are pinned here
+  // rather than left to inspection because the fan overlaps in Seat.tsx are
+  // tuned against these exact widths — changing one without the other either
+  // overflows the viewport again or buries the corner indices.
   it('emits exactly one width utility, chosen by size', () => {
     const widthsFor = (el: Element) => (el.className.match(/(^|\s)w-\S+/g) ?? []).map((s) => s.trim())
 
@@ -36,17 +42,29 @@ describe('PlayingCard', () => {
     const { container: md } = render(<PlayingCard suit={Suit.Spades} rank="A" size="md" />)
     const { container: lg } = render(<PlayingCard suit={Suit.Spades} rank="A" />)
 
-    expect(widthsFor(sm.firstElementChild!)).toEqual(['w-9'])
-    expect(widthsFor(md.firstElementChild!)).toEqual(['w-[60px]'])
-    expect(widthsFor(lg.firstElementChild!)).toEqual(['w-20'])
+    expect(widthsFor(sm.firstElementChild!)).toEqual(['w-7'])
+    expect(widthsFor(md.firstElementChild!)).toEqual(['w-12'])
+    expect(widthsFor(lg.firstElementChild!)).toEqual(['w-16'])
+  })
+
+  // A card is a width plus a ratio — nothing sets a height — so `aspect-5/7`
+  // is what makes it card-shaped at all. #161 changed every width; this is the
+  // guard that a future size pass doesn't quietly drop the ratio with them.
+  it('keeps the 5/7 aspect ratio at every size', () => {
+    for (const size of ['sm', 'md', 'lg'] as const) {
+      const { container } = render(<PlayingCard suit={Suit.Spades} rank="A" size={size} />)
+      expect(container.firstElementChild!.className).toContain('aspect-5/7')
+    }
+    const { container: back } = render(<PlayingCard suit={Suit.Spades} rank="A" faceDown />)
+    expect(back.firstElementChild!.className).toContain('aspect-5/7')
   })
 
   it('keeps a caller className from introducing a competing width', () => {
     const { container } = render(<PlayingCard suit={Suit.Spades} rank="A" size="sm" className="-ml-2" />)
     const cls = container.firstElementChild!.className
-    expect(cls).toContain('w-9')
+    expect(cls).toContain('w-7')
     expect(cls).toContain('-ml-2')
-    expect(cls.match(/(^|\s)w-\S+/g)!.map((s) => s.trim())).toEqual(['w-9'])
+    expect(cls.match(/(^|\s)w-\S+/g)!.map((s) => s.trim())).toEqual(['w-7'])
   })
 
   it('renders every suit and rank without throwing', () => {

--- a/web/src/components/PlayingCard.tsx
+++ b/web/src/components/PlayingCard.tsx
@@ -2,7 +2,8 @@ import { type Rank, type Suit } from '../engine/card'
 import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
 
 /**
- * Card sizes, as matched sets of width + corner/centre type scale.
+ * Card sizes, as matched sets of width + corner/centre type scale + the
+ * positions of both corner indices.
  *
  * Size is a prop rather than something a caller passes through `className`
  * because Tailwind resolves conflicting utilities by their order in the
@@ -10,15 +11,23 @@ import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
  * passing `w-6` alongside the base `w-20` silently lost — `w-6` sorts first,
  * so `w-20` won and the card rendered full size (#94). Keeping width here
  * means there is never a competing utility to lose to, and the type scale
- * stays proportional to the card instead of overflowing it.
+ * stays proportional to the card instead of overflowing it. Everything that
+ * scales with the card belongs in this table for the same reason: the rotated
+ * corner's offsets used to be hardcoded in the JSX, so they stayed put while
+ * the card shrank under them.
+ *
+ * Widths came down ~20% for #161 (lg 80 -> 64, md 60 -> 48, sm 36 -> 28): at
+ * the old sizes a 12-card hand measured 564px against a 390px phone viewport.
+ * `aspect-5/7` is what turns each width into a card, so the heights follow
+ * (lg 112 -> 90, md 84 -> 67, sm 50 -> 39) and the ratio is unchanged.
  */
 const CARD_SIZES = {
   /** Compact, for dense read-only displays like meld declaration. */
-  sm: { width: 'w-9', corner: 'text-[0.5rem]', cornerPos: 'top-0.5 left-1', centre: 'text-lg' },
+  sm: { width: 'w-7', corner: 'text-[0.5rem]', cornerPos: 'top-0 left-0.5', cornerPosAlt: 'right-0.5 bottom-0', centre: 'text-base' },
   /** The fanned hand in a seat. */
-  md: { width: 'w-[60px]', corner: 'text-sm', cornerPos: 'top-1 left-1.5', centre: 'text-3xl' },
+  md: { width: 'w-12', corner: 'text-xs', cornerPos: 'top-0.5 left-1', cornerPosAlt: 'right-1 bottom-0.5', centre: 'text-xl' },
   /** Full size — trick area, pass selector, pass reveal. */
-  lg: { width: 'w-20', corner: 'text-sm', cornerPos: 'top-1 left-1.5', centre: 'text-3xl' },
+  lg: { width: 'w-16', corner: 'text-xs', cornerPos: 'top-0.5 left-1', cornerPosAlt: 'right-1 bottom-0.5', centre: 'text-2xl' },
 } as const
 
 export type PlayingCardSize = keyof typeof CARD_SIZES
@@ -39,7 +48,7 @@ export interface PlayingCardProps {
  * either a light or dark table background by construction.
  */
 export function PlayingCard({ suit, rank, faceDown, size = 'lg', className = '' }: PlayingCardProps) {
-  const { width, corner, cornerPos, centre } = CARD_SIZES[size]
+  const { width, corner, cornerPos, cornerPosAlt, centre } = CARD_SIZES[size]
 
   if (faceDown) {
     return (
@@ -67,7 +76,7 @@ export function PlayingCard({ suit, rank, faceDown, size = 'lg', className = '' 
         <span>{glyph}</span>
       </div>
       {showRotatedCorner && (
-        <div className={`absolute right-1.5 bottom-1 flex rotate-180 flex-col items-center ${corner} leading-none font-semibold`}>
+        <div className={`absolute ${cornerPosAlt} flex rotate-180 flex-col items-center ${corner} leading-none font-semibold`}>
           <span>{rank}</span>
           <span>{glyph}</span>
         </div>

--- a/web/src/components/Scoreboard.tsx
+++ b/web/src/components/Scoreboard.tsx
@@ -23,7 +23,11 @@ export function Scoreboard({ scoresByTeam, teamNames, currentBid, bidWinnerName,
   const trumpColor = trumpSuit && RED_SUITS.includes(trumpSuit) ? 'text-red-400' : 'text-white'
 
   return (
-    <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-1 bg-green-950 px-4 py-2 text-sm text-white shadow-md">
+    // The strip owns the top safe-area inset (#161) rather than the Table root,
+    // so its own background fills the space behind the status bar instead of
+    // leaving a bare band of table felt above it. Gutters are tightened from
+    // gap-x-6/px-4 so the five items pack into fewer wrapped lines on a phone.
+    <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-0.5 bg-green-950 pt-[calc(0.375rem_+_var(--safe-top))] pr-[calc(0.5rem_+_var(--safe-right))] pb-1.5 pl-[calc(0.5rem_+_var(--safe-left))] text-sm text-white shadow-md">
       <span>
         Trump:{' '}
         <span className={`text-lg font-semibold ${trumpColor}`}>

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -40,7 +40,11 @@ const POSITION_LAYOUT: Record<SeatPosition, string> = {
 export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable, exposeCards }: SeatProps) {
   return (
     <div className={`flex gap-1 ${POSITION_LAYOUT[position]}`}>
-      <div className="flex items-center gap-2 text-sm font-medium">
+      {/* Wraps and breaks (#161): the left/right seats live in columns that are
+          allowed to fall to zero width, and a nowrap header of "Beauregard" +
+          badges + "12 cards" would otherwise set a min-content floor under the
+          column and widen the whole board on a phone. */}
+      <div className="flex flex-wrap items-center justify-center gap-x-2 text-center text-sm font-medium [overflow-wrap:anywhere]">
         <span>{seat.name}</span>
         {isDealer && (
           <span className="rounded bg-neutral-700/80 px-1.5 py-0.5 text-xs font-bold text-amber-300">
@@ -66,12 +70,19 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
         // second row's leading card still carried the big negative margin and
         // rendered shifted/misaligned relative to the row above it. One row
         // that scrolls horizontally instead keeps every row's cards flush.
-        <div className="flex justify-center gap-1 overflow-x-auto">
+        // -ml-11 against a 64px card leaves 24px of every card showing, which
+        // is enough for the corner index and puts all 12 in 328px — inside a
+        // 360px phone (#161). The overlap is paired with the card width, so
+        // changing one without the other either re-overflows or hides the
+        // indices. `w-full` is what makes `overflow-x-auto` mean anything: it
+        // resolves against the seat's stretched width (Table.tsx), so the row
+        // is as wide as the column and scrolls, instead of sizing to the fan.
+        <div className="flex w-full justify-center gap-1 overflow-x-auto">
           {sortHandForDisplay(seat.hand).map((card) => {
             const cardFace = <PlayingCard suit={card.suit} rank={card.rank} />
             if (!playable) {
               return (
-                <div key={card.toString()} className="-ml-10 first:ml-0">
+                <div key={card.toString()} className="-ml-11 first:ml-0">
                   {cardFace}
                 </div>
               )
@@ -84,7 +95,7 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
                 disabled={!isLegal}
                 onClick={() => playable.onPlay(card)}
                 aria-label={`Play ${card.rank} of ${card.suit}`}
-                className={`-ml-10 first:ml-0 rounded-lg transition-transform ${
+                className={`-ml-11 first:ml-0 rounded-lg transition-transform ${
                   isLegal
                     ? 'cursor-pointer ring-2 ring-amber-400 hover:-translate-y-2'
                     : 'cursor-not-allowed opacity-40'
@@ -96,9 +107,10 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
           })}
         </div>
       ) : exposeCards ? (
-        <div className="flex justify-center gap-1 overflow-x-auto">
+        <div className="flex w-full justify-center gap-1 overflow-x-auto">
+          {/* Same 24px reveal as the human fan above, against a 48px `md` card. */}
           {sortHandForDisplay(seat.hand).map((card, i) => (
-            <div key={i} className="-ml-10 first:ml-0">
+            <div key={i} className="-ml-7 first:ml-0">
               <PlayingCard suit={card.suit} rank={card.rank} size="md" />
             </div>
           ))}

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -28,11 +28,28 @@ export interface TableProps {
   exposeCards?: boolean
 }
 
+/**
+ * Where each seat sits in the 3x3 board.
+ *
+ * The top and bottom seats span the full width (#161). Pinned to the centre
+ * column they got half the board, which is not enough for a hand: the human's
+ * 12-card fan measured 564px against a 390px phone.
+ *
+ * Every seat is `justify-self-stretch min-w-0`, overriding the grid's
+ * `justify-items-center` (which is still what centres the trick circle). A
+ * centred grid item is sized by its own content, and a fanned hand's
+ * min-content width is the whole fan — `overflow-x-auto` does not reduce it —
+ * so a seat sized itself to its cards and then overflowed its column no matter
+ * how narrow the column was. Stretching gives the seat the column's width and
+ * `min-w-0` lets that width actually be smaller than the cards, which is what
+ * finally hands the fan a definite width to scroll inside.
+ */
+const SEAT_CELL_CLASS = 'min-w-0 justify-self-stretch'
 const POSITION_GRID_CLASS: Record<SeatPosition, string> = {
-  top: 'col-start-2 row-start-1',
-  left: 'col-start-1 row-start-2',
-  right: 'col-start-3 row-start-2',
-  bottom: 'col-start-2 row-start-3',
+  top: `col-span-full row-start-1 ${SEAT_CELL_CLASS}`,
+  left: `col-start-1 row-start-2 ${SEAT_CELL_CLASS}`,
+  right: `col-start-3 row-start-2 ${SEAT_CELL_CLASS}`,
+  bottom: `col-span-full row-start-3 ${SEAT_CELL_CLASS}`,
 }
 
 /**
@@ -72,13 +89,22 @@ export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, expos
   const bidWinnerSeat = bidWinner === null ? undefined : seats.find((seat) => seat.player === bidWinner)
 
   return (
-    <div className="relative flex min-h-svh flex-col bg-green-900 text-white">
+    // Safe-area insets (#161, --safe-* in index.css): on an installed instance
+    // the board runs under the home indicator, so the bottom/side insets come
+    // off the height budget here. `box-sizing: border-box` (Tailwind preflight)
+    // means this padding comes out of `min-h-svh` rather than adding to it. The
+    // top inset is handled by the Scoreboard, whose own background then fills
+    // the strip behind the status bar instead of leaving a bare gap.
+    <div className="relative flex min-h-svh flex-col bg-green-900 pr-[var(--safe-right)] pb-[var(--safe-bottom)] pl-[var(--safe-left)] text-white">
       {onOpenMenu && (
         <button
           type="button"
           onClick={onOpenMenu}
           aria-label="Open menu"
-          className="absolute top-2 left-2 z-10 rounded bg-black/40 px-2 py-1 text-xs font-semibold text-white hover:bg-black/60"
+          // Absolute offsets resolve against the padding box, i.e. the very
+          // top-left corner, so this needs the inset added in explicitly or it
+          // sits under the notch.
+          className="absolute top-[calc(0.5rem_+_var(--safe-top))] left-[calc(0.5rem_+_var(--safe-left))] z-10 rounded bg-black/40 px-2 py-1 text-xs font-semibold text-white hover:bg-black/60"
         >
           ☰ Menu
         </button>
@@ -91,7 +117,17 @@ export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, expos
         trumpSuit={trumpSuit}
         meldPoints={meldPoints}
       />
-      <div className="grid flex-1 grid-cols-[1fr_2fr_1fr] grid-rows-[1fr_2fr_1fr] items-center justify-items-center gap-4 p-4">
+      {/* Columns are capped, not proportional (#161). `1fr 2fr 1fr` let the
+          centre column be sized by its contents, so the trick circle set a
+          floor under the whole board and the grid was wider than the phone
+          before a single card was dealt. `minmax(0, 13rem)` caps the centre at
+          the circle's width and lets it shrink below that on a narrow screen,
+          and `minmax(0, 1fr)` lets the side seats fall to zero rather than
+          widening the board — together they make the grid physically unable to
+          exceed the viewport down to ~240px. Rows stay content-sized top and
+          bottom with the circle taking the slack. Gutters halved from 4 to 2
+          (16px -> 8px): 32px of the 390 was board margin. */}
+      <div className="grid flex-1 grid-cols-[minmax(0,1fr)_minmax(0,13rem)_minmax(0,1fr)] grid-rows-[auto_1fr_auto] items-center justify-items-center gap-2 p-2">
         {seats.map((seat) => (
           <div
             key={seat.player}
@@ -112,10 +148,20 @@ export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, expos
           <TrickArea trick={trick} humanPlayer={humanPlayer} winningPlayer={trickWinner} trickNumber={trickNumber} />
         </div>
       </div>
-      {logPanel && <div className="fixed top-16 right-2 z-30">{logPanel}</div>}
+      {/* Fixed to the viewport, so the root's safe-area padding doesn't reach
+          it — both of these carry the insets themselves. */}
+      {logPanel && (
+        <div className="fixed top-[calc(4rem_+_var(--safe-top))] right-[calc(0.5rem_+_var(--safe-right))] z-30">
+          {logPanel}
+        </div>
+      )}
       {overlay && (
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4" onMouseDown={onMouseDown} onTouchStart={onMouseDown}>
+        <div
+          className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 pt-[calc(1rem_+_var(--safe-top))] pr-[calc(1rem_+_var(--safe-right))] pb-[calc(1rem_+_var(--safe-bottom))] pl-[calc(1rem_+_var(--safe-left))]"
+          onMouseDown={onMouseDown}
+          onTouchStart={onMouseDown}
+        >
           <div data-draggable className="inline-block cursor-grab">
             {overlay}
           </div>

--- a/web/src/components/TrickArea.tsx
+++ b/web/src/components/TrickArea.tsx
@@ -33,7 +33,16 @@ export function TrickArea({ trick, humanPlayer, winningPlayer, trickNumber }: Tr
       {trickNumber !== undefined && (
         <span className="text-xs font-semibold text-white/70">Trick {trickNumber} of 12</span>
       )}
-      <div className="grid aspect-square w-72 max-w-full min-h-[12rem] grid-cols-3 grid-rows-3 items-center justify-items-center rounded-full bg-green-950/40">
+      {/* 13rem (208px) rather than the old 18rem (288px), which was 74% of a
+          390px phone viewport on its own and left ~100px for the two side
+          seats put together (#161). 208 is three 64px cards across, which is
+          all the 3x3 placement grid inside ever needs. The old
+          `min-h-[12rem]` is gone with it: it existed to stop `max-w-full`
+          collapsing the circle on a narrow screen, but it did that by letting
+          the box go taller than it is wide — at 208 the aspect ratio holds the
+          height on its own, and a floor above the width would only re-introduce
+          a non-circular circle. */}
+      <div className="grid aspect-square w-52 max-w-full grid-cols-3 grid-rows-3 items-center justify-items-center rounded-full bg-green-950/40">
       {trick.map((play) => (
         <div
           key={play.player}

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -280,7 +280,9 @@ export function TrickPlayFlow({
           <button
             type="button"
             onClick={() => setShowConfirmDialog(true)}
-            className="absolute top-2 right-2 z-20 rounded bg-red-800 px-3 py-1 text-xs font-semibold text-white hover:bg-red-900"
+            // Safe-area insets (#161): pinned to the top-right corner, which is
+            // where the status bar / notch sits on an installed instance.
+            className="absolute top-[calc(0.5rem_+_var(--safe-top))] right-[calc(0.5rem_+_var(--safe-right))] z-20 rounded bg-red-800 px-3 py-1 text-xs font-semibold text-white hover:bg-red-900"
           >
             Concede hand
           </button>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,6 +2,20 @@
 
 :root {
   color-scheme: light dark;
+
+  /* Safe-area insets (#161). index.html sets `viewport-fit=cover` and the app
+     is `apple-mobile-web-app-capable`, so an installed instance renders *under*
+     the notch and the home indicator — the usable height is less than the
+     viewport height, and anything pinned to an edge lands under hardware.
+     env() is only readable in a property value, so it is captured here once and
+     composed at the call sites (`calc(0.5rem + var(--safe-top))`) rather than
+     repeated. Naming them also makes them overridable, which is how
+     src/layout/layoutProbe.tsx simulates an installed render in a plain browser
+     tab, where every env(safe-area-inset-*) is 0 and the problem is invisible. */
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
 }
 
 body {

--- a/web/src/layout/layoutProbe.tsx
+++ b/web/src/layout/layoutProbe.tsx
@@ -1,0 +1,423 @@
+// Dev-only portrait-fit probe for #161.
+//
+// #161's acceptance criterion is a measurement, not a look: at a phone-sized
+// viewport, in every phase, the document must not scroll. Driving a real game
+// to each phase by hand is slow and non-reproducible (AI bids are random, and
+// game-over needs a full game), so this page mounts each phase's *actual*
+// component tree from fixed, seeded data and measures it.
+//
+// Two modes, both served from layout/index.html:
+//
+//   /layout/                      the runner — loads every (phase, viewport)
+//                                 pair in an exactly-sized iframe and prints
+//                                 the overflow numbers as a table + JSON.
+//   /layout/?frame=1&phase=meld   one phase, rendered alone. What the runner
+//                                 puts in its iframes; also useful to open
+//                                 directly and look at.
+//
+// Notes on what the numbers mean:
+//
+//   An iframe of width W gives its document a viewport of exactly W CSS px,
+//   which is the point — `resize`-ing a desktop browser window cannot produce
+//   a 390px viewport without also involving the device pixel ratio. Classic
+//   desktop scrollbars would steal ~15px of that, which a phone's overlay
+//   scrollbars do not, so frame mode hides them; the frame is measuring what
+//   the phone sees, not what a Windows Chrome window sees.
+//
+//   `env(safe-area-inset-*)` is always 0 in a browser tab, so `?insets=1`
+//   overrides index.css's --safe-* variables with an iPhone-14-Pro-class
+//   portrait inset set. That is the real height budget for an installed
+//   instance (index.html sets viewport-fit=cover + apple-mobile-web-app-capable),
+//   and it is smaller than the nominal viewport.
+//
+//   Overlays are `position: fixed`, which by spec contributes nothing to the
+//   document's scrollable overflow — a modal taller than the screen would be
+//   clipped and unreachable while still measuring 0 overflow. So the runner
+//   also reports the overlay panel's own rect against the viewport.
+
+import { StrictMode, type ReactElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import '../index.css'
+import { Deck, Suit, type Card } from '../engine/card'
+import type { Hands, TeamId } from '../engine/round'
+import { Trick, type PlayerIndex } from '../engine/trick'
+import { AuctionLog } from '../components/AuctionLog'
+import type { AuctionLogEntry } from '../components/auctionTypes'
+import { BiddingControls } from '../components/BiddingControls'
+import { GameOverScreen } from '../components/GameOverScreen'
+import { MeldFlow } from '../components/MeldFlow'
+import { PassSelector } from '../components/PassSelector'
+import { RoundSummary } from '../components/RoundSummary'
+import { Table } from '../components/Table'
+import type { TableState } from '../components/tableTypes'
+import { TrickLog } from '../components/TrickLog'
+import type { TrickPlayLogEntry } from '../components/trickPlayTypes'
+
+// ---------------------------------------------------------------------------
+// Fixed worst-case fixtures — deliberately the longest names in the pools
+// (names.ts / teamNames.ts) and a full 12-card human hand, since name length
+// is what the narrow side seats have to survive and hand size is what the
+// bottom seat has to survive.
+// ---------------------------------------------------------------------------
+
+const HUMAN: PlayerIndex = 0
+const SEAT_NAMES: Record<PlayerIndex, string> = {
+  0: 'You',
+  1: 'Maximilian',
+  2: 'Beauregard',
+  3: 'Lorathien',
+}
+const TEAM_NAMES: Record<TeamId, string> = {
+  0: 'Wyrmscale Brotherhood',
+  1: 'Thornveil Ascendancy',
+}
+const SCORES: Record<TeamId, number> = { 0: 480, 1: 520 }
+const TRUMP = Suit.Hearts
+const BID = 340
+const BID_WINNER: PlayerIndex = 1
+
+/** Seeded deal, so every run of the probe measures the same cards. */
+function seededHands(seed: number): Hands {
+  const realRandom = Math.random
+  let s = seed >>> 0
+  Math.random = () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0
+    return s / 4294967296
+  }
+  try {
+    const deck = new Deck()
+    deck.shuffle()
+    return deck.deal()
+  } finally {
+    Math.random = realRandom
+  }
+}
+
+const HANDS = seededHands(161)
+
+const AUCTION_LOG: readonly AuctionLogEntry[] = [
+  { kind: 'pass-bid', player: 3, name: SEAT_NAMES[3] },
+  { kind: 'bid', player: 0, name: SEAT_NAMES[0], amount: 300 },
+  { kind: 'bid', player: 1, name: SEAT_NAMES[1], amount: 310 },
+  { kind: 'bid', player: 2, name: SEAT_NAMES[2], amount: 320 },
+  { kind: 'bid', player: 1, name: SEAT_NAMES[1], amount: 340 },
+  { kind: 'pass-bid', player: 0, name: SEAT_NAMES[0] },
+  { kind: 'pass-bid', player: 2, name: SEAT_NAMES[2] },
+  { kind: 'trump', player: 1, name: SEAT_NAMES[1], suit: TRUMP },
+  { kind: 'card-pass', fromPlayer: 3, fromName: SEAT_NAMES[3], toPlayer: 1, toName: SEAT_NAMES[1], count: 3 },
+]
+
+function baseSeats(hands: Hands, statusText?: (p: PlayerIndex) => string | undefined): TableState['seats'] {
+  const seat = (p: PlayerIndex) => ({
+    player: p,
+    name: SEAT_NAMES[p],
+    hand: hands[p] as readonly Card[],
+    statusText: statusText?.(p),
+  })
+  return [seat(0), seat(1), seat(2), seat(3)]
+}
+
+const noop = () => {}
+
+// ---------------------------------------------------------------------------
+// Phases — each is the same composition its real flow component builds, so
+// what the probe measures is what a player gets.
+// ---------------------------------------------------------------------------
+
+export const PHASES = ['auction', 'pass', 'meld', 'trick', 'summary', 'gameover'] as const
+export type PhaseId = (typeof PHASES)[number]
+
+function auctionPhase() {
+  // AuctionFlow's bidding composition: table + BiddingControls overlay + log.
+  const state: TableState = {
+    seats: baseSeats(HANDS, (p) => (p === 3 ? 'Pass' : p === 1 ? '(310)' : p === 2 ? '(Waiting)' : undefined)),
+    humanPlayer: HUMAN,
+    trick: [],
+    trumpSuit: null,
+    currentBid: 310,
+    bidWinner: null,
+    scoresByTeam: SCORES,
+    teamNames: TEAM_NAMES,
+    dealer: 3,
+  }
+  return (
+    <Table
+      state={state}
+      overlay={
+        <BiddingControls minBid={320} currentBid={310} suggestedCeiling={330} onBid={noop} onPass={noop} />
+      }
+      logPanel={
+        <AuctionLog
+          entries={AUCTION_LOG.slice(0, 5)}
+          currentBid={310}
+          bidWinnerName={SEAT_NAMES[1]}
+          dealerName={SEAT_NAMES[3]}
+        />
+      }
+      onOpenMenu={noop}
+    />
+  )
+}
+
+function passPhase() {
+  // AuctionFlow's passing composition: table + PassSelector overlay + log.
+  const state: TableState = {
+    seats: baseSeats(HANDS),
+    humanPlayer: HUMAN,
+    trick: [],
+    trumpSuit: TRUMP,
+    currentBid: BID,
+    bidWinner: BID_WINNER,
+    scoresByTeam: SCORES,
+    teamNames: TEAM_NAMES,
+    dealer: 3,
+  }
+  return (
+    <Table
+      state={state}
+      overlay={<PassSelector hand={HANDS[HUMAN]} count={3} trumpSuit={TRUMP} onConfirm={noop} />}
+      logPanel={<AuctionLog entries={AUCTION_LOG} currentBid={BID} bidWinnerName={SEAT_NAMES[1]} dealerName={SEAT_NAMES[3]} />}
+      onOpenMenu={noop}
+    />
+  )
+}
+
+function meldPhase() {
+  // The real MeldFlow — it is deterministic given hands + trump, and it is the
+  // phase that puts every seat's cards on the table at once (exposeCards) with
+  // both teams' meld columns over the top.
+  return (
+    <MeldFlow
+      hands={HANDS.map((h) => [...h]) as Hands}
+      trumpSuit={TRUMP}
+      bidWinner={BID_WINNER}
+      bid={BID}
+      seatNames={SEAT_NAMES}
+      humanPlayer={HUMAN}
+      scoresByTeam={SCORES}
+      teamNames={TEAM_NAMES}
+      dealer={3}
+      onOpenMenu={noop}
+      onComplete={noop}
+      onConcede={noop}
+    />
+  )
+}
+
+function trickPhase() {
+  // TrickPlayFlow's composition at the tightest moment of a hand: the human
+  // still holds all 12 cards, three opponents' cards are already on the table,
+  // and both logs are up.
+  const hands = HANDS.map((h) => [...h]) as Hands
+  const trick = new Trick(TRUMP)
+  for (const p of [1, 2, 3] as PlayerIndex[]) {
+    const card = hands[p].pop()
+    if (card) trick.play(p, card)
+  }
+  const log: TrickPlayLogEntry[] = trick.plays.map((play, i) => ({
+    kind: 'card-play',
+    player: play.player,
+    name: SEAT_NAMES[play.player],
+    card: play.card,
+    isLead: i === 0,
+  }))
+  const state: TableState = {
+    seats: baseSeats(hands),
+    humanPlayer: HUMAN,
+    trick: trick.plays,
+    trumpSuit: TRUMP,
+    currentBid: BID,
+    bidWinner: BID_WINNER,
+    scoresByTeam: SCORES,
+    teamNames: TEAM_NAMES,
+    humanPlayable: { legalCards: hands[HUMAN], onPlay: noop },
+    trickWinner: null,
+    dealer: 3,
+    meldPoints: 60,
+  }
+  return (
+    <Table
+      state={state}
+      logPanel={
+        <div className="flex flex-col gap-2">
+          <AuctionLog entries={AUCTION_LOG} />
+          <TrickLog entries={log} />
+        </div>
+      }
+      onOpenMenu={noop}
+      trickNumber={1}
+    />
+  )
+}
+
+function summaryPhase() {
+  return (
+    <RoundSummary
+      data={{
+        meldPointsByTeam: { 0: 60, 1: 140 },
+        trickPointsByTeam: { 0: 110, 1: 140 },
+        roundScoreByTeam: { 0: 170, 1: 280 },
+        bidWinnerTeam: 1,
+        bid: BID,
+        cumulativeScoresByTeam: { 0: 650, 1: 800 },
+        teamNames: TEAM_NAMES,
+      }}
+      onContinue={noop}
+    />
+  )
+}
+
+function gameOverPhase() {
+  return (
+    <GameOverScreen
+      data={{ winningTeam: 1, finalScoresByTeam: { 0: 880, 1: 1030 }, teamNames: TEAM_NAMES }}
+      onNewGame={noop}
+    />
+  )
+}
+
+const PHASE_RENDERERS: Record<PhaseId, () => ReactElement> = {
+  auction: auctionPhase,
+  pass: passPhase,
+  meld: meldPhase,
+  trick: trickPhase,
+  summary: summaryPhase,
+  gameover: gameOverPhase,
+}
+
+// ---------------------------------------------------------------------------
+// Runner — loads each phase in an exactly-sized iframe and reads the numbers
+// out of it. Same-origin, so the parent can measure the child directly.
+// ---------------------------------------------------------------------------
+
+/** iPhone 14 Pro portrait insets, the case index.html's viewport-fit=cover buys. */
+const SIM_INSETS = { top: '59px', right: '0px', bottom: '34px', left: '0px' }
+
+const VIEWPORTS: readonly { label: string; w: number; h: number }[] = [
+  { label: '390x844', w: 390, h: 844 },
+  { label: '360x640', w: 360, h: 640 },
+  { label: '430x932', w: 430, h: 932 },
+]
+
+interface Measurement {
+  phase: PhaseId
+  viewport: string
+  insets: boolean
+  overflowY: number
+  overflowX: number
+  /** Overlay/modal panel bottom and right relative to the viewport — positive
+   * means part of the panel is off-screen and unreachable (fixed elements do
+   * not show up in the document overflow numbers above). */
+  panelOverflowY: number
+  panelOverflowX: number
+}
+
+function measureFrame(win: Window, doc: Document): Omit<Measurement, 'phase' | 'viewport' | 'insets'> {
+  const de = doc.documentElement
+  const panel = doc.querySelector('.fixed.inset-0')?.firstElementChild
+  const rect = panel?.getBoundingClientRect()
+  return {
+    overflowY: de.scrollHeight - win.innerHeight,
+    overflowX: de.scrollWidth - win.innerWidth,
+    panelOverflowY: rect ? Math.round(Math.max(rect.bottom - win.innerHeight, -rect.top)) : 0,
+    panelOverflowX: rect ? Math.round(Math.max(rect.right - win.innerWidth, -rect.left)) : 0,
+  }
+}
+
+function frameUrl(phase: PhaseId, insets: boolean): string {
+  return `?frame=1&phase=${phase}${insets ? '&insets=1' : ''}`
+}
+
+async function runOne(phase: PhaseId, w: number, h: number, insets: boolean): Promise<Measurement> {
+  const frame = document.createElement('iframe')
+  frame.setAttribute('style', `width:${w}px;height:${h}px;border:0;display:block;position:absolute;left:-9999px`)
+  frame.src = frameUrl(phase, insets)
+  document.body.appendChild(frame)
+  await new Promise((resolve) => frame.addEventListener('load', resolve, { once: true }))
+  // React mounts in an effect; give it a couple of frames plus a beat for
+  // fonts/layout to settle before reading rects.
+  await new Promise((resolve) => setTimeout(resolve, 250))
+  const measurement = measureFrame(frame.contentWindow!, frame.contentDocument!)
+  frame.remove()
+  return { phase, viewport: `${w}x${h}`, insets, ...measurement }
+}
+
+async function runAll(out: HTMLElement, insets: boolean): Promise<void> {
+  const rows: Measurement[] = []
+  const lines = [
+    `viewport   phase     insets  overflowY  overflowX  panelY  panelX  verdict`,
+  ]
+  out.textContent = 'measuring…'
+  for (const vp of VIEWPORTS) {
+    for (const phase of PHASES) {
+      const m = await runOne(phase, vp.w, vp.h, insets)
+      rows.push(m)
+      const ok = m.overflowY <= 0 && m.overflowX <= 0 && m.panelOverflowY <= 0 && m.panelOverflowX <= 0
+      lines.push(
+        [
+          vp.label.padEnd(10),
+          phase.padEnd(9),
+          String(insets).padEnd(7),
+          String(m.overflowY).padStart(9),
+          String(m.overflowX).padStart(10),
+          String(m.panelOverflowY).padStart(7),
+          String(m.panelOverflowX).padStart(7),
+          '  ' + (ok ? 'PASS' : 'FAIL'),
+        ].join(''),
+      )
+      out.textContent = lines.join('\n')
+    }
+  }
+  const failures = rows.filter(
+    (m) => m.overflowY > 0 || m.overflowX > 0 || m.panelOverflowY > 0 || m.panelOverflowX > 0,
+  )
+  lines.push('')
+  lines.push(failures.length === 0 ? 'ALL PASS' : `${failures.length} FAILING`)
+  lines.push('')
+  lines.push(JSON.stringify(rows))
+  out.textContent = lines.join('\n')
+}
+
+function mountRunner(): void {
+  document.body.innerHTML = `
+    <div style="font:12px/1.5 ui-monospace,monospace;margin:12px">
+      <h1 style="font-size:14px">Portrait fit probe (#161)</h1>
+      <p>Each row loads one phase in an iframe sized to a real phone viewport and reads
+         <code>scrollHeight - innerHeight</code> / <code>scrollWidth - innerWidth</code>.
+         Non-positive is a pass. <code>panelY/panelX</code> is the modal overlay's own rect
+         against the viewport, since <code>position: fixed</code> never shows up in document overflow.</p>
+      <button id="run">run (no insets)</button>
+      <button id="run-insets">run (simulated notch/home-indicator insets)</button>
+      <pre id="out" style="white-space:pre">idle</pre>
+    </div>
+  `
+  const out = document.getElementById('out') as HTMLElement
+  document.getElementById('run')!.addEventListener('click', () => void runAll(out, false))
+  document.getElementById('run-insets')!.addEventListener('click', () => void runAll(out, true))
+}
+
+function mountFrame(phase: PhaseId, insets: boolean): void {
+  // Desktop scrollbars take layout width; phone overlay scrollbars do not, and
+  // it is the phone we are measuring for.
+  const style = document.createElement('style')
+  style.textContent = 'html{scrollbar-width:none}html::-webkit-scrollbar{display:none}'
+  document.head.appendChild(style)
+  if (insets) {
+    const root = document.documentElement
+    root.style.setProperty('--safe-top', SIM_INSETS.top)
+    root.style.setProperty('--safe-right', SIM_INSETS.right)
+    root.style.setProperty('--safe-bottom', SIM_INSETS.bottom)
+    root.style.setProperty('--safe-left', SIM_INSETS.left)
+  }
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>{PHASE_RENDERERS[phase]()}</StrictMode>,
+  )
+}
+
+const params = new URLSearchParams(location.search)
+if (params.get('frame') === '1') {
+  const phase = (params.get('phase') ?? 'trick') as PhaseId
+  mountFrame(PHASES.includes(phase) ? phase : 'trick', params.get('insets') === '1')
+} else {
+  mountRunner()
+}


### PR DESCRIPTION
Paul reported the table was too wide and too big on a 2532x1170 phone. That
device reports `devicePixelRatio: 3`, so CSS sees **390 x 844** — everything
below is in that space.

## What was actually wrong

At 390x844 the document was **882px wide** before a card was dealt. Cards being
too big was real but was not the whole story; two structural things were:

- The trick circle was `w-72` (288px, **74% of the viewport**) inside a
  `1fr 2fr 1fr` grid whose centre column is sized by its contents. The circle
  therefore set a floor under the entire board and left ~100px for both side
  seats put together.
- The human's 12-card fan measured **564px**, and because the grid centres its
  items (`justify-items-center` → a grid item sized by its own content) the fan
  never reached the width that would make its own `overflow-x-auto` engage — it
  just pushed the page out. `min-w-0` on the cell is not enough on its own: a
  fan's min-content width is the whole fan, and being a scroll container does
  not reduce it. The seat has to be *stretched* to the column before the
  overflow rule means anything.

Vertical was already fine at 844, but overflowed 68–132px at 360x640.

## Changes

**Cards ~20% smaller**, as matched sets in `CARD_SIZES` (`PlayingCard.tsx`):
`lg` 80 → 64 (`w-16`), `md` 60 → 48, `sm` 36 → 28, with the corner/centre type
scale following. `aspect-5/7` is untouched, so heights follow: 112 → 90,
84 → 67, 50 → 39. Width still lives in `CARD_SIZES` and nowhere else — #94 is
not reintroduced, and the test that guards it is updated rather than relaxed.
The rotated corner's offsets move into `CARD_SIZES` too: they were hardcoded in
the JSX and would otherwise have stayed put while the card shrank under them.

**Fan overlaps retuned to the new widths** (`Seat.tsx`): `-ml-11` against a 64px
card, `-ml-7` against 48. Both leave a 24px reveal — enough for the corner index
— and put all 12 cards in 328px. The overlap is paired with the card width, so
the pairing is called out in a comment and pinned by the size test.

**Trick circle 288 → 208** (`w-72` → `w-52`), which is three 64px cards across —
all the 3x3 placement grid inside ever needs. `min-h-[12rem]` is removed with
it: as the issue predicted it would have become the binding constraint, and it
only ever worked by letting the "circle" be taller than it is wide.

**Board**: `grid-cols-[minmax(0,1fr)_minmax(0,13rem)_minmax(0,1fr)]` and
`grid-rows-[auto_1fr_auto]`, gutters `gap-4 p-4` → `gap-2 p-2` (32px of the 390
was board margin). Top and bottom seats span the full width, and every seat is
`justify-self-stretch min-w-0`. The grid is now physically unable to exceed the
viewport down to ~240px wide.

**Safe-area insets — these were not handled at all.** `index.html` sets
`viewport-fit=cover` and the app is `apple-mobile-web-app-capable`, so an
installed instance renders under the notch and home indicator and the real
height budget is less than 844; the menu button sat under the status bar.
`--safe-*` in `index.css` captures `env(safe-area-inset-*)` once. The Scoreboard
owns the top inset so its own background fills the status-bar strip rather than
leaving a bare band of felt, the Table root takes bottom/sides out of
`min-h-svh` (border-box, so it comes out of the budget rather than adding to
it), and the edge-pinned controls (menu, concede, log panel) plus the modal
gutter compose it in.

## Measured, not eyeballed

`layout/index.html` + `src/layout/layoutProbe.tsx` is a dev-only probe on the
same terms as the existing `bench/` page — served at `/layout/`, never a
`vite build` input, confirmed absent from `dist/`. It mounts each phase's real
component tree from a seeded deal and worst-case fixtures (the longest names in
both pools, a full 12-card hand).

Three things about it are load-bearing, and are documented in `web/README.md`:

- **An iframe, not a resized window** — a desktop browser cannot produce a 390px
  viewport by resizing, which is exactly the confusion the issue opens with.
  Frame mode also hides scrollbars, since desktop scrollbars take ~15px of
  layout width and a phone's overlay scrollbars take none.
- **`?insets=1`** overrides `--safe-*` with an iPhone-14-Pro-class portrait
  inset set, because `env(safe-area-inset-*)` is always 0 in a browser tab and
  the problem is otherwise invisible.
- **A separate panel column** — overlays are `position: fixed` and contribute
  nothing to document overflow, so a modal taller than the screen would be
  clipped and unreachable while still measuring 0.

`scrollWidth - innerWidth` at **390x844**, before → after:

| phase | before X | after X | before Y | after Y |
|---|---|---|---|---|
| auction | **454** | 0 | 0 | 0 |
| 3-card pass | **492** | 0 | 0 | 0 |
| meld | **570** | 0 | 0 | 0 |
| trick play | **492** | 0 | 0 | 0 |
| round summary | 0 | 0 | 0 | 0 |
| game over | 0 | 0 | 0 | 0 |

Meld was indeed the worst case, as the issue predicted — it is the phase that
puts every seat's cards on the table (`exposeCards`) with both teams' meld
columns over the top, and it was the last thing still failing after the card
and circle changes.

At **360x640** the before numbers were worse in both axes (auction 68/484,
pass 68/522, meld 92/600, trick 132/522) and are now 0/0. **430x932** clips
nothing. All **36** cases pass — 6 phases x 3 viewports, with and without
simulated insets.

Numbers from the probe are cross-checked against a real driven game rather than
fixtures: a full round (auction → pass → pass reveal → meld → 12 tricks → round
summary) in a 390x844 frame measured **0/0 at every one of 44 samples**.

Landscape is not a target (`orientation: portrait` in the manifest) but does not
become unusable — it scrolls ~20–95px at 844x390.

## Checks

- `npm test` — **339 passed** (338 baseline, +1: a new guard that `aspect-5/7`
  survives future size changes, since a card is a width plus a ratio and
  nothing sets a height)
- `python -m pytest -q` — **288 passed**
- `npm run build` — clean; `dist/` contains no `layout/`
- `npm run lint` — 3 pre-existing `exhaustive-deps` warnings, untouched by this
  change

Out of scope and untouched: colours, typography, animation, general restyling.

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
