### PR TITLE
feat(ai): skill-capped trump memory, landed inert (#157)

### DIFF
--- a/web/src/engine/trumpMemory.test.ts
+++ b/web/src/engine/trumpMemory.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+import type { SkillLevel } from '../persistence/options'
+import { Card, RANKS, Suit } from './card'
+import { TRUMP_MEMORY_CAPACITY, TrumpMemory } from './trumpMemory'
+
+const TRUMP = Suit.Spades
+
+/** 6 ranks x 2 copies — the same 12 `tracker.ts` calls `TOTAL_TRUMP_COPIES`,
+ *  derived here rather than hard-coded so this drifts if the deck ever does. */
+const TOTAL_TRUMP = RANKS.length * 2
+
+/** Every trump in the deck, in a fixed order: both copies of 9, then J, and so
+ *  on up to A. Order is what these tests are about, so it must not be random. */
+function allTrumpInOrder(): Card[] {
+  return RANKS.flatMap((rank) => [new Card(TRUMP, rank, 1), new Card(TRUMP, rank, 2)])
+}
+
+describe('TRUMP_MEMORY_CAPACITY', () => {
+  it('is 2 x skill level for each of the five levels', () => {
+    expect(TRUMP_MEMORY_CAPACITY).toEqual({
+      easy: 2,
+      medium: 4,
+      hard: 6,
+      proficient: 8,
+      expert: 10,
+    })
+  })
+
+  it('leaves even expert short of the full 12 trump', () => {
+    expect(TOTAL_TRUMP).toBe(12)
+    expect(TRUMP_MEMORY_CAPACITY.expert).toBeLessThan(TOTAL_TRUMP)
+  })
+
+  const levels: [SkillLevel, number][] = [
+    ['easy', 2],
+    ['medium', 4],
+    ['hard', 6],
+    ['proficient', 8],
+    ['expert', 10],
+  ]
+  it.each(levels)('a %s memory holds %i trump', (skill, capacity) => {
+    expect(new TrumpMemory(TRUMP, skill).capacity).toBe(capacity)
+  })
+})
+
+describe('TrumpMemory recall', () => {
+  it('starts empty', () => {
+    const memory = new TrumpMemory(TRUMP, 'hard')
+    expect(memory.size).toBe(0)
+    expect(memory.forgottenCount).toBe(0)
+    for (const rank of RANKS) expect(memory.seenCount(rank)).toBe(0)
+  })
+
+  it('counts both copies of a rank separately', () => {
+    const memory = new TrumpMemory(TRUMP, 'hard')
+    memory.see(new Card(TRUMP, 'A', 1))
+    expect(memory.seenCount('A')).toBe(1)
+    memory.see(new Card(TRUMP, 'A', 2))
+    expect(memory.seenCount('A')).toBe(2)
+  })
+
+  it('ignores non-trump entirely, so callers can pipe every card through', () => {
+    const memory = new TrumpMemory(TRUMP, 'easy')
+    memory.seeAll([
+      new Card(Suit.Hearts, 'A', 1),
+      new Card(Suit.Clubs, 'K', 1),
+      new Card(Suit.Diamonds, '10', 1),
+    ])
+    expect(memory.size).toBe(0)
+    expect(memory.seenCount('A')).toBe(0)
+    // ...and no capacity was spent on them
+    memory.seeAll([new Card(TRUMP, '9', 1), new Card(TRUMP, 'J', 1)])
+    expect(memory.size).toBe(2)
+  })
+})
+
+describe('TrumpMemory forgetting', () => {
+  it('at exactly capacity, nothing is forgotten yet', () => {
+    const memory = new TrumpMemory(TRUMP, 'easy') // capacity 2
+    memory.seeAll([new Card(TRUMP, '9', 1), new Card(TRUMP, 'J', 1)])
+    expect(memory.size).toBe(2)
+    expect(memory.forgottenCount).toBe(0)
+    expect(memory.seenCount('9')).toBe(1)
+    expect(memory.seenCount('J')).toBe(1)
+  })
+
+  it('past capacity, the oldest goes and the newest is kept', () => {
+    const memory = new TrumpMemory(TRUMP, 'easy') // capacity 2
+    memory.seeAll([new Card(TRUMP, '9', 1), new Card(TRUMP, 'J', 1), new Card(TRUMP, 'Q', 1)])
+    expect(memory.size).toBe(2)
+    expect(memory.forgottenCount).toBe(1)
+    expect(memory.seenCount('9')).toBe(0) // oldest — gone
+    expect(memory.seenCount('J')).toBe(1)
+    expect(memory.seenCount('Q')).toBe(1) // newest — kept
+  })
+
+  it('forgets in sighting order, not rank order', () => {
+    const memory = new TrumpMemory(TRUMP, 'medium') // capacity 4
+    // Aces first, junk last: the Aces are the high cards but the oldest news.
+    memory.seeAll([
+      new Card(TRUMP, 'A', 1),
+      new Card(TRUMP, 'A', 2),
+      new Card(TRUMP, '10', 1),
+      new Card(TRUMP, '10', 2),
+      new Card(TRUMP, '9', 1),
+      new Card(TRUMP, '9', 2),
+    ])
+    expect(memory.size).toBe(4)
+    expect(memory.seenCount('A')).toBe(0) // both Aces seen, both forgotten
+    expect(memory.seenCount('10')).toBe(2)
+    expect(memory.seenCount('9')).toBe(2)
+    expect(memory.remembered().map((s) => s.rank)).toEqual(['10', '10', '9', '9'])
+  })
+
+  it('an expert who sees all 12 trump still forgets the first 2', () => {
+    const memory = new TrumpMemory(TRUMP, 'expert') // capacity 10
+    memory.seeAll(allTrumpInOrder()) // 9,9,J,J,Q,Q,K,K,10,10,A,A
+    expect(memory.size).toBe(10)
+    expect(memory.forgottenCount).toBe(TOTAL_TRUMP - TRUMP_MEMORY_CAPACITY.expert)
+    expect(memory.seenCount('9')).toBe(0) // the two earliest sightings
+    expect(memory.seenCount('J')).toBe(2)
+    expect(memory.seenCount('A')).toBe(2)
+  })
+
+  it('re-seeing a remembered card refreshes it instead of pushing it out', () => {
+    const memory = new TrumpMemory(TRUMP, 'easy') // capacity 2
+    memory.seeAll([new Card(TRUMP, '9', 1), new Card(TRUMP, 'J', 1)])
+    memory.see(new Card(TRUMP, '9', 1)) // same physical card again
+    expect(memory.size).toBe(2)
+    expect(memory.forgottenCount).toBe(0) // no second slot spent, nothing evicted
+    // ...but the 9 is now the fresher of the two, so the J is next to go.
+    memory.see(new Card(TRUMP, 'Q', 1))
+    expect(memory.seenCount('J')).toBe(0)
+    expect(memory.seenCount('9')).toBe(1)
+    expect(memory.seenCount('Q')).toBe(1)
+  })
+
+  it('re-seeing a forgotten card admits it again', () => {
+    const memory = new TrumpMemory(TRUMP, 'easy') // capacity 2
+    memory.seeAll([new Card(TRUMP, '9', 1), new Card(TRUMP, 'J', 1), new Card(TRUMP, 'Q', 1)])
+    expect(memory.seenCount('9')).toBe(0)
+    memory.see(new Card(TRUMP, '9', 1))
+    expect(memory.seenCount('9')).toBe(1)
+    expect(memory.seenCount('J')).toBe(0) // the J was next in line and is now out
+    expect(memory.size).toBe(2)
+  })
+})
+
+describe('TrumpMemory and meld', () => {
+  it('counts trump shown in meld, before a card is played', () => {
+    const memory = new TrumpMemory(TRUMP, 'hard')
+    // A trump run melded face-up: A,10,K,Q,J of trump.
+    memory.seeAll([
+      new Card(TRUMP, 'A', 1),
+      new Card(TRUMP, '10', 1),
+      new Card(TRUMP, 'K', 1),
+      new Card(TRUMP, 'Q', 1),
+      new Card(TRUMP, 'J', 1),
+    ])
+    expect(memory.size).toBe(5)
+    expect(memory.seenCount('A')).toBe(1)
+    expect(memory.seenCount('J')).toBe(1)
+  })
+
+  it('meld consumes capacity like anything else', () => {
+    const memory = new TrumpMemory(TRUMP, 'easy') // capacity 2
+    memory.seeAll([new Card(TRUMP, 'A', 1), new Card(TRUMP, '10', 1)]) // melded
+    memory.see(new Card(TRUMP, '9', 1)) // then one played
+    expect(memory.size).toBe(2)
+    expect(memory.seenCount('A')).toBe(0) // the melded Ace is already crowded out
+    expect(memory.seenCount('10')).toBe(1)
+    expect(memory.seenCount('9')).toBe(1)
+  })
+
+  it('a trump melded and later played is one card, not two sightings', () => {
+    const memory = new TrumpMemory(TRUMP, 'medium') // capacity 4
+    const meldedAce = new Card(TRUMP, 'A', 1)
+    memory.see(meldedAce) // laid face-up in meld
+    memory.seeAll([new Card(TRUMP, '9', 1), new Card(TRUMP, 'J', 1), new Card(TRUMP, 'Q', 1)])
+    memory.see(meldedAce) // taken back into hand and played
+    expect(memory.size).toBe(4)
+    expect(memory.forgottenCount).toBe(0)
+    expect(memory.seenCount('A')).toBe(1) // one Ace copy accounted for, not two
+  })
+})

--- a/web/src/engine/trumpMemory.ts
+++ b/web/src/engine/trumpMemory.ts
@@ -1,0 +1,147 @@
+// Skill-capped trump memory (#157) — a capacity-limited *view* of which trump
+// have been seen this round, in meld and in play.
+//
+// Trick-play *rules* are identical at every skill level (#156): every seat runs
+// the same cascade in `tracker.ts`. This module is the one thing the skill dial
+// still changes during trick play — not the decision, the information the
+// decision is made on. Same reasoning, worse recall.
+//
+// Why this is a sibling of `PlayTracker` rather than a subclass or a wrapper:
+// `PlayTracker` stores counts, not order, and order is exactly what a capacity
+// limit needs — "the oldest sighting is the one you forget" is unanswerable
+// from a count. So `TrumpMemory` observes card sightings itself, on the same
+// feed. `PlayTracker` is left counting perfectly, deliberately: the parity
+// fixtures (`engineParity.*`) and `chooseFollowCard`'s trump-secure test depend
+// on exact counts, and degrading it in place would break both.
+//
+// SCOPE — trump only, and knowingly lopsided. Non-trump counting stays perfect
+// via `PlayTracker`, so an `easy` seat has flawless recall of the side suits and
+// remembers only 2 of the 12 trump. That is odd on its face and it is the
+// accepted simplification (#157): trump counting is the thing that separates a
+// weak player from a strong one, so it is the thing that is modelled first. Not
+// a bug to be fixed in passing — if side-suit memory should degrade too, that is
+// its own issue with its own measurement.
+//
+// INERT ON ARRIVAL. Nothing constructs a `TrumpMemory` yet; the consumer is
+// #158, which uses it to answer "is my 10 the boss card now" instead of
+// guessing. Landing it unwired keeps the eventual behaviour change measurable on
+// its own, the way #114 landed the bid evaluator switched on for nobody so #115
+// could measure it, and the way #153 landed the play-policy dial.
+
+import type { SkillLevel } from '../persistence/options'
+import type { Card, CopyId, Rank, Suit } from './card'
+
+/**
+ * How many of the 12 trump a seat can hold in mind at once: **2 x skill level**,
+ * skill 1 (`easy`) through skill 5 (`expert`).
+ *
+ * `expert` at 10 of 12 is deliberately imperfect. A tier that never forgets a
+ * card is not a strong player, it is a different kind of thing to play against,
+ * and the top of the dial is meant to still be beatable.
+ *
+ * The 12-copy total (6 ranks x 2 copies) is `TOTAL_TRUMP_COPIES` in
+ * `tracker.ts`, which is module-private there. This module deliberately does
+ * **not** declare a second copy of it: capacity is expressed against skill
+ * level, and nothing here needs the total. When #158 needs to compare the two,
+ * export the existing constant rather than adding one.
+ */
+export const TRUMP_MEMORY_CAPACITY: Record<SkillLevel, number> = {
+  easy: 2,
+  medium: 4,
+  hard: 6,
+  proficient: 8,
+  expert: 10,
+}
+
+/** One remembered card, identified within the trump suit by rank plus which of
+ *  the two copies it is. The suit is fixed for the whole memory, so it is not
+ *  part of the identity. */
+export interface TrumpSighting {
+  readonly rank: Rank
+  readonly copyId: CopyId
+}
+
+/**
+ * What one seat remembers about trump this round.
+ *
+ * The model, in full:
+ *
+ *   - **Capacity** is `TRUMP_MEMORY_CAPACITY[skill]` *physical trump cards*, not
+ *     sightings. Once it is full, seeing a new one pushes the oldest out.
+ *   - **Most recent wins.** Sightings are held newest-first; the card whose
+ *     sighting is furthest back is the one forgotten.
+ *   - **Meld counts.** Meld is laid face-up before trick play, so trump shown
+ *     there is real information and consumes a slot exactly like a played card
+ *     does. Feed `extractMeldCards`' output through `seeAll` alongside every
+ *     card `PlayTracker.record` sees.
+ *   - **Re-seeing a card refreshes it, it does not consume a second slot.** A
+ *     trump melded and then played later is one card and one fact; charging it
+ *     twice would let a round produce more sightings than the 12 trump that
+ *     exist, and then "10 of 12" would not mean anything. So this is an LRU over
+ *     physical cards, keyed on rank + copy id.
+ *   - **Non-trump is ignored**, silently, so a caller can pipe every card of the
+ *     round through `see` without filtering first.
+ *
+ * Nothing here is authoritative about the round — it is one seat's recollection,
+ * and it is *supposed* to be wrong below `expert`. Anything that needs the truth
+ * (parity fixtures, rules enforcement, scoring) must keep using `PlayTracker`.
+ */
+export class TrumpMemory {
+  /** Remembered sightings, oldest first — index 0 is the next to be forgotten. */
+  private readonly recent: TrumpSighting[] = []
+  private distinctSeen = 0
+
+  readonly trump: Suit
+  readonly skill: SkillLevel
+  readonly capacity: number
+
+  constructor(trump: Suit, skill: SkillLevel = 'hard') {
+    this.trump = trump
+    this.skill = skill
+    this.capacity = TRUMP_MEMORY_CAPACITY[skill]
+  }
+
+  /** Note one card. Non-trump is discarded; trump is remembered as the most
+   *  recent sighting, evicting the oldest if that puts it over capacity. */
+  see(card: Card): void {
+    if (card.suit !== this.trump) return
+    const existing = this.recent.findIndex((s) => s.rank === card.rank && s.copyId === card.copyId)
+    if (existing >= 0) {
+      this.recent.splice(existing, 1) // same card again — refresh, don't double-charge
+    } else {
+      this.distinctSeen += 1
+    }
+    this.recent.push({ rank: card.rank, copyId: card.copyId })
+    if (this.recent.length > this.capacity) this.recent.shift()
+  }
+
+  /** `see` over a group — a meld spread, a completed trick. */
+  seeAll(cards: readonly Card[]): void {
+    for (const card of cards) this.see(card)
+  }
+
+  /** Copies of this trump rank (0-2) the seat currently recalls seeing. Answers
+   *  "are both trump Aces gone?" as far as this seat knows, which is the whole
+   *  point — a low count may mean the copies are still out, or may mean they
+   *  were seen and forgotten. The seat cannot tell the difference, by design. */
+  seenCount(rank: Rank): number {
+    return this.recent.reduce((count, s) => count + (s.rank === rank ? 1 : 0), 0)
+  }
+
+  /** How many distinct trump are currently recalled. Never exceeds `capacity`. */
+  get size(): number {
+    return this.recent.length
+  }
+
+  /** Distinct trump seen and since forgotten — the gap between what passed in
+   *  front of this seat and what it can still use. */
+  get forgottenCount(): number {
+    return this.distinctSeen - this.recent.length
+  }
+
+  /** Everything currently recalled, oldest first. Diagnostics and tests —
+   *  strategy code should ask `seenCount`. */
+  remembered(): readonly TrumpSighting[] {
+    return [...this.recent]
+  }
+}


### PR DESCRIPTION
## What this is

The skill-capped trump-memory model from #157. `web/src/engine/trumpMemory.ts` plus its tests — two new files, nothing else touched.

Trick-play *rules* are the same at every level (#156), so this is the only thing the skill dial changes during trick play: not the decision, the information the decision is made on. Same reasoning, worse recall.

## The model

- **Capacity = 2 x skill level** — easy 2, medium 4, hard 6, proficient 8, expert 10 — out of the 12 trump in the deck. Expert at 10 of 12 is deliberately imperfect; a tier that never forgets is not a strong player, it is a different kind of thing to play against.
- **Most recent wins.** Sightings are held newest-first; past capacity the card seen furthest back is the one that goes.
- **Meld counts.** Meld is laid face-up before trick play, so trump shown there is real information and consumes a slot exactly like a played card. `extractMeldCards`' output goes through `seeAll` alongside everything `PlayTracker.record` sees.
- **Re-seeing a card refreshes it rather than consuming a second slot.** A trump melded and then played is one physical card and one fact. Charging it twice would let a round produce more sightings than the 12 trump that exist, and then "10 of 12" would stop meaning anything — so this is an LRU over physical cards, keyed on rank + copy id. This is the one modelling choice the issue did not spell out; it is documented at the class and covered by two tests.
- **Non-trump is ignored silently**, so a caller can pipe every card of the round through `see` without filtering.

## API

```ts
export const TRUMP_MEMORY_CAPACITY: Record<SkillLevel, number>
export interface TrumpSighting { rank: Rank; copyId: CopyId }

class TrumpMemory {
  constructor(trump: Suit, skill: SkillLevel = 'hard')
  readonly capacity: number
  see(card: Card): void
  seeAll(cards: readonly Card[]): void
  seenCount(rank: Rank): number      // 0-2 copies of that trump rank recalled
  get size(): number                 // distinct trump recalled, <= capacity
  get forgottenCount(): number       // seen and since lost
  remembered(): readonly TrumpSighting[]  // oldest first, diagnostics/tests
}
```

`seenCount` is what #158 will ask: "are both trump Aces gone?" as far as this seat knows. A low count may mean the copies are still out, or may mean they were seen and forgotten — the seat cannot tell the difference, which is the point.

## Sibling of `PlayTracker`, not a wrapper

`PlayTracker` stores counts, not order, and order is exactly what a capacity limit needs — "the oldest sighting is the one you forget" is unanswerable from a count. So `TrumpMemory` observes the card feed itself.

**`PlayTracker` is untouched and still counts perfectly**, deliberately: the `engineParity.*` fixtures and `chooseFollowCard`'s trump-secure test depend on exact counts, and degrading it in place would break both. `tracker.ts` is byte-identical to `origin/main` (blob `bdd12df`) — this PR adds two files and modifies none.

## Scoped oddity, recorded not fixed

Trump only. Non-trump counting stays perfect via `PlayTracker`, so an `easy` seat has flawless recall of the side suits and remembers 2 of the 12 trump. That is lopsided on its face and it is the accepted simplification: trump counting is the thing that separates a weak player from a strong one, so it is the thing modelled first. Recorded in the module header as scoped, not a bug to be fixed in passing.

## This changes no decision

Nothing constructs a `TrumpMemory` yet — the consumer is #158. The proof is stronger than "no call sites": the built bundle is byte-identical with and without these files, same content hash `index-2CyRGHgU.js` at 256.27 kB, because the module is reachable only from its own test.

Same shape as the precedents. #114 landed the bid evaluator wired but switched on for nobody so #115 could measure it cleanly; #153 landed the play-policy dial the same way. No A/B here, because there is not yet a behaviour to measure — that belongs to #158.

## One thing that could not be done as written

The issue says to reuse `TOTAL_TRUMP_COPIES` from `tracker.ts`. It is **module-private** there (`const`, not `export`), and this PR was scoped to not touch `tracker.ts` at all — a sibling branch is editing it for #155. So this module declares no total constant of its own rather than duplicating the 12; capacity is expressed against skill level, and nothing in the module needs the total. The test file derives it as `RANKS.length * 2` from `card.ts` and asserts it is 12, so a deck change surfaces there.

**When #158 needs to compare the two, add `export` to the existing constant in `tracker.ts` rather than introducing a second one.**

## Testing

19 new tests, all on the recall path since that is where this is most likely to be subtly wrong:

- capacity exactly reached — nothing forgotten yet
- capacity exceeded — oldest gone, newest kept
- forgetting follows sighting order, not rank order (both Aces seen first are both gone while the junk seen last survives)
- an expert seeing all 12 still forgets 2
- all five levels resolve to the right capacity, and the table is asserted whole
- trump in meld counted, and meld consuming capacity
- a trump melded then played counted once, not twice
- re-seeing a remembered card refreshes it; re-seeing a forgotten card readmits it
- non-trump ignored, and spending no capacity

`npm test` 360 passed (341 baseline + 19), `python -m pytest -q` 291 passed, `npm run build` clean, `oxlint` clean.

One note on the JS run: under the default `forks` pool this machine intermittently times out starting workers, and on one run `TrickPlayFlow.test.tsx` hit the 5 s per-test timeout — machine load, not a regression. It passes 6/6 in isolation, and the full 360/360 green run is `npx vitest run --pool=threads`.

Closes #157
