### PR TITLE
fix(ai): forced beat compares trick-winning power, not raw rank (#155)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -291,6 +291,67 @@ differing in exactly one field, and this is the baseline every remaining child
 of #152 is judged against. Deleting it as dead code would leave a one-member
 union and take the ruler away days after #153 built it.
 
+### Fixing the forced-beat comparison (#155)
+
+`Trick.legalMoves` forces a seat to beat the best **lead-suit** card on the table
+whenever it can, and does not care who played it — so a seat is regularly
+compelled to overtake its own partner. `chooseFollowCard`'s first tier is what
+decides which card to take with, and until this issue that tier was gated on
+
+    legalMoves.every((c) => c.rankValue > winner.card.rankValue)
+
+`rankValue` is rank-only and suit-blind, and `currentWinner` returns a **trump**
+whenever one has been played. So a partner who had ruffed in with the 9 of trump
+— the lowest `rankValue` there is — read as beatable by every Queen in hand: the
+forced-beat tier fired, and the seat threw its cheapest card into a trick its own
+side had already won. The feed-partner tier underneath, which #154 had just
+finished tuning, never ran. The condition is now `Card.beats(winner.card, trump)`
+— trump over non-trump, rank within the suit.
+
+The blast radius is small and worth stating exactly, because it is what sizes the
+result. The fixed reading is strictly weaker than the old one (no card of the
+lead suit beats a trump at any rank), so the only positions that change are those
+where a trump was winning and the comparison fired anyway. Of *those*, only the
+ones where **partner** holds that trump change the card actually played:
+pinochle's rank order (9 J Q K 10 A) puts every non-counter strictly below every
+counter, so on the opponent side "lowest legal card" and "lowest non-counter,
+else lowest counter" are the same card and the tiers agree.
+
+That last point is also why the selection rule this issue specifies —
+
+1. beat with a non-counter (Q, J, 9) if any legal beater is one;
+2. else the lowest counter that cannot itself be beaten — **not implemented**,
+   it needs #157's outstanding-card memory and is #158's job, left as a gap
+   rather than approximated;
+3. else the lowest counter
+
+— picks the same card as the `minByRank` it replaces. `chooseForcedBeat` spells
+it out anyway, so the preference is a tested property rather than a side effect
+of `RANK_VALUE`, and so #158 inserts one branch instead of re-deriving the rule.
+
+Measured with a throwaway `'legacy-beat'` arm on `PlayPolicy` plus a temporary
+`cli.ts beat` command, in the shape the section below describes and deleted
+before the fix was committed, over 5000 pairs / 10 000 games:
+
+| | margin per deal | 95% CI | swept | p |
+| --- | --- | --- | --- | --- |
+| seed 1 | **+1.81** | +0.86 to +2.77 | 12–4 | 0.077 |
+| seed 2 | **+1.77** | +0.93 to +2.64 | 7–1 | 0.070 |
+
+The margin interval excludes zero on both seeds and the sign test reaches
+significance on neither, off sixteen and eight decisive deals in 5000 —
+which is precisely the reading #154's methodology note exists to prevent being
+mistaken for a null. Half the size of #154, and #154 was already two orders of
+magnitude under the dial's own span, because the divergence needs four things at
+once: partner ruffs in, this seat still holds the lead suit, `legalMoves` forces
+a beat, and the legal set holds both a counter and a non-counter. When it does
+fire it is worth a whole counter.
+
+`pinochle_engine.py` carries the identical comparison, in `choose_follow_card`
+and again in the expert follow path — this is a faithful port of a reference bug,
+not a porting error. Fixing it there is its own issue on the Python side, the way
+#164 followed #154.
+
 ### Checking that a dial can see a change
 
 A self-test proves a dial reports nothing when nothing differs. It does not

--- a/web/src/engine/tracker.test.ts
+++ b/web/src/engine/tracker.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { SkillLevel } from '../persistence/options'
 import { Card, Suit } from './card'
 import { SKILL_PARAMS } from './skills'
-import type { TrickPlay } from './trick'
+import { Trick, type TrickPlay } from './trick'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from './tracker'
 
 /**
@@ -261,6 +261,84 @@ describe('chooseFollowCard', () => {
     const hand = legalMoves
     const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
     expect(played.rank).toBe('10')
+  })
+
+  // -- Forced-beat selection (#155) -----------------------------------------
+
+  it('forced beat: prefers a non-counter beater over a counter, taking the trick for free', () => {
+    // Step 1 of Paul's rule. Opponent is winning with the Jack; the Queen, King
+    // and 10 all beat it, so the trick is taken either way — the Queen takes it
+    // without also putting 10 points into it.
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'J', 1) }]
+    const legalMoves = [
+      new Card(Suit.Hearts, 'K', 1),
+      new Card(Suit.Hearts, 'Q', 1),
+      new Card(Suit.Hearts, '10', 1),
+    ]
+    const played = chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('Q')
+  })
+
+  it('forced beat with only counters legal: spends the cheapest one (King before 10 before Ace)', () => {
+    // Step 3. There is no free beat available, so a counter has to go in; the
+    // King is the one to spend, for #154's reason — every counter pays the same
+    // 10, and the 10 it keeps loses to nothing but an Ace.
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const legalMoves = [
+      new Card(Suit.Hearts, '10', 1),
+      new Card(Suit.Hearts, 'A', 1),
+      new Card(Suit.Hearts, 'K', 1),
+    ]
+    const played = chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('K')
+  })
+
+  it('a trump ruff by partner is not a forced beat — no card of the lead suit can touch it', () => {
+    // The #155 bug. `currentWinner` returns the trump, and the old test compared
+    // `rankValue` alone: the 9 of trump has the lowest rank there is, so every
+    // legal Heart "beat" it and the seat skipped the feed-partner tier to throw
+    // its cheapest card into a trick its own side had already won. A Heart
+    // cannot beat a Spade at any rank — partner is winning, so feed the King.
+    const trickPlays: TrickPlay[] = [
+      { player: 3, card: new Card(Suit.Hearts, '9', 1) }, // opponent leads
+      { player: 0, card: new Card(Suit.Spades, '9', 1) }, // partner is void, ruffs
+      { player: 1, card: new Card(Suit.Diamonds, '9', 1) }, // opponent sluffs
+    ]
+    // Seat 2 holds Hearts, so it must follow, and must beat the 9 of Hearts.
+    const legalMoves = [new Card(Suit.Hearts, 'Q', 1), new Card(Suit.Hearts, 'K', 1)]
+    const played = chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('K')
+  })
+
+  it('a trump ruff by an opponent is not a forced beat either, and still costs them nothing', () => {
+    // Same suit-blind comparison, opponent side. Both the old and the fixed
+    // reading play the Queen here — the forced-beat tier and the dump-low tier
+    // agree, because pinochle's rank order puts every non-counter below every
+    // counter — so this pins that the fix changed nothing on this side.
+    const trickPlays: TrickPlay[] = [
+      { player: 3, card: new Card(Suit.Hearts, '9', 1) },
+      { player: 1, card: new Card(Suit.Spades, '9', 1) }, // opponent ruffs
+    ]
+    const legalMoves = [new Card(Suit.Hearts, 'Q', 1), new Card(Suit.Hearts, 'K', 1)]
+    const played = chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('Q')
+  })
+
+  it("#155's worked example is decided before the comparison is reached", () => {
+    // Partner leads the King of Diamonds, an opponent ruffs with the 9 of
+    // trump, this seat holds the Ace and the 9 of Diamonds. `legalMoves` is
+    // forced to the Ace alone, so `chooseFollowCard` returns on the
+    // single-legal-move line and never evaluates `forcedBeat` at all — the
+    // suit-blind comparison was unreachable in exactly the position that made
+    // it look suspicious. It is the multi-card positions above that expose it.
+    const trick = new Trick(Suit.Spades)
+    trick.play(0, new Card(Suit.Diamonds, 'K', 1))
+    trick.play(1, new Card(Suit.Spades, '9', 1))
+    const hand = [new Card(Suit.Diamonds, 'A', 1), new Card(Suit.Diamonds, '9', 1)]
+    const legalMoves = trick.legalMoves(hand)
+    expect(legalMoves.map((c) => c.rank)).toEqual(['A'])
+    const played = chooseFollowCard(hand, legalMoves, trick.plays, Suit.Spades, [0, 2])
+    expect(played.rank).toBe('A')
   })
 
   it('feeds partner the lowest King/10 when partner is winning and not every card is a forced beat', () => {

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -163,9 +163,11 @@ function leadSafeCascade(hand: readonly Card[], trump: Suit, tracker: PlayTracke
  *
  * @param isBidderFirstLead - When true (bidder opening the first trick of the
  *   round), forces a trump lead if the player has any trump cards remaining.
- * @param skill - Skill level, read for `playPolicy` (#153). `'simple'` uses
- *   simplified logic: prefers low non-trump non-count cards. Defaults to 'hard'
- *   (`'cascade'`, the full Proficient cascade).
+ * @param skill - Skill level, read for `playPolicy` (#153). Since #156 every
+ *   shipped row is `'cascade'` — the full Proficient cascade — so this argument
+ *   no longer varies the strategy in a real game. `'simple'` (low non-trump
+ *   non-counter) survives as an A/B arm, reachable only through an override.
+ *   Defaults to 'hard'.
  * @param isBiddingTeam - Which side this seat is on. Undefined = fallback.
  */
 export function chooseLeadCard(
@@ -176,10 +178,11 @@ export function chooseLeadCard(
   skill: SkillLevel = 'hard',
   isBiddingTeam?: boolean,
 ): Card {
-  // Simplified leading — prefer low non-trump non-count cards. Reached by
-  // `easy` and nothing else, which is the mapping the `meld_only` test this
-  // replaces produced (#153); `playPolicy` is the field to change, not the
-  // valuation one, because that one also decides how the seat bids.
+  // Simplified leading — prefer low non-trump non-count cards. No shipped
+  // `SKILL_PARAMS` row selects this since #156 moved `easy` onto the cascade
+  // with everyone else, so nothing reaches it in a real game; it stays as the
+  // `'simple'` arm of `PLAY_AB_POLICIES`, the baseline every remaining child of
+  // epic #152 is measured against, and is reachable only by overriding the dial.
   if (SKILL_PARAMS[skill].playPolicy === 'simple') {
     const safeLeads = hand.filter((c) => c.suit !== trump && c.rank !== 'A' && c.rank !== '10' && c.rank !== 'K')
     const pool = safeLeads.length > 0 ? safeLeads : hand
@@ -242,6 +245,36 @@ function feedPartner(legalMoves: readonly Card[]): Card {
 }
 
 /**
+ * Forced to take the trick: every legal card already beats whoever is winning,
+ * so the only question left is which one to spend (#155). Paul's rule — "if you
+ * are going to beat, you want to take with either no point, or take with the
+ * lowest point that cannot be beat":
+ *
+ *   1. A non-counter (Q, J, 9) if any legal beater is one — take the trick
+ *      without also donating 10 points into it.
+ *   2. Otherwise the lowest counter that cannot itself be beaten. **Not
+ *      implemented here.** Knowing a counter is safe means knowing what is still
+ *      outstanding, which is #158 on top of #157's trump memory; this gap is the
+ *      seam it slots into, left deliberately rather than approximated.
+ *   3. Otherwise the lowest counter.
+ *
+ * Tiers 1 and 3 pick the card `minByRank` picked before this function existed,
+ * and that is worth stating rather than relying on silently: pinochle's rank
+ * order (9 J Q K 10 A) happens to put every non-counter strictly below every
+ * counter, so "lowest legal card" already reads as "cheapest free beat, else
+ * cheapest counter". Spelling the tiers out costs nothing, makes the preference
+ * a tested property instead of a side effect of `RANK_VALUE`, and means #158
+ * inserts one branch rather than re-deriving the rule. The behaviour #155
+ * measured is all in `chooseFollowCard`'s *detection* of the forced beat below,
+ * not in this selection.
+ */
+function chooseForcedBeat(legalMoves: readonly Card[]): Card {
+  const nonCounters = legalMoves.filter((c) => !POINT_RANKS.has(c.rank))
+  if (nonCounters.length > 0) return minByRank(nonCounters)
+  return minByRank(legalMoves)
+}
+
+/**
  * Who's currently winning the trick-in-progress: highest trump if any
  * trump has been played, else highest card of the lead suit. Ties go to
  * whichever copy was played first (`reduce` only replaces the running
@@ -265,8 +298,9 @@ function currentWinner(trickPlays: readonly TrickPlay[], trump: Suit): TrickPlay
  * rules, and each gets its own tiered strategy:
  *   - Forced to follow a non-trump lead suit:
  *       1. Forced beat (every legal card already beats the current
- *          winner) - play the lowest one that still wins, saving bigger
- *          cards for later.
+ *          winner, measured as trick-winning power rather than raw rank
+ *          - #155) - take it with a non-counter if one is legal, else
+ *          with the cheapest counter. See `chooseForcedBeat`.
  *       2. Partner is currently winning - feed them points: the lowest
  *          King/10 available (#154 - every counter pays 10, so spend the
  *          weakest), or (if none) the lowest card, to avoid donating a
@@ -284,8 +318,11 @@ function currentWinner(trickPlays: readonly TrickPlay[], trump: Suit): TrickPlay
  *     suits - work toward voiding the shortest suit, lowest rank within
  *     it.
  *
- * @param skill Skill level, read for `playPolicy` (#153). `'simple'` plays the
- *   lowest legal card. Defaults to 'hard' (`'cascade'`, the tiered logic above).
+ * @param skill Skill level, read for `playPolicy` (#153). Since #156 every
+ *   shipped row is `'cascade'` — the tiered logic above — so this argument no
+ *   longer varies the strategy in a real game. `'simple'` (play the lowest legal
+ *   card) survives as an A/B arm, reachable only through an override. Defaults
+ *   to 'hard'.
  */
 export function chooseFollowCard(
   hand: readonly Card[],
@@ -298,7 +335,9 @@ export function chooseFollowCard(
 ): Card {
   if (legalMoves.length === 1) return legalMoves[0]
 
-  // Simplified following: always play the lowest legal card (#153)
+  // Simplified following: always play the lowest legal card (#153). Unreachable
+  // from a shipped `SKILL_PARAMS` row since #156, and kept for the same reason
+  // as its counterpart in `chooseLeadCard` above — it is the A/B baseline.
   if (SKILL_PARAMS[skill].playPolicy === 'simple') {
     return legalMoves.reduce((lowest, c) => (c.rankValue < lowest.rankValue ? c : lowest))
   }
@@ -311,8 +350,18 @@ export function chooseFollowCard(
   const allTrump = legalMoves.every((c) => c.suit === trump)
 
   if (allLeadSuit && leadSuit !== trump) {
-    const forcedBeat = winner !== undefined && legalMoves.every((c) => c.rankValue > winner.card.rankValue)
-    if (forcedBeat) return minByRank(legalMoves)
+    // Trick-winning power, not raw rank (#155). `currentWinner` returns a trump
+    // whenever one has been played, and `rankValue` is suit-blind, so the
+    // comparison this replaces — `c.rankValue > winner.card.rankValue` — read a
+    // partner who had ruffed in with the 9 of trump as beatable by any Queen.
+    // That is not a near miss: it skipped the feed-partner tier below and threw
+    // the cheapest card into a trick this side had already won. `Card.beats`
+    // answers the question actually being asked (trump over non-trump, rank
+    // within the suit), and here every legal card is of the lead suit, so it
+    // returns false against any trump — correctly, since no card of the lead
+    // suit can take a trick a trump is winning.
+    const forcedBeat = winner !== undefined && legalMoves.every((c) => c.beats(winner.card, trump))
+    if (forcedBeat) return chooseForcedBeat(legalMoves)
 
     if (partnerWinning) return feedPartner(legalMoves)
 


### PR DESCRIPTION
## What was wrong

`chooseFollowCard`'s forced-beat tier was gated on

```ts
legalMoves.every((c) => c.rankValue > winner.card.rankValue)
```

`rankValue` is rank-only and suit-blind, and `currentWinner` returns a **trump**
whenever one has been played. So a partner who had ruffed in with the 9 of trump
— the lowest `rankValue` there is — read as beatable by every Queen in hand. The
tier fired, and the seat played its cheapest card into a trick its own side had
already won, never reaching the feed-partner tier underneath that #154 had just
finished tuning.

It is now `Card.beats(winner.card, trump)` — trump over non-trump, rank within
the suit.

The issue's worked example (partner leads K♦, opponent ruffs 9♠, you hold A♦ and
9♦) turns out **not** to reach the comparison at all: `legalMoves` is forced to
`{A♦}` and `chooseFollowCard` returns on its single-legal-move line. Pinned as a
test, because it is the position that makes the bug look reachable and isn't.

## Blast radius

The fixed reading is strictly weaker than the old one — no card of the lead suit
beats a trump at any rank — so the only positions that change are those where a
trump was winning and the old comparison fired anyway. Of those, only the ones
where **partner** holds that trump change the card actually played: pinochle's
rank order (9 J Q K 10 A) puts every non-counter strictly below every counter, so
on the opponent side the forced-beat tier and the dump-low tier pick the same
card. Both directions are pinned as tests.

## The selection rule

Scoped to steps 1 and 3, as the issue asks, in `chooseForcedBeat`:

1. a non-counter (Q, J, 9) beater if one is legal — take the trick without
   donating 10 points to it;
2. else the lowest counter that cannot itself be beaten — **not implemented**,
   it needs #157's outstanding-card memory and is #158's job. Left as a
   documented gap rather than a half-version of the counting;
3. else the lowest counter.

For the same rank-order reason, tiers 1 and 3 pick the card `minByRank` already
picked. Writing them out makes the preference a tested property instead of a side
effect of `RANK_VALUE`, and gives #158 one branch to insert into.

## Measurement

Per #154's methodology note. Self-tests first — `cascade`, `simple` and the
temporary arm each found *exactly* nothing against themselves (200 pairs, every
pair split, paired margin 0.00). Then the dial-is-read check: the two arms were
dumped against fixed positions before any number was believed, and returned
`K♥` vs `Q♥` on the divergent one and identical cards on three controls.

5000 paired deals / 10 000 games, throwaway `'legacy-beat'` arm vs the fix:

| | margin per deal | 95% CI | swept | p |
| --- | --- | --- | --- | --- |
| seed 1 | **+1.81** | +0.86 to +2.77 | 12–4 | 0.077 |
| seed 2 | **+1.77** | +0.93 to +2.64 | 7–1 | 0.070 |

The margin interval excludes zero on both seeds; the sign test reaches
significance on neither, off sixteen and eight decisive deals in 5000 — exactly
the reading #154 says to report as margin and not as games-won. Half the size of
#154 because the divergence needs four things at once: partner ruffs in, this
seat still holds the lead suit, `legalMoves` forces a beat, and the legal set
holds both a counter and a non-counter.

The temporary arm (`'legacy-beat'` on the `PlayPolicy` union, `BEAT_AB_POLICIES`,
a `cli.ts beat` command, a `legacy` self-test arm and two scratch scripts) is
**removed** — `skills.ts`, `abRun.ts` and `cli.ts` are byte-identical to `main`.
Same call as #126, #153, #154 and #167.

## Follow-up, not fixed here

`pinochle_engine.py` carries the identical comparison in `choose_follow_card`
(~line 624) and again in the expert follow path (~line 1609). That is a faithful
port of a reference bug, not a porting error — it wants its own issue on the
Python side, the way #164 followed #154. Not touched here: this is a
TypeScript-only change.

## Checks

- `npm test` — **346 passed** (341 baseline + 5 new)
- `python -m pytest -q` — 291 passed
- `npm run build` clean, `npm run lint` clean (three pre-existing
  `exhaustive-deps` warnings in components, untouched)

Closes #155
