### PR TITLE
fix(names): replace 'Trump Tight' in the team-name pool (#162)

### DIFF
--- a/web/src/engine/teamNames.test.ts
+++ b/web/src/engine/teamNames.test.ts
@@ -9,6 +9,13 @@ describe('TEAM_NAME_POOL', () => {
   it('has no duplicate entries', () => {
     expect(new Set(TEAM_NAME_POOL).size).toBe(50)
   })
+
+  // #162: Paul wants no team name containing "trump" in any casing. The word
+  // is everywhere in this codebase as the game mechanic (trumpSuit, etc.) —
+  // this guard is scoped to the *name pool* only, so it can't drift back in.
+  it('contains no name matching /trump/i', () => {
+    expect(TEAM_NAME_POOL.filter((name) => /trump/i.test(name))).toEqual([])
+  })
 })
 
 describe('sampleTeamNames', () => {

--- a/web/src/engine/teamNames.ts
+++ b/web/src/engine/teamNames.ts
@@ -16,7 +16,7 @@ export const TEAM_NAME_POOL: readonly string[] = [
   'Nova Squadron', 'Quantum Drifters', 'Voidrunner Fleet', 'Ironstar Collective', 'Photon Vanguard',
   'Nebula Task Force', 'Cryo Raiders', 'Orbital Sentinels', 'Fusion Reactants', 'Starforge Division',
   // Normal / casual (10)
-  'The Card Sharks', 'Trump Tight', 'Meld Squad', 'The Bid Bandits', 'Table Talk',
+  'The Card Sharks', 'Trick Takers', 'Meld Squad', 'The Bid Bandits', 'Table Talk',
   'Deal Breakers', 'The Aces High', 'Suit Yourselves', 'Full House Crew', 'Pinochle Posse',
 ]
 


### PR DESCRIPTION
## What

`TEAM_NAME_POOL` had exactly one entry containing "trump" as a *name* rather than as the game mechanic: `'Trump Tight'`, in the "Normal / casual" block. Replaced it with **`'Trick Takers'`** — same slot, same register as its neighbours (`Meld Squad`, `The Bid Bandits`, `Deal Breakers`, `Pinochle Posse`).

Replaced rather than deleted, per the issue: the themed blocks are deliberately sized, and dropping the casual block to 9 would skew the random draw toward the fantasy and sci-fi blocks. The casual block is still 10 entries and the pool is still 50.

## Regression guard

Added a test asserting no `TEAM_NAME_POOL` entry matches `/trump/i`. It reports the offending names on failure rather than just a boolean. The existing `teamNames.test.ts` asserted pool length (50) and uniqueness but nothing about specific contents, so no other test needed updating.

## Scoping — nothing else was touched

Every other occurrence of "trump" in the codebase is the game mechanic and is left completely alone. I verified this rather than assuming:

- Aggregated every `\w*trump\w*` token across `web/src` and the root `.py` files: all are identifiers (`trumpSuit`, `trump_suit`, `trump_length`, `TOTAL_TRUMP_COPIES`, `TrumpSelector`, `overtrump`, …), prose in comments/docstrings, or UI labels (`Trump: ♥`).
- Case-sensitive search for `\bTrump\b` across all `.ts/.tsx/.js/.py/.json/.md/.css`: the only name-shaped hit was `teamNames.ts:19`. The rest are UI strings, doc headings, and comments.
- Confirmed `NAME_POOL` in `web/src/engine/names.ts` and its Python original `names.py` are both clean — zero matches for "trump" in either.

The diff is two files: one string, plus the guard.

## Tests

- `npm test` in `web/`: **341 passed** (340 baseline + the new guard), 38 files
- `python -m pytest -q` at root: **288 passed**
- `npm run build`: clean. `npm run lint`: only the three pre-existing `exhaustive-deps` warnings in `TrickPlayFlow.tsx` / `AuctionFlow.tsx`, both untouched here.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)