### PR TITLE
fix(ai): Python feeds partner the lowest counter too (#164)

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -552,11 +552,63 @@ def _current_winner(trick_plays, trump):
     return max(pool, key=lambda pc: RANK_VALUE[pc[1].rank])
 
 
+def _feed_partner(legal_moves):
+    """
+    Partner is winning and you cannot take the trick off them: bank a counter
+    into it, and make it the *cheapest* one you hold (#164).
+
+    A, 10 and K are worth exactly 10 points each (`pinochle_rules.md:140`), so
+    which counter goes in does not change what the trick pays - only what is
+    left in hand afterwards. The King is the one to spend: it banks the same
+    10 while the 10 it keeps is beaten by nothing but an Ace and will often take
+    a later trick outright. This used to be `max`, which threw the 10 and kept
+    the King - identical points for a worse hand, on every deal.
+
+    The Ace stays out of it, so a hand holding an Ace and no other counter
+    donates junk rather than the boss of the suit. That exclusion is measured,
+    not assumed: #154 ran the "play your lowest legal point" variant (which
+    orders K -> 10 -> A and so puts the Ace in) as its own arm over 5000 paired
+    deals, where it was a null against the old `max` behaviour (+0.4 per deal,
+    95% CI -1.7 to +2.5) and 3.6 points a deal behind this one - donating the
+    Ace gives back the whole gain of spending the King. Both results reproduced
+    on a second seed; see `web/README.md`. That question is settled, in both
+    engines, and this side did not re-open it.
+
+    Re-measured here rather than inherited, because the Python AI reaches this
+    tier differently - `ab_harness.py`, 5000 paired deals per arm, this against
+    the old `max`:
+
+        Proficient, seed 164   +3.61/deal   95% CI +1.83 to +5.45   swept 32-10
+        Proficient, seed 27    +2.16/deal   95% CI +0.66 to +3.70   swept 16-8
+        GeneralStrategy 4      -3.07/deal   95% CI -7.67 to +1.54   swept 125-135
+
+    Proficient reproduces the TypeScript result almost exactly (+3.55 there),
+    on both seeds. Skill 4 is a null, and expected to be: skills 4-5 follow with
+    `choose_expert_follow_card`, so the only thing this function changes for
+    them is how the *rollouts* play - and a rollout is self-play, so both sides
+    of the simulated playout get the same 10 points either way. That arm is also
+    much noisier (260 decisive pairs against Proficient's 42), so it could not
+    have resolved an effect this size regardless. Skills 1-3 are the levels this
+    moves, and skill 3 measured byte-identical to Proficient.
+    """
+    counters = [c for c in legal_moves if c.rank in ("K", "10")]
+    if counters:
+        return min(counters, key=lambda c: RANK_VALUE[c.rank])
+    return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])  # avoid donating a live Ace unless forced
+
+
 def choose_follow_card(hand, legal_moves, trick_plays, trump, my_team_players, tracker=None):
     """
     Choose which legal card to play when following (not leading).
     `legal_moves` already has the mandatory beat-if-possible / trump-if-void
     rules applied by Trick.legal_moves - this only picks which one to use.
+
+    Following suit, off-trump, in priority order:
+      1. Forced beat (every legal card already beats the current winner) -
+         play the lowest one, saving the bigger cards for later.
+      2. Partner is winning - feed them the cheapest counter (`_feed_partner`).
+      3. Otherwise - lowest non-point card, falling back to the lowest legal
+         card when only point cards are left.
     """
     if len(legal_moves) == 1:
         return legal_moves[0]
@@ -575,10 +627,7 @@ def choose_follow_card(hand, legal_moves, trick_plays, trump, my_team_players, t
         if forced_beat:
             return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
         if partner_winning:
-            feed_cards = [c for c in legal_moves if c.rank in ("K", "10")]
-            if feed_cards:
-                return max(feed_cards, key=lambda c: RANK_VALUE[c.rank])
-            return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])  # avoid donating a live Ace unless forced
+            return _feed_partner(legal_moves)
         non_points = [c for c in legal_moves if c.rank not in POINT_RANKS]
         if non_points:
             return min(non_points, key=lambda c: RANK_VALUE[c.rank])

--- a/test_trick_play_strategy.py
+++ b/test_trick_play_strategy.py
@@ -32,6 +32,9 @@ Covers:
      move.
   7. General legality across randomized hands/trick states for both the
      lead and follow entry points.
+  8. The Proficient-tier `choose_follow_card`'s feed-partner tier (#164) -
+     not a #62 function, but the same rule as section 4's feed case, so it
+     is asserted here rather than in a file of its own.
 
 Run directly (`python test_trick_play_strategy.py`) or via pytest.
 """
@@ -44,6 +47,7 @@ from pinochle_engine import (
     Trick,
     choose_expert_follow_card,
     choose_expert_lead_card,
+    choose_follow_card,
     generate_fake_void_candidates,
     generate_false_card_candidates,
 )
@@ -373,6 +377,51 @@ def test_follow_always_returns_a_legal_move():
         legal = trick.legal_moves(follower_hand)
         card = choose_expert_follow_card(follower_hand, legal, trick.plays, trump, {"p0"}, tracker)
         assert card in legal
+
+
+# ---------------------------------------------------------------------------
+# 8. Proficient-tier choose_follow_card - the feed-partner tier (#164).
+# ---------------------------------------------------------------------------
+
+def test_proficient_follow_feeds_partner_the_lowest_counter():
+    """King and 10 bank the same 10 points, so spend the King and keep the 10 -
+    it loses only to an Ace and often takes a later trick outright. This tier
+    used to call `max` and throw the 10; #154 fixed the identical bug in
+    `web/src/engine/tracker.ts` and #164 fixed it here."""
+    trump = Suit.SPADES
+    partner = object()
+    # Partner leads a Queen; the 9 does not beat it, so this is not a forced
+    # beat and the feed tier is what runs.
+    trick_plays = [(partner, C(Suit.HEARTS, "Q"))]
+    legal = [C(Suit.HEARTS, "9"), C(Suit.HEARTS, "K"), C(Suit.HEARTS, "10")]
+    card = choose_follow_card(legal, legal, trick_plays, trump, {partner}, PlayTracker())
+    assert card.rank == "K"
+
+
+def test_proficient_follow_holds_the_ace_back_when_it_is_the_only_counter():
+    """The measured half of #154, mirrored into Python. "Play your lowest legal
+    point" read literally orders K -> 10 -> A and would donate the Ace here for
+    the same 10 points; that variant was a null against the pre-fix behaviour
+    over 5000 paired deals and 3.6 points a deal behind this one. The trick pays
+    the same either way; the boss of a suit does not."""
+    trump = Suit.SPADES
+    partner = object()
+    trick_plays = [(partner, C(Suit.HEARTS, "Q"))]
+    legal = [C(Suit.HEARTS, "9"), C(Suit.HEARTS, "A")]
+    card = choose_follow_card(legal, legal, trick_plays, trump, {partner}, PlayTracker())
+    assert card.rank == "9"
+
+
+def test_proficient_follow_forced_beat_still_wins_cheaply():
+    """Guards the tier above it: when every legal card already beats the current
+    winner the forced-beat branch runs first, so `_feed_partner` must not be
+    reached and the cheapest winner goes in."""
+    trump = Suit.SPADES
+    opponent = object()
+    trick_plays = [(opponent, C(Suit.HEARTS, "J"))]
+    legal = [C(Suit.HEARTS, "K"), C(Suit.HEARTS, "A")]
+    card = choose_follow_card(legal, legal, trick_plays, trump, set(), PlayTracker())
+    assert card.rank == "K"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`choose_follow_card`'s partner-is-winning tier called `max` on the King/10 it was
about to donate, so it threw the **10** and kept the King — the identical bug #154
fixed in `web/src/engine/tracker.ts`. The TypeScript was a faithful port of a wrong
heuristic, so fixing the port left the original standing. A, 10 and K are worth
exactly 10 points each (`pinochle_rules.md:140`), so both cards bank the same score
and the only difference is what is left in hand — and the 10 loses to nothing but an
Ace. Now `min`, in a named `_feed_partner` helper mirroring TS's `feedPartner`.

**The Ace exclusion is retained.** #154 measured that arm over 5000 paired deals and
it was a null against the old behaviour and ~3.5 points a deal *behind* the
exclusion. Settled; not re-opened here.

## Measured

`ab_harness.py`, 5000 paired deals per arm (10 000 games), lowest-counter against the
old `max`. Both arms play the same deals with the seats mirrored; margin is the
headline because games-won is uninformative at this scale.

| tier | seed | margin/deal | 95% CI | swept | sign-test p | games |
| --- | --- | --- | --- | --- | --- | --- |
| Proficient | 164 | **+3.61** | +1.83 to +5.45 | 32–10 | 0.0009 | 5022–4978 |
| Proficient | 27 | **+2.16** | +0.66 to +3.70 | 16–8 | 0.15 | 5008–4992 |
| GeneralStrategy skill 3 | 164 | +3.61 | +1.83 to +5.45 | 32–10 | 0.0009 | 5022–4978 |
| GeneralStrategy skill 4 | 164 | −3.07 | −7.67 to +1.54 | 125–135 | 0.58 | 4990–5010 |

**Proficient reproduces the TypeScript result almost exactly** — +3.61 against TS's
+3.55, with an interval that excludes zero, and it replicates on a second seed at
+2.16 (also excluding zero). The Python AI does reach this tier under different
circumstances, and the answer came back the same.

**Skill 4 is a null, and reads as one rather than as a contradiction.** Skills 4–5
follow with `choose_expert_follow_card`, not this function, so the only thing the fix
changes for them is how their *rollouts* play — and a rollout is self-play, so both
sides of the simulated playout collect the same 10 points either way. That arm is
also six times noisier (260 decisive pairs against Proficient's 42; CI half-width 4.6
against 1.8), so it could not have resolved a 3-point effect even if one were there.
The point estimate is negative but the interval spans the Proficient result.

**Skill 3 measured byte-identical to Proficient** — same margin, same CI, same 32–10
sweep, same deals. Not a coincidence and worth recording: skill 3 is `base_bid`
bidding + `proficient` passing + `proficient` trick logic with `fold_samples: 0`, so
it shares every decision path this touches. It is not an independent second
observation of the effect.

**Control.** Run before believing any of the above, per #153's rule: the low policy
against itself over 200 pairs split all 200 with every paired margin exactly `0.00`,
and stock `python ab_harness.py --pairs 200 --seed 164` likewise reported NO EVIDENCE
with all 200 split. The dial then did move on the real comparison, so it is not
silent by construction.

## Housekeeping

- The temporary `_FEED_POLICY` switch and the `ab_feed164.py` runner the two arms
  needed are **removed** — `pinochle_engine.py` carries no policy dial, as #126, #153
  and #154 established. `git grep _FEED_POLICY` is empty.
- `python -m pytest -q` → **291 passed** (288 before; 3 new tests for the Proficient
  feed tier, which had none — the existing follow-card tests all target
  `choose_expert_follow_card`).
- `export_parity_scenarios.py --check` and `export_evaluator.py --check` both still
  pass, and would not have been expected to fail: each renders from a committed
  artifact (`parity_scenarios.json`, `rollout_evaluator.json`) rather than from live
  AI decisions, which is exactly why `--record` is on-demand.

## Two things this surfaced, not fixed here

1. **`_expert_follow_card_honest` (`pinochle_engine.py:1617`) has the same `max`.**
   It is the skill 4–5 follow path and a third copy of the same heuristic. Out of
   scope for #164, which names `choose_follow_card`, and folding it in would have
   conflated two changes in one measurement — but it means skills 4–5 still feed the
   10 in their own play. Worth its own issue and its own A/B.
2. **`rollout_dataset.csv` / `rollout_evaluator.json` were labelled by the pre-fix
   rollouts,** and `evaluatorModel.ts` is fitted to them. Nothing goes stale
   mechanically (no `--check` covers the dataset), and regenerating is a ~15-minute
   run that lands in `web/`, so it is a separate decision rather than something to do
   blindly. Flagging it because it is the chain #164 opens with.

Closes #164
