### PR TITLE
fix(ai): expert follow tier feeds the King too - the copy skills 4-5 play (#168)

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -590,6 +590,25 @@ def _feed_partner(legal_moves):
     much noisier (260 decisive pairs against Proficient's 42), so it could not
     have resolved an effect this size regardless. Skills 1-3 are the levels this
     moves, and skill 3 measured byte-identical to Proficient.
+
+    #168 then found a third copy of the same `max`, inline in
+    `_expert_follow_card_honest` - the one skills 4-5 follow with *at the table*,
+    rather than only inside their rollouts. That copy now calls this helper, so
+    Python has one implementation of the rule, and the skill 4-5 arms #164 could
+    not move were re-run against it, same harness and same 5000 paired deals:
+
+        skill 4, seed 168000   +6.69/deal   95% CI +3.26 to +10.03   swept  89-67
+        skill 4, seed 270000  +10.56/deal   95% CI +7.22 to +13.95   swept 117-55
+        skill 5, seed 168000   +6.22/deal   95% CI +2.79 to  +9.63   swept  91-62
+
+    All three intervals exclude zero, so the rule is worth roughly twice at the
+    top of the dial what it is at Proficient (+3.55 to +3.61). That is consistent
+    with the reason it works: skills 4-5 hold their counters into the late tricks
+    far more often, so the difference between banking the King and banking the 10
+    keeps mattering for longer. It also closes out the "skill 4 is a null" line
+    above - that null was a property of #164's scope, not of the rule, and the
+    two are not in conflict. Both readings needed the measurement; neither could
+    have been argued from the code.
     """
     counters = [c for c in legal_moves if c.rank in ("K", "10")]
     if counters:
@@ -1584,8 +1603,12 @@ def _expert_follow_card_honest(hand, legal_moves, trick_plays, trump, my_team_pl
         is where "third-hand-high" is mechanically enforced by the rules
         engine itself, so there's no separate heuristic needed for it.
       - Duck when partner is already winning: don't spend a big card on a
-        trick that's already secured; feed K/10 across if doing so is
-        free (doesn't cost the trick).
+        trick that's already secured; feed a counter across if doing so is
+        free (doesn't cost the trick). Delegates to `_feed_partner` — this
+        tier had its own inline copy of that rule, and the copy carried the
+        `max`-instead-of-`min` bug for the whole life of the function
+        (#168, after #154 in TypeScript and #164 in `choose_follow_card`).
+        Sharing the one helper is what stops a fourth copy drifting.
       - Protect count cards (A/10/K): when following suit but unable to
         beat, or when free-sluffing, prefer a zero-count card (9/J/Q)
         over a count card whenever one is legal.
@@ -1612,10 +1635,7 @@ def _expert_follow_card_honest(hand, legal_moves, trick_plays, trump, my_team_pl
         if forced_beat:
             return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
         if partner_winning:
-            feed_cards = [c for c in legal_moves if c.rank in ("K", "10")]
-            if feed_cards:
-                return max(feed_cards, key=lambda c: RANK_VALUE[c.rank])
-            return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
+            return _feed_partner(legal_moves)
         non_points = [c for c in legal_moves if c.rank not in POINT_RANKS]
         if non_points:
             return min(non_points, key=lambda c: RANK_VALUE[c.rank])

--- a/test_trick_play_strategy.py
+++ b/test_trick_play_strategy.py
@@ -18,10 +18,11 @@ Covers:
   3. Endgame loser-first sequencing: once all trump is accounted for
      outside a near-empty hand, losers lead first and trump is held back.
   4. Following-suit heuristics: duck vs. feed when partner is already
-     winning, count-card protection on both a forced non-beat and a free
-     sluff (including the case where a naive shortest-suit tie-break would
-     get it wrong), and over-trump-vs-under-trump judgment when first to
-     trump a trick.
+     winning (including *which* counter goes across, and that the
+     mandatory-beat tier above pre-empts the choice - #168), count-card
+     protection on both a forced non-beat and a free sluff (including the
+     case where a naive shortest-suit tie-break would get it wrong), and
+     over-trump-vs-under-trump judgment when first to trump a trick.
   5. The defender static/rollout-compare split (doc Section 9 Q5, revised
      resolution): static mode never leads trump; rollout-compare mode CAN
      override that default when the injected evaluator prefers it.
@@ -216,6 +217,68 @@ def test_follow_feeds_partner_when_a_count_card_is_free():
     hand = [C(Suit.CLUBS, "9"), C(Suit.CLUBS, "K", 2)]  # 2nd copy of K ties, doesn't beat
     card = choose_expert_follow_card(hand, hand, trick_plays, trump, {partner}, PlayTracker())
     assert card.rank == "K", "should feed the count card across to partner's secured trick"
+
+
+def test_expert_follow_feeds_the_king_not_the_ten():
+    """#168 - the third and last copy of the bug #154 fixed in TypeScript and
+    #164 fixed in `choose_follow_card`. King and 10 are worth 10 points each
+    (`pinochle_rules.md`), so the trick banks the same score either way; the
+    only difference is what stays in hand, and the 10 is beaten by nothing but
+    an Ace. This tier called `max` - throwing the 10, keeping the King - for
+    the whole life of the function, and it is the copy skills 4-5 actually
+    follow with.
+
+    The legal set is taken from `Trick.legal_moves` rather than written by
+    hand: partner is sitting on the Ace, so no card of this suit beats it, no
+    beat is mandatory, and the feed tier is genuinely the one that runs."""
+    trump = Suit.SPADES
+    partner = "partner"
+    trick = Trick(trump)
+    trick.play(partner, C(Suit.HEARTS, "A"))
+    hand = [C(Suit.HEARTS, "9"), C(Suit.HEARTS, "K"), C(Suit.HEARTS, "10")]
+    legal = trick.legal_moves(hand)
+    assert {c.rank for c in legal} == {"9", "K", "10"}, "no beater exists, so nothing is forced"
+    card = choose_expert_follow_card(hand, legal, trick.plays, trump, {partner}, PlayTracker())
+    assert card.rank == "K", card
+
+
+def test_expert_follow_holds_the_ace_when_it_is_the_only_counter():
+    """The half of the rule that was measured rather than reasoned out. "Feed
+    your cheapest counter" read literally orders K -> 10 -> A and would donate
+    the Ace here for the same 10 points; #154 ran that variant as its own arm
+    over 5000 paired deals, where it was a null against the pre-fix behaviour
+    and 3.5 points a deal behind excluding the Ace. The trick pays the same
+    either way, the boss of the suit does not. Settled in both engines - #168
+    kept the exclusion rather than re-opening it.
+
+    Partner leads one copy of the Ace, so the second copy ties instead of
+    beating it and is legal without being forced."""
+    trump = Suit.SPADES
+    partner = "partner"
+    trick = Trick(trump)
+    trick.play(partner, C(Suit.HEARTS, "A", 1))
+    hand = [C(Suit.HEARTS, "9"), C(Suit.HEARTS, "A", 2)]
+    legal = trick.legal_moves(hand)
+    assert len(legal) == 2, "the tying second Ace is legal, not a mandatory beat"
+    card = choose_expert_follow_card(hand, legal, trick.plays, trump, {partner}, PlayTracker())
+    assert card.rank == "9", card
+
+
+def test_expert_follow_forced_beat_pre_empts_the_feed_tier():
+    """Guards the tier ordering: when every legal card already beats the card
+    on the table the mandatory-beat tier runs first and wins as cheaply as
+    possible, so `_feed_partner` is never reached. Chosen so the two tiers
+    disagree - the cheapest legal card is the zero-count Queen, while the feed
+    tier would have spent the King."""
+    trump = Suit.SPADES
+    partner = "partner"
+    trick = Trick(trump)
+    trick.play(partner, C(Suit.HEARTS, "J"))
+    hand = [C(Suit.HEARTS, "Q"), C(Suit.HEARTS, "K")]
+    legal = trick.legal_moves(hand)
+    assert len(legal) == 2, "both cards beat the Jack, so the beat is mandatory"
+    card = choose_expert_follow_card(hand, legal, trick.plays, trump, {partner}, PlayTracker())
+    assert card.rank == "Q", card
 
 
 def test_follow_protects_count_card_when_unable_to_beat():


### PR DESCRIPTION
`_expert_follow_card_honest`'s partner-is-winning tier kept its own inline copy
of the feed rule, and that copy still called `max` on the King/10 it was about
to donate — so it threw the 10 and kept the King. Third and last copy of the bug
#154 fixed in `web/src/engine/tracker.ts` and #164 fixed in
`choose_follow_card`. A, 10 and K are worth exactly 10 points each, so both
cards bank the same score; the only difference is what stays in hand, and the 10
loses to nothing but an Ace.

## The change

```diff
         if partner_winning:
-            feed_cards = [c for c in legal_moves if c.rank in ("K", "10")]
-            if feed_cards:
-                return max(feed_cards, key=lambda c: RANK_VALUE[c.rank])
-            return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
+            return _feed_partner(legal_moves)
```

The tier calls the existing `_feed_partner` helper rather than repeating it.
That is provably behaviour-identical to a bare `max` → `min` here — the fallback
line was already the same — and it is what stops a fourth copy drifting. It is
**not** the tier-structure refactor #168 raises; that stays out of a PR carrying
a measured behaviour change. The Ace exclusion is retained: #154 measured that
question closed and this side did not re-open it.

## Why this copy is the one that matters

Skills 4-5 follow with this function *at the table*. #164 could only reach their
rollouts, and a rollout is self-play — both sides of the simulated playout
collect the same 10, so the effect cancelled and its skill-4 arm read a null
(−3.07, 95% CI −7.67 to +1.54). Re-run against the live decision:

`ab_harness.py`, 5000 paired deals (10,000 games) per arm, fixed against the old
`max`:

| arm | margin/deal | 95% CI | swept | split | p (pairs) |
|---|---|---|---|---|---|
| skill 4, seed 168000 | **+6.69** | +3.26 to +10.03 | 89–67 | 4844 | 0.092 |
| skill 4, seed 270000 | **+10.56** | +7.22 to +13.95 | 117–55 | 4828 | <0.0001 |
| skill 5, seed 168000 | **+6.22** | +2.79 to +9.63 | 91–62 | 4847 | 0.023 |

**All three intervals exclude zero.** #168 expected a null and said one would be
a legitimate outcome; it is not what the data says. The rule is worth roughly
twice at the top of the dial what it is at Proficient (+3.55 in TypeScript,
+3.61 here), which fits the mechanism — skills 4-5 carry counters deeper into a
hand, so which counter gets spent keeps paying for longer.

The two seeds at skill 4 agree in direction and overlap, but +6.69 and +10.56
are not a tight replication; treat the size as "clearly positive, roughly 5-12
points a deal" rather than a point estimate. Games-won stays the uninformative
statistic #154 said it was: 4828–4847 of every 5000 pairs split, and only the
seed-270000 arm reaches significance on it alone.

Skills 1-3 were not re-run and did not need to be — they follow with
`choose_follow_card`, which #164 already fixed and measured.

## Controls, run first

Per #153's rule that a dial must report nothing when nothing differs:

| control | result |
|---|---|
| old vs old, skill 4, 200 pairs | 200/200 split, every paired margin exactly 0 |
| old vs old, skill 5, 200 pairs | 200/200 split, every paired margin exactly 0 |
| fixed vs wrapper-only-fixed, skill 4, 200 pairs | 200/200 split, every paired margin exactly 0 |

The third is the one that matters for this design: it proves the two-arm
machinery contributes nothing of its own.

## No temporary switch to remove

`pinochle_engine.py` never carried one. The pre-#168 arm is a `GeneralStrategy`
subclass in a throwaway runner that swaps the module-level function for the
duration of its own `choose_card` call and restores it — nothing in the follow
path runs a rollout (skills 4 and 5 both have `deception: False`, and rollouts
build plain `Player` objects, which follow with `choose_follow_card`), so the
swap window covers exactly one decision and cannot leak. The runner lived
outside the repo for its whole life.

Before any deal was played it was differential-tested against HEAD's function
over 150,000 randomised trick states: identical on every one, and it differs
from the fix only ever by K-for-10 in this tier (3,249 flips, ~2% of follow
decisions).

Cost, for whoever budgets the next one of these: ~28 CPU-hours across the three
arms, 20 shards each, 20-38 minutes wall per arm on 20 cores. Shards are cached
to disk, which is what let two runs resume after being cut off mid-flight.

## Tests

This tier had **no coverage at all** — the same gap #167 found on the Proficient
side. Every existing follow-card test either hit a different tier or held only
one counter, so `max` and `min` agreed and the bug sat under a green suite.
Three added, built through `Trick.legal_moves` so the states are reachable
rather than hand-asserted:

- spends the King over the 10 (fails against the old behaviour)
- holds the Ace back when it is the only counter
- the mandatory-beat tier above still pre-empts the feed, chosen so the two
  tiers actually disagree (Queen vs King)

`python -m pytest -q` → **294 pass** (291 + 3). `export_parity_scenarios.py
--check` and `export_evaluator.py --check` both pass — each renders from a
committed artifact, so an AI change cannot make them stale.

## Still open

All three copies of the heuristic now agree, and Python has one implementation
instead of two. The remaining duplication is the cross-engine one, which is by
design. #168's note that `choose_follow_card` and `_expert_follow_card_honest`
share a tier structure that has drifted twice is untouched here and is worth its
own issue.

Closes #168
