### PR TITLE
test(web): fail loudly on incomplete runs, and give the jsdom tier a load-proof budget

### DIFF
--- a/web/src/components/AuctionFlow.test.tsx
+++ b/web/src/components/AuctionFlow.test.tsx
@@ -222,7 +222,13 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-describe('AuctionFlow (component)', () => {
+// #170: raised from the 5 s default because the first test to call `render()`
+// in a file also absorbs jsdom/React/RTL first-render warmup inside its own
+// wall-clock budget — negligible on an idle machine, 2.5-4.5 s when several
+// agents are building in parallel. Full rationale in TrickPlayFlow.test.tsx.
+// Only the component suite needs it; the `auctionReducer` suite above is pure
+// logic and stays at the strict default.
+describe('AuctionFlow (component)', { timeout: 20_000 }, () => {
   it('walks the human through bidding, naming trump, and passing cards, then reports the result', () => {
     vi.useFakeTimers()
     const hands = buildTestHands()

--- a/web/src/components/GameFlow.test.tsx
+++ b/web/src/components/GameFlow.test.tsx
@@ -43,7 +43,10 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-describe('GameFlow (component)', () => {
+// #170: raised from the 5 s default — the first test to call `render()` also
+// absorbs jsdom/React/RTL first-render warmup inside its own wall-clock
+// budget, which balloons under parallel load. See TrickPlayFlow.test.tsx.
+describe('GameFlow (component)', { timeout: 20_000 }, () => {
   it('deals straight into the auction when no seat is misdeal-eligible', async () => {
     mockDeals([weakHand(), weakHand(), weakHand(), weakHand()])
 

--- a/web/src/components/GameShell.test.tsx
+++ b/web/src/components/GameShell.test.tsx
@@ -28,7 +28,10 @@ afterEach(() => {
   window.localStorage.clear()
 })
 
-describe('GameShell', () => {
+// #170: raised from the 5 s default — the first test to call `render()` also
+// absorbs jsdom/React/RTL first-render warmup inside its own wall-clock
+// budget, which balloons under parallel load. See TrickPlayFlow.test.tsx.
+describe('GameShell', { timeout: 20_000 }, () => {
   it('shows the start menu on load with Continue disabled when there is no save', () => {
     render(<GameShell />)
     expect(screen.getByText('Pinochle')).not.toBeNull()

--- a/web/src/components/MeldFlow.test.tsx
+++ b/web/src/components/MeldFlow.test.tsx
@@ -40,7 +40,10 @@ function renderMeld() {
 
 afterEach(cleanup)
 
-describe('MeldFlow', () => {
+// #170: raised from the 5 s default — the first test to call `render()` also
+// absorbs jsdom/React/RTL first-render warmup inside its own wall-clock
+// budget, which balloons under parallel load. See TrickPlayFlow.test.tsx.
+describe('MeldFlow', { timeout: 20_000 }, () => {
   // #94: the panel used to stack all four seats in one column, growing to
   // roughly twice the viewport height and pushing Continue off-screen.
   it('lays meld out in one column per team, each holding that team‘s two seats', () => {

--- a/web/src/components/PlayingCard.test.tsx
+++ b/web/src/components/PlayingCard.test.tsx
@@ -3,7 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { Suit } from '../engine/card'
 import { PlayingCard } from './PlayingCard'
 
-describe('PlayingCard', () => {
+// #170: raised from the 5 s default — these assertions are trivial, but this is
+// the file's first `render()`, so it absorbs jsdom/React/RTL first-render
+// warmup inside its own wall-clock budget, which balloons under parallel load.
+// See TrickPlayFlow.test.tsx.
+describe('PlayingCard', { timeout: 20_000 }, () => {
   it('renders rank and suit glyph for a face-up card', () => {
     render(<PlayingCard suit={Suit.Spades} rank="A" />)
     const card = screen.getByRole('img', { name: 'A of S' })

--- a/web/src/components/TrickPlayFlow.test.tsx
+++ b/web/src/components/TrickPlayFlow.test.tsx
@@ -35,7 +35,36 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-describe('TrickPlayFlow (component)', () => {
+/**
+ * #170: vitest's 5 s default `testTimeout` is a *wall-clock* budget, but what
+ * these tests spend is *CPU*. That difference is the whole bug.
+ *
+ * The AI delays are already driven by fake timers (see the
+ * `advanceTimersByTime` calls below), so nothing here ever waits on a real
+ * clock — the original "it sits on real timers" theory does not apply. What
+ * costs time is genuine computation: the full-round test alone drives 48 card
+ * plays, which is 48 React commits over a 4-seat table plus 36 real
+ * `chooseLeadCard`/`chooseFollowCard` decisions. That measures ~1.3 s on an
+ * idle machine — only ~3.8x under the default budget — and a 3-4x slowdown is
+ * routine when several agents are building and running sweeps in parallel,
+ * which is the normal mode on this project. Measured at 5.4 s median and 11.0 s
+ * worst case under that contention, i.e. over budget.
+ *
+ * A wall-clock budget on CPU-bound work cannot be made load-proof by rewriting
+ * the test; it can only be given enough room. So the budget is raised here,
+ * per suite, rather than globally: the ~300 pure-logic engine tests stay at the
+ * strict 5 s default so a genuine hang there still surfaces fast, and the cost
+ * of the jsdom integration tier stays an explicit, reviewed number instead of a
+ * suite-wide default nobody looks at again.
+ *
+ * The same reasoning covers the *first* test of every component file, which
+ * additionally absorbs jsdom/React/RTL first-render warmup (~150 ms idle, but
+ * 2.5-4.5 s under load) inside its own budget — hence the identical raise in
+ * AuctionFlow/GameFlow/GameShell/MeldFlow/PlayingCard.
+ */
+const COMPONENT_SUITE_TIMEOUT_MS = 20_000
+
+describe('TrickPlayFlow (component)', { timeout: COMPONENT_SUITE_TIMEOUT_MS }, () => {
   it('highlights only legal cards for the human, forcing a follow of the lead suit', () => {
     vi.useFakeTimers()
     disableAiFold()
@@ -160,9 +189,17 @@ describe('TrickPlayFlow (component)', () => {
     let guard = 0
     while (onComplete.mock.calls.length === 0 && guard < 500) {
       guard++
-      const playable = screen
-        .queryAllByRole('button', { name: /^Play / })
-        .find((button) => !button.hasAttribute('disabled'))
+      // Deliberately a plain attribute selector rather than
+      // `queryAllByRole('button', { name: /^Play / })`. This runs ~60 times per
+      // round, and the role query computes an accessible name for every
+      // candidate and a `getComputedStyle` visibility check for every node in
+      // the tree on each call — measured at ~30% of this test's total runtime
+      // (#170). Nothing is lost by dropping it: this loop is a *driver*, not an
+      // assertion, and the role/accessible-name contract on these buttons is
+      // what the two tests above actually assert.
+      const playable = document.querySelector<HTMLButtonElement>(
+        'button[aria-label^="Play "]:not([disabled])',
+      )
       if (playable) {
         fireEvent.click(playable)
       } else {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,131 @@
 /// <reference types="vitest/config" />
+import { readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
+
+// -- Suite completeness guard (#170) -----------------------------------------
+//
+// Under CPU contention vitest can fail to start its workers
+// (`[vitest-pool]: Failed to start forks worker ... Timeout waiting for worker
+// to respond`; `START_TIMEOUT` is hardcoded at 60 s in the pool runner and is
+// not configurable). Measured here: a 30-process load run executed 14 of 39
+// files and another executed 28 — and both printed a *green* summary,
+// `Tests 127 passed (127)`, because the denominator shrinks with the numerator.
+//
+// The exit code was non-zero in those runs, so CI would have caught them. But
+// the summary line is what a human reads, and "127 passed" over a suite of 372
+// looks like success. `npm test` is the gate every PR here has to pass, and a
+// gate that can run a third of the suite and print green is worse than one that
+// times out loudly.
+//
+// So the file count is asserted rather than trusted: whatever vitest discovered
+// and ran must match what is on disk, or the run fails with a message that says
+// so in as many words. That covers both shapes of the problem — workers that
+// fail to start, and files that are never discovered — without depending on
+// which one occurred.
+const TEST_FILE_RE = /\.(test|spec)\.(c|m)?[jt]sx?$/
+const IGNORED_DIRS = new Set(['node_modules', 'dist', 'coverage', '.git'])
+
+function countTestFilesOnDisk(dir: string): number {
+  let found = 0
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRS.has(entry.name)) found += countTestFilesOnDisk(`${dir}/${entry.name}`)
+    } else if (TEST_FILE_RE.test(entry.name)) {
+      found++
+    }
+  }
+  return found
+}
+
+/**
+ * `npm test` runs `vitest run` and nothing else, so that exact argv is the gate
+ * and only that invocation is held to the full on-disk count. Anything more
+ * specific is a developer narrowing the run on purpose (`vitest run one.test.ts`,
+ * `-t 'name'`, `--exclude ...`) and would fail such a check by design. Matching
+ * the gate's argv exactly, rather than trying to parse arbitrary vitest CLI, is
+ * what keeps this free of false alarms — an earlier attempt to detect filters by
+ * scanning argv stood down on `--exclude "**‍/engine/**"`, because a flag's
+ * space-separated value is indistinguishable from a positional filter.
+ */
+function isGateRun(): boolean {
+  const args = process.argv.slice(2)
+  return args.length === 0 || (args.length === 1 && args[0] === 'run')
+}
+
+function reportIncomplete(ran: number, expected: number, source: string): void {
+  console.error(
+    `\n  INCOMPLETE TEST RUN\n` +
+      `  Ran ${ran} test files, but ${expected} ${source}.\n` +
+      `  ${expected - ran} file(s) never executed, so the summary above reports success\n` +
+      `  over a subset of the suite. Treat this run as FAILED.\n` +
+      `  Usual cause is vitest failing to start workers under CPU load (#170):\n` +
+      `  re-run on a quieter machine and check the file count, not just the colour.\n`,
+  )
+  process.exitCode = 1
+}
+
+/**
+ * A module left in one of these at the end of the run was resolved but never
+ * executed. Counting modules is not enough on its own: vitest keeps unrun files
+ * in the results (a `--bail` run reports `states={failed:1, pending:39}` with
+ * all 40 modules present), so the state is the signal, not the length.
+ */
+const UNEXECUTED_STATES = new Set(['pending', 'queued', 'running'])
+
+function isUnexecuted(testModule: { state?: () => string }): boolean {
+  try {
+    return UNEXECUTED_STATES.has(String(testModule.state?.()))
+  } catch {
+    return false
+  }
+}
+
+/** `--bail` deliberately abandons the remaining files, and already exits non-zero. */
+function isBailRun(): boolean {
+  return process.argv.slice(2).some((arg) => arg === '--bail' || arg.startsWith('--bail='))
+}
+
+let intendedSpecCount = -1
+
+const suiteCompletenessReporter = {
+  onTestRunStart(specifications: readonly unknown[] = []) {
+    intendedSpecCount = specifications.length
+  },
+  onTestRunEnd(
+    testModules: readonly { state?: () => string }[] = [],
+    _errors: readonly unknown[] = [],
+    _reason?: string,
+  ) {
+    if (isBailRun()) return
+    const unexecuted = testModules.filter(isUnexecuted).length
+    const ran = testModules.length - unexecuted
+
+    // 1. Resolved but never executed. Filter-agnostic, so it holds under any
+    //    combination of CLI narrowing.
+    if (unexecuted > 0) {
+      reportIncomplete(ran, testModules.length, 'were resolved for this run')
+      return
+    }
+
+    // 2. Dropped from the results entirely — the shape the worker-startup
+    //    failure takes, where the denominator itself shrinks (`14 passed (14)`
+    //    out of 39 files) and the summary still reads green.
+    if (intendedSpecCount >= 0 && testModules.length < intendedSpecCount) {
+      reportIncomplete(ran, intendedSpecCount, 'were resolved for this run')
+      return
+    }
+
+    // 3. Gate only: catches discovery itself, which 1 and 2 cannot see — if the
+    //    glob resolves 33 files, "33 of 33 ran" is true and still wrong.
+    if (!isGateRun()) return
+    const onDisk = countTestFilesOnDisk(fileURLToPath(new URL('./src', import.meta.url)))
+    if (ran < onDisk) reportIncomplete(ran, onDisk, 'exist on disk')
+  },
+}
 
 // The app is not currently hosted anywhere — GitHub holds the code only.
 // Root base works for `npm run dev` / `npm run preview` and for any host that
@@ -70,5 +193,8 @@ export default defineConfig({
   ],
   test: {
     environment: 'jsdom',
+    // 'default' keeps the normal output; the guard only adds the completeness
+    // assertion on top of it (#170).
+    reporters: ['default', suiteCompletenessReporter],
   },
 })


### PR DESCRIPTION
Two independent problems with `npm test`, both triggered by CPU contention. The
second is the one that mattered.

## 1. An incomplete run now fails loudly

Under load, vitest can fail to start workers (`[vitest-pool]: Failed to start
forks worker … Timeout waiting for worker to respond` — `START_TIMEOUT` is
hardcoded at 60 s and not configurable). The files it could not start are dropped
from the results entirely, so **the denominator shrinks with the numerator** and
the summary prints green:

```
Test Files  33 passed (33)      <- 39 exist on disk
Test Files  29 passed (29)      <- 39 exist on disk
Test Files  14 passed (14)      <- measured under a 30-process load
```

`npm test` is the gate every PR here passes. A gate that can run a third of the
suite and print "passed" is worse than one that times out, because a timeout gets
investigated and this does not — the denominator is the only tell and nobody
reads it.

**Correction to the issue's framing:** those runs *did* exit non-zero, so CI would
have caught them. The failure is in what a human reads, not in the exit code. That
is still worth fixing, because the summary line is what everyone actually looks at.

A reporter in `vite.config.ts` now asserts completeness in three layers:

1. **Resolved but never executed** — filter-agnostic, holds under any CLI
   narrowing. Checks module *state*, not count: vitest keeps unrun files in the
   results, so a `--bail` run reports all 40 modules present with 39 pending.
2. **Dropped from the results entirely** — the worker-startup shape, where the
   denominator itself shrinks. Compares against the spec count captured at run
   start.
3. **Discovery** — gate runs only. If the glob resolves 33 files, "33 of 33 ran"
   is true and still wrong, so the count is checked against what is on disk.

Layer 3 applies only to the exact argv `npm test` uses (`vitest run`, no args).
Anything more specific is a developer narrowing the run on purpose and would fail
such a check by design. Matching the gate's argv exactly, rather than parsing
arbitrary vitest CLI, is what keeps it free of false alarms — a flag's
space-separated value is indistinguishable from a positional filter.

`--bail` is exempt: it abandons remaining files deliberately and already exits
non-zero.

## 2. The timeout, and why the obvious fix was the wrong one

The issue proposed fake timers. **The tests already use them** — the AI delays are
driven by `advanceTimersByTime` and nothing waits on a real clock. That diagnosis
was wrong.

The actual cause: vitest's `testTimeout` is a **wall-clock** budget, and what
these tests spend is **CPU**. The full-round test drives 48 card plays — 48 React
commits over a 4-seat table plus 36 real `chooseLeadCard`/`chooseFollowCard`
decisions. That is ~1.3 s idle, only ~3.8x under the 5 s default, and a 3-4x
slowdown is routine when several agents are building in parallel. Measured 5.4 s
median and 11.0 s worst case under contention.

A wall-clock budget on CPU-bound work cannot be made load-proof by rewriting the
test; it can only be given room. So the budget is raised **per suite** to 20 s for
the six jsdom component files, not globally. The ~300 pure-logic engine tests keep
the strict 5 s default, so a genuine hang there still surfaces fast, and the cost
of the integration tier stays an explicit reviewed number rather than a suite-wide
default nobody looks at again.

The same reasoning covers the first test in each component file, which absorbs
jsdom/React/RTL first-render warmup inside its own budget (~150 ms idle, 2.5-4.5 s
under load).

## Verification

- **Idle:** 39 files / 372 tests, exit 0.
- **Under load:** 24 busy processes on a 20-core machine, `npm test` three
  consecutive times — 39/39 every run, exit 0 each time.
- **The guard actually fires:** injected a deliberate off-by-one into the on-disk
  count. The summary still printed `Test Files 39 passed (39)`, and the run
  failed with `INCOMPLETE TEST RUN / Ran 39 test files, but 40 exist on disk` and
  **exit 1**. Reverted, re-verified clean.
- `python -m pytest -q` — 294 passed. `npm run build` clean.

The under-load verification is the point: passing once on an idle machine proves
nothing, since idle is the state that already worked.

Closes #170
