### PR TITLE
Take the partner-passed bid floor off 321 and onto 330 (#177)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -441,6 +441,77 @@ The four throwaway arms (`open_q`, `hold_all`, `hold_ace`, `last_trick`) on the
 measurement in the shape the section below describes and deleted before the fix
 was committed — the same call #126, #153 and #154 made.
 
+### The partner-passed bid floor (#177)
+
+The first measurement in this file that is not about *strength*. Bids move in
+tens; `chooseBid`'s partner-passed floor was **321**, written as `320 + 1` to
+encode "strictly above `OPENER_THRESHOLD`" by someone thinking in ceiling points
+rather than in bids. `OPENER_THRESHOLD` and `DEFENSIVE_PUSH_FLOOR` really are
+points — thresholds a hand's valuation is compared against, where 321 is a
+perfectly ordinary number — and the floor sits one line away from them but is an
+actual bid placed on the table. It is now `PARTNER_PASSED_FLOOR = 330`.
+
+What it cost while it was wrong, over 20 000 headless auctions: **11 553 of
+40 200 bids placed — 28.7% — were not multiples of 10**, and 18.3% of deals
+settled on a contract of exactly 321. The floor branch is not a corner case; it
+fires in about 28% of auctions. And one off-grid bid is not one bad bid, because
+it reseeds `currentBid`: from 321 the ladder runs 331, 341, 351, and
+`BiddingControls` gates its Bid button on `amount % 10 === 0`, so the panel shows
+the human "Minimum: 331" — a number the +/− buttons, which step in tens, cannot
+produce. Typing 340 by hand works. Nothing says so.
+
+**Why 330 and not 320**, since both are legal and the code and its comment
+disagreed about which was meant. The rule (#93/#95) is that a seat whose partner
+has passed is buying the contract alone and must *clear* the opener threshold,
+not merely equal it — and `chooseBid` already says exactly that one tier up, in
+the other direction: it wants `ceiling > OPENER_THRESHOLD` when the partner has
+passed against `ceiling >= OPENER_THRESHOLD` when they have not. 320 would make
+the floor "at least 320" and leave that strict `>` arbitrary. So 330, on the
+rule, not on the arithmetic.
+
+Measured with a throwaway `partnerPassedFloor` field on `SkillParams` plus a
+temporary `cli.ts floor --baseline N` command, added in the shape the section
+below describes and deleted before the fix was committed — the same call #126,
+#153, #154 and #159 made. 5000 pairs / 10 000 games per row, A = 330:
+
+| vs 321 (the fix) | margin per deal | 95% CI | swept | p |
+| --- | --- | --- | --- | --- |
+| seed 1 | −2.89 | −5.37 to −0.39 | 37–56 | 0.061 |
+| seed 2 | −0.57 | −2.85 to +1.72 | 29–47 | 0.051 |
+| seed 3 | −2.27 | −4.85 to +0.28 | 39–61 | 0.035 |
+| seed 4 | −2.71 | −5.04 to −0.55 | 31–50 | 0.045 |
+
+Negative on all four seeds, excluding zero on two of them, ~2 points per deal in
+a game to 1000. Read it as a small real cost rather than a null: the sign never
+flips and the sign test sits at p ≈ 0.05 pointing the same way. The mechanism is
+not subtle — 321 is nine points cheaper to commit to than 330, so the old value
+took slightly more contracts (23 885 vs 23 352) at the same make rate. **Shipped
+anyway.** A bid the human cannot make is not a strategy setting, and two points
+per deal is the price of the ladder being legal.
+
+| vs 320 (the other reading) | margin per deal | 95% CI | swept | p |
+| --- | --- | --- | --- | --- |
+| seed 1 | **−9.82** | −14.85 to −4.98 | 148–170 | 0.239 |
+| seed 2 | **−6.76** | −11.35 to −2.12 | 140–171 | 0.089 |
+| seed 3 | **−10.68** | −15.56 to −5.94 | 130–193 | 0.0005 |
+| seed 4 | **−12.10** | −16.96 to −7.43 | 126–196 | 0.0001 |
+
+That one is not small and it is not ambiguous: four seeds, four intervals
+excluding zero, ~10 points per deal — larger than #159's +7.61 and #154's +3.55,
+both of which shipped on their numbers. **320 plays better than 330.** It is
+left unshipped deliberately, because it is a different question: #177 is a
+legality fix, both candidates are legal, and lowering the floor changes what
+#93/#95's rule *means* rather than correcting how it is spelled. Deciding that
+on a strength number alone would settle a design rule in passing under cover of
+a bug fix. It wants its own issue, and this table is the evidence for it.
+
+Controls, run first as the section below requires: `selftest --policy distilled`
+split all 200 pairs with a paired margin of exactly 0, and so did the floor arm
+against itself (`floor --baseline 330`), which is the same check for the new
+dial. The dial's ability to *see* a change is carried by the 320 rows rather than
+by a deliberately-bad arm — four intervals that clean is not what a field which
+is written but never read produces.
+
 ### Checking that a dial can see a change
 
 A self-test proves a dial reports nothing when nothing differs. It does not

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { Card, OPENING_BID, Suit } from './card'
+import type { SkillLevel } from '../persistence/options'
+import { Card, Deck, OPENING_BID, Suit } from './card'
 import {
   ACE_VALUE,
   type AuctionContext,
@@ -14,7 +15,11 @@ import {
   MAX_BID_DEFAULT,
   NEAR_DOUBLE_PINOCHLE_VALUE,
   NEAR_RUN_VALUE,
+  OPENER_THRESHOLD,
+  PARTNER_PASSED_FLOOR,
 } from './bidding'
+import { partnerOf } from './round'
+import type { PlayerIndex } from './trick'
 
 const trump = Suit.Spades
 const RUN_RANKS = ['A', '10', 'K', 'Q', 'J'] as const
@@ -412,5 +417,152 @@ describe('parity with the Python reference engine (#118)', () => {
     expect(NEAR_DOUBLE_PINOCHLE_VALUE).toBe(225)
     expect(ACE_VALUE).toBe(20)
     expect(MAX_BID_DEFAULT).toBe(400)
+  })
+})
+
+// -- The multiple-of-10 invariant (#177) ------------------------------------
+//
+// Bids move in tens. Nothing in the engine said so: the only multiple-of-10
+// check anywhere was the disabled state of one button in `BiddingControls`,
+// which is a *display* rule enforced after the fact and on the human's side
+// only. So `Math.max(321, ...)` — "strictly above OPENER_THRESHOLD", written as
+// `320 + 1` by someone thinking in points rather than in bids — reached players
+// as a real AI bid, and from 321 the whole ladder ran 331, 341, 351, every rung
+// of it a minimum the +/- buttons could not produce.
+//
+// The specific constant is a one-line fix. What made it possible to ship is
+// that no test could have caught it: the case-by-case tests above each assert
+// one hand against one expected number, so they only cover paths someone
+// already thought about, and `engineParity.test.ts` compares rules against
+// Python rather than AI decisions (Python never had this constant — it is
+// TypeScript-only, not a port slip).
+//
+// Hence a property rather than another case: sweep the decision surface and
+// assert the shape of every answer. The next off-grid constant fails here
+// instead of reaching a player, wherever in `chooseBid` someone puts it.
+const SKILL_LEVELS: readonly SkillLevel[] = ['easy', 'medium', 'hard', 'proficient', 'expert']
+const SEATS: readonly PlayerIndex[] = [0, 1, 2, 3]
+
+/** mulberry32, the generator `src/ab/headlessGame.ts` uses. Inlined rather than
+ *  imported so an engine test does not depend on the measurement harness.
+ *  `meldOnlyBid`'s noise term reads `Math.random`, so an unseeded sweep would be
+ *  a different test on every run — and a property test that cannot be replayed
+ *  from its failure is not much of a property test. */
+function seededRandom(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+describe('every bid chooseBid can return is legal (#177)', () => {
+  it('is a multiple of 10 and at least OPENING_BID, across skills, auction states and seats', () => {
+    const realRandom = Math.random
+    Math.random = seededRandom(0x1770_2026)
+    const offGrid: string[] = []
+
+    // Dealer seat and running score are cycled through the case list rather
+    // than nested as two more loops. They are independent of the auction state
+    // for this property's purposes — the branches that read them (dealer
+    // protection, `computeCompetitiveAdjustment`) do not interact with the
+    // branches that set a bid level — and 8 deals x 4 seats re-rolls the offset,
+    // so every state still meets every dealer and every score pairing across
+    // the sweep. Nesting them instead multiplied the run by 12x for ~85s, which
+    // is the difference between a property test that gets run and one that gets
+    // skipped.
+    const SCORE_CASES: Record<0 | 1, number>[] = [
+      { 0: 0, 1: 0 },
+      { 0: 850, 1: 400 },
+      { 0: 400, 1: 900 },
+    ]
+
+    try {
+      for (let deal = 0; deal < 8; deal++) {
+        const deck = new Deck()
+        deck.shuffle()
+        const hands = deck.deal()
+
+        for (const player of SEATS) {
+          const partner = partnerOf(player)
+          const opponent = ((player + 1) % 4) as PlayerIndex
+
+          // Auction states worth sweeping, each paired with the currentBid that
+          // actually goes with it. The partner-passed rows are the ones #177
+          // lived in; the rest are there so the property covers the whole
+          // function rather than the one branch known to have been wrong.
+          const cases: { currentBid: number; context: AuctionContext }[] = []
+          const spin = deal * 4 + player
+          const push = (currentBid: number, partial: Omit<AuctionContext, 'dealer' | 'scores'>) => {
+            const n = cases.length + spin
+            cases.push({
+              currentBid,
+              context: { ...partial, dealer: (n % 4) as PlayerIndex, scores: SCORE_CASES[n % 3] },
+            })
+          }
+
+          for (const passedPlayers of [[], [partner], [opponent], [partner, opponent]] as PlayerIndex[][]) {
+            // Nobody has bid: opener, 3rd-bidder-opens-cheap, and dealer seats.
+            for (const passesSoFar of [0, 1, 2, 3]) {
+              push(OPENING_BID - 10, { everBid: false, passesSoFar, bidHistory: [], passedPlayers })
+            }
+            // Someone holds the bid — opponents, then partner, then this seat's
+            // own earlier bid, at rungs on both sides of the partner-passed
+            // floor so the raise ladder and the floor are both exercised.
+            for (const currentBid of [300, 310, 320, 330, 390, 400]) {
+              for (const lastBidder of [opponent, partner, player] as PlayerIndex[]) {
+                push(currentBid, {
+                  everBid: true,
+                  passesSoFar: passedPlayers.length,
+                  bidHistory: [
+                    { player: opponent, amount: OPENING_BID },
+                    { player: lastBidder, amount: currentBid },
+                  ],
+                  passedPlayers,
+                })
+              }
+            }
+          }
+
+          for (const skill of SKILL_LEVELS) {
+            for (const { currentBid, context } of cases) {
+              const bid = chooseBid(player, hands[player], currentBid, 10, context, skill)
+              if (bid === null) continue
+              if (bid % 10 !== 0 || bid < OPENING_BID) {
+                offGrid.push(
+                  `${bid} (skill ${skill}, seat ${player}, dealer ${context.dealer}, currentBid ${currentBid}, ` +
+                    `everBid ${context.everBid}, passed [${context.passedPlayers.join(',')}])`,
+                )
+              }
+            }
+          }
+        }
+      }
+    } finally {
+      Math.random = realRandom
+    }
+
+    // Reported as a list rather than as the first failure: if a constant is off
+    // the grid it is off it in several places at once (#177 had three), and
+    // seeing them together is what says "one wrong constant" rather than "one
+    // wrong branch".
+    expect(offGrid.slice(0, 10)).toEqual([])
+  }, 30_000)
+
+  it('takes the partner-passed floor to 330, the first legal bid clearing OPENER_THRESHOLD', () => {
+    // The decision the fix encodes, asserted directly rather than only through
+    // the sweep: 330 is not an arbitrary rounding of 321, it is "above 320" —
+    // the same strictness `chooseBid`'s static verdict applies to the ceiling
+    // when the partner has passed.
+    expect(PARTNER_PASSED_FLOOR).toBe(330)
+    expect(PARTNER_PASSED_FLOOR % 10).toBe(0)
+    expect(PARTNER_PASSED_FLOOR).toBeGreaterThan(OPENER_THRESHOLD)
+    // 320 would also be a legal bid; it is rejected because it only *equals*
+    // the threshold. Guards against a later "simplify" that sets the floor to
+    // OPENER_THRESHOLD itself.
+    expect(PARTNER_PASSED_FLOOR - OPENER_THRESHOLD).toBe(10)
   })
 })

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -71,6 +71,36 @@ export const OPENER_THRESHOLD = 320
 // hopeless" hands (no meld, no aces — ceiling ~130) fall below this floor.
 export const DEFENSIVE_PUSH_FLOOR = 200
 
+/**
+ * The bid a seat must commit to once its partner has passed (#93/#95).
+ *
+ * Not a ceiling like the two above — it is an actual bid, placed on the table,
+ * and **bids move in tens**. That distinction is what #177 was: this was
+ * written as `320 + 1` to encode "strictly above OPENER_THRESHOLD", which is
+ * the right *intent* and an impossible *bid*. Once any seat bid 321 the whole
+ * ladder went off-grid (331, 341, ...) and `BiddingControls` — which gates its
+ * Bid button on `amount % 10 === 0` — displayed a minimum the human could not
+ * reach with the +/- buttons.
+ *
+ * Why 330 and not 320. The rule this encodes is that a hand bidding alone must
+ * *clear* the opener threshold, not merely equal it: with no partner left to
+ * speak, the seat is buying the contract outright, so it should be worth more
+ * than the hand that would open with help still to come. `chooseBid`'s static
+ * verdict one tier up already says so in the other direction — it asks for
+ * `ceiling > OPENER_THRESHOLD` when the partner has passed against
+ * `ceiling >= OPENER_THRESHOLD` when they have not. 320 would make the floor
+ * "at least 320", which collapses that distinction and makes the strict `>` on
+ * the ceiling arbitrary. The next legal bid above 320 is 330.
+ *
+ * That settles what the rule *means*. It does not settle which value plays
+ * better, and those turned out to differ: 320 measures ~10 points per deal
+ * ahead of 330 over 5000 paired deals, replicated on four seeds (`web/README.md`,
+ * "The partner-passed bid floor"). #177 is a legality fix and both candidates
+ * are legal, so that is left as an open strategy question rather than settled
+ * in passing by a bug fix.
+ */
+export const PARTNER_PASSED_FLOOR = 330
+
 function handCount(hand: readonly Card[], suit: Suit, rank: Rank): number {
   return hand.reduce((count, c) => count + (c.suit === suit && c.rank === rank ? 1 : 0), 0)
 }
@@ -444,11 +474,12 @@ export function chooseBid(
   const partnerHasBid = context.bidHistory.some((b) => b.player === partner)
 
   // When partner has already passed they cannot come back in (#93), so a bid
-  // here is one this hand must carry alone — which means committing to at
-  // least 321. That raises the *bid floor*, not the hand's ceiling: the
-  // ceiling still reflects what the cards are actually worth, so a hopeless
-  // hand declines rather than being talked into 321 it cannot make.
-  const minBidAfterPartnerPass = Math.max(321, currentBid + minIncrement)
+  // here is one this hand must carry alone — which means committing to
+  // PARTNER_PASSED_FLOOR (330), the first legal bid clearing OPENER_THRESHOLD.
+  // That raises the *bid floor*, not the hand's ceiling: the ceiling still
+  // reflects what the cards are actually worth, so a hopeless hand declines
+  // rather than being talked into a 330 it cannot make.
+  const minBidAfterPartnerPass = Math.max(PARTNER_PASSED_FLOOR, currentBid + minIncrement)
 
   // "Is this hand worth committing to a contract at `level`?" — the single
   // question `OPENER_THRESHOLD` and `DEFENSIVE_PUSH_FLOOR` were each a crude
@@ -485,9 +516,10 @@ export function chooseBid(
       return OPENING_BID
     }
 
-    // With partner passed the bid must clear 321, so the static rule wants the
-    // ceiling strictly above the opener threshold rather than merely level
-    // with it. (Ceilings move in tens, so the two differ only at exactly 320.)
+    // With partner passed the bid must clear OPENER_THRESHOLD (so, 330), so the
+    // static rule wants the ceiling strictly above the opener threshold rather
+    // than merely level with it. (Ceilings move in tens, so the two differ only
+    // at exactly 320.)
     const openingLevel = partnerPassed ? minBidAfterPartnerPass : OPENING_BID
     const opens = worthContract(
       openingLevel,
@@ -544,13 +576,16 @@ export function chooseBid(
   // contract. The distilled rule asks the evaluator about the level actually
   // being pushed to; declining here is not the end of the auction, it just
   // falls through to the ordinary raise ladder below.
-  const pushLevel = partnerPassed ? Math.max(nextBid, 321) : nextBid
+  const pushLevel = partnerPassed ? Math.max(nextBid, PARTNER_PASSED_FLOOR) : nextBid
   if (currentBid <= OPENING_BID && worthContract(pushLevel, ceiling >= DEFENSIVE_PUSH_FLOOR)) {
     return pushLevel
   }
 
-  // When partner passed, the bid must be at least 320 regardless of ceiling.
-  if (partnerPassed && nextBid < 321) return competitiveCeiling >= 321 ? 321 : null
+  // When partner passed, the bid must clear OPENER_THRESHOLD regardless of
+  // ceiling — so PARTNER_PASSED_FLOOR (330), not a bid one point over 320.
+  if (partnerPassed && nextBid < PARTNER_PASSED_FLOOR) {
+    return competitiveCeiling >= PARTNER_PASSED_FLOOR ? PARTNER_PASSED_FLOOR : null
+  }
   return nextBid <= competitiveCeiling ? nextBid : null
 }
 

--- a/web/src/engine/biddingSim.test.ts
+++ b/web/src/engine/biddingSim.test.ts
@@ -16,6 +16,7 @@ function runAuction(dealer: PlayerIndex) {
   deck.shuffle()
   let state: AuctionState = initAuctionState(deck.deal(), dealer, SEAT_NAMES, SCORES)
   const askedAfterPassing: PlayerIndex[] = []
+  const bidsPlaced: number[] = []
   const passed = new Set<PlayerIndex>()
 
   let guard = 0
@@ -35,10 +36,11 @@ function runAuction(dealer: PlayerIndex) {
       passed.add(turn)
       state = auctionReducer(state, { type: 'PASS_BID', player: turn })
     } else {
+      bidsPlaced.push(decision)
       state = auctionReducer(state, { type: 'BID', player: turn, amount: decision })
     }
   }
-  return { phase: state.phase, bid: state.bid, winner: state.bidWinner, askedAfterPassing }
+  return { phase: state.phase, bid: state.bid, winner: state.bidWinner, askedAfterPassing, bidsPlaced }
 }
 
 describe('AI-vs-AI auction simulation', () => {
@@ -50,5 +52,20 @@ describe('AI-vs-AI auction simulation', () => {
       expect(winner).not.toBeNull()
       expect(bid).toBeGreaterThanOrEqual(FORCED_BID)
     }
+  })
+
+  it('never takes the ladder off multiples of 10 (#177)', () => {
+    // The end-to-end half of the invariant `bidding.test.ts` states over
+    // `chooseBid` in isolation. It matters separately because #177's damage was
+    // cumulative: one off-grid bid does not just misprice that one call, it
+    // reseeds `currentBid` so every later rung is off the grid too, including
+    // the "Minimum: 331" the human is then shown and cannot bid.
+    const offGrid: number[] = []
+    for (let i = 0; i < 400; i++) {
+      const { bid, bidsPlaced } = runAuction((i % 4) as PlayerIndex)
+      offGrid.push(...bidsPlaced.filter((amount) => amount % 10 !== 0))
+      if (bid !== null && bid % 10 !== 0) offGrid.push(bid)
+    }
+    expect(offGrid.slice(0, 10)).toEqual([])
   })
 })


### PR DESCRIPTION
Closes #177

`chooseBid`'s partner-passed bid floor was **321**, at three sites, with the
surrounding comments saying 320. It is now `PARTNER_PASSED_FLOOR = 330`.

## Why this was worth more than a one-line fix

Bids move in tens. `OPENER_THRESHOLD` and `DEFENSIVE_PUSH_FLOOR`, which this
constant sits two lines away from, are *ceiling points* — thresholds a hand's
valuation is compared against, where 321 is a perfectly ordinary number. The
partner-passed floor is an actual bid, placed on the table. Someone wrote
"strictly above `OPENER_THRESHOLD`" as `320 + 1` while thinking in the first
kind of number, and nothing in the engine knew the difference.

Measured on the pre-fix code, over 20,000 headless auctions:

- **11,553 of 40,200 bids placed — 28.7% — were not multiples of 10.**
- **18.3% of deals settled on a contract of exactly 321.**
- The floor branch fires in ~28% of auctions. Not a corner case.

And an off-grid bid is not one bad bid, because it reseeds `currentBid`: from
321 the ladder runs 331, 341, 351. `BiddingControls` gates its Bid button on
`amount >= minBid && amount % 10 === 0`, so the panel displays the human
"Minimum: 331" — a number the +/− buttons, which step in tens, cannot produce.
Typing 340 by hand works. Nothing tells the player that.

## 330, not 320 — and this is the part to review

Both are legal bids, so #177 is fixed either way. The code and its own comment
disagreed about which was meant, and that disagreement is the actual decision.

The rule (#93/#95) is that a seat whose partner has passed cannot be rescued —
it is buying the contract alone — and so must **clear** the opener threshold
rather than merely equal it. `chooseBid` already says exactly that one tier up,
in the other direction:

```ts
partnerPassed ? ceiling > OPENER_THRESHOLD : ceiling >= OPENER_THRESHOLD
```

A floor of 320 would make the rule "at least 320" and leave that strict `>` on
the ceiling arbitrary. 330 is the next legal bid above 320, so 330 — decided on
what the rule means, not on what the arithmetic happened to produce.

## The invariant, not just the constant

Nothing anywhere enforced multiple-of-10. The only such check in the codebase
was the disabled state of one button in `BiddingControls` — a *display* rule,
applied after the fact and on the human's side only. The existing engine tests
each assert one hand against one expected number, so they cover paths someone
already thought about, and `engineParity.test.ts` compares rules against Python
rather than AI decisions (Python never had this constant — TypeScript-only, not
a port slip). Nothing could have caught it.

Added, both of which **fail on the old constant and pass on the new**:

1. `bidding.test.ts` — a property test over `chooseBid`, sweeping all five skill
   levels x 4 seats x 8 deals x both auction phases x partner-passed /
   opponent-passed / both / neither x rungs on either side of the floor
   (290/300/310/320/330/390/400) x last-bidder = opponent / partner / self, with
   dealer seat and score context cycled through the case list. Every non-null
   return must be a multiple of 10 and at least `OPENING_BID`. Off-grid results
   are collected into a list rather than failing on the first, because a bad
   constant is bad in several branches at once — the old code reports 321 from
   three of them, which is what says "one wrong constant" instead of "one wrong
   branch". Seeded (`meldOnlyBid` reads `Math.random`), so a failure replays.
   ~500 ms.
2. `biddingSim.test.ts` — the end-to-end half: 400 full AI-vs-AI auctions,
   asserting no bid placed and no settled contract is off the grid. This is the
   one that catches the *cascade*, which the isolated property cannot see.

## Measurement (project policy: this changes AI bidding)

Controls first. `selftest --policy distilled` at 200 pairs split every pair with
a paired margin of exactly 0; the new floor arm against itself
(`floor --baseline 330`) did the same. 5000 pairs / 10,000 games per row,
side A = 330, seeds 1–4.

### 330 vs 321 — the change actually being shipped

| seed | margin per deal | 95% CI | swept (A–B) | p |
| --- | --- | --- | --- | --- |
| 1 | −2.89 | −5.37 to −0.39 | 37–56 | 0.061 |
| 2 | −0.57 | −2.85 to +1.72 | 29–47 | 0.051 |
| 3 | −2.27 | −4.85 to +0.28 | 39–61 | 0.035 |
| 4 | −2.71 | −5.04 to −0.55 | 31–50 | 0.045 |

**Reported as a small real cost, not as a null.** The interval excludes zero on
two seeds of four, which on its own would be a null — but the sign never flips,
the sign test sits at p ≈ 0.05 pointing the same way on all four, and the
mechanism is not subtle: 321 is nine points cheaper to commit to than 330, so
the old value took slightly more contracts (23,885 vs 23,352) at the same make
rate (71.3% both sides). Call it ~2 points per deal in a game to 1000.

It ships anyway. A bid the human cannot make is not a difficulty setting, and
two points a deal is the price of the ladder being legal. I would rather state
that plainly than round it to "no measurable effect".

### 330 vs 320 — the other reading of the same rule

| seed | margin per deal | 95% CI | swept (A–B) | p |
| --- | --- | --- | --- | --- |
| 1 | **−9.82** | −14.85 to −4.98 | 148–170 | 0.239 |
| 2 | **−6.76** | −11.35 to −2.12 | 140–171 | 0.089 |
| 3 | **−10.68** | −15.56 to −5.94 | 130–193 | 0.0005 |
| 4 | **−12.10** | −16.96 to −7.43 | 126–196 | 0.0001 |

Four seeds, four intervals excluding zero, ~10 points per deal — **larger than
#159's +7.61 and #154's +3.55, both of which shipped on their numbers.** 320
plays better than 330.

It is deliberately not shipped here. #177 is a legality fix; both candidates are
legal; and lowering the floor changes what #93/#95's rule *means* rather than
correcting how it was spelled. Settling a design rule in passing, under cover of
a bug fix, on a strength number alone, is not a call this PR should make.
**Recommend a follow-up issue** — the table above is the evidence for it, and
`web/README.md` records how to reproduce it in about ten minutes.

Seeds used: 1, 2, 3, 4 for both comparisons; 7 for both controls. Every number
here is from `web/src/ab/` on this branch's tree.

## Scaffolding, added and removed

The comparison needed two floors at one table, and `chooseBid` reads per-seat
config only through `SKILL_PARAMS[skill]`. So a throwaway `partnerPassedFloor`
field on `SkillParams`, a `bidFloorAbPolicies(baseline)` factory and a
`cli.ts floor --baseline N` command carried it, and **all three are deleted** —
the same call #126, #153, #154 and #159 made, and for the same reason: a
permanent knob whose only other setting is an illegal bid is not a dial. The
"Checking that a dial can see a change" section of `web/README.md` is the
procedure for putting it back.

## Checks

- `npx tsc -b` clean.
- `npm test` — 375 passed, 39 files.
- `npx oxlint src` — 3 warnings, all pre-existing `exhaustive-deps` in
  `TrickPlayFlow.tsx` / `AuctionFlow.tsx`, untouched here.
- `python -m pytest -q` at the repo root — 294 passed. No Python changed;
  `pinochle_engine.py` never had this constant, so this is only confirming the
  `export_evaluator.py --check` parity gate is undisturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
