### PR TITLE
feat(ai): take with the counter that cannot be beaten (#158)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -512,6 +512,153 @@ dial. The dial's ability to *see* a change is carried by the 320 rows rather tha
 by a deliberately-bad arm — four intervals that clean is not what a field which
 is written but never read produces.
 
+### "Cannot be beaten", and the first place skill decides a card (#158)
+
+The last child of epic #152, and the one that makes #157's trump memory do
+something. #155 wrote the forced-beat rule as three tiers and could only build
+two of them:
+
+1. beat with a non-counter (Q, J, 9) if one is legal — take the trick for free;
+2. else the lowest counter that **cannot itself be beaten**;
+3. else the lowest counter.
+
+Tier 2 needs to know what is still outstanding, so it was left as a documented
+gap. It is now `isBoss` in `tracker.ts`, and the same predicate answers the
+leading half of the rule that was already there under the name `isSafe`: a
+counter that is provably boss is safe to lead, one that is not is not.
+
+**"Cannot be beaten" can only ever mean cannot be beaten *in suit*.** Whether an
+opponent is void and holds a trump is unknowable — `PlayTracker` records what was
+played, not who is out of what — and no amount of counting fixes it. So the claim
+is never "this wins the trick", it is "nobody takes it with a bigger card of this
+suit", which is the loss the rule exists to avoid: spending a King into a trick an
+opponent's Ace then takes gives away 20 points rather than 10.
+
+Where the information comes from is the whole of the skill dial:
+
+- **Side suits** are exact at every level. #157 scoped its cap to trump, so
+  `PlayTracker` still counts perfectly and an `easy` seat answers a side-suit
+  question exactly as an `expert` does.
+- **Trump** comes from that seat's `TrumpMemory`, capacity `2 × skill level`.
+
+Unknowns resolve conservatively **by construction rather than by a branch**.
+`TrumpMemory.seenCount` can only ever *under*-report — forgetting removes
+sightings and never invents them — and an under-report makes `isBoss` answer
+"beatable". A seat that cannot remember therefore plays as though the card can be
+beaten, which is what #158 asks for, and there is no code path where an unknown
+becomes an assumed best case. `newTrumpMemories` protects the same invariant from
+the other end: a seat is seeded with the *other three* seats' meld and never its
+own, because `isBoss` counts the hand separately and a seat fed its own melded
+King would count one physical card twice and manufacture certainty.
+
+Two positions changed, and two deliberately did not:
+
+- **Forced to beat in a side suit.** With only counters legal, the cheapest one
+  that will still be standing goes in. When nobody is left to play the tier
+  collapses to the cheapest counter, because nothing is outstanding — a property
+  of the position, not of the counting, so the fourth seat cannot be made worse.
+- **Forced to overtrump.** A trump is already winning and `Trick.legalMoves` has
+  restricted the seat to beaters (rule 3 when trump was led, rule 5 over a ruff).
+  The trump branch had no notion of a forced beat at all and answered this with
+  "surrender the lowest point trump". The issue's own worked example — both trump
+  Aces gone makes the 10 boss, then the Kings after the 10s — is a *trump*
+  example, so tier 2 could not be built as specified without one.
+- **A plain ruff is left alone.** Void in the lead suit with no trump yet on the
+  table, every trump in hand "beats" the winner but the rules restricted nothing.
+  That position keeps its existing tiers.
+- **`trumpSecure` still reads the exact count.** "Is every trump accounted for"
+  is a different question from "can this card be beaten", and #157 recorded the
+  exact `PlayTracker` as load-bearing for the parity fixtures. Degrading it is
+  its own issue with its own measurement.
+
+**The measurement.** `cli.ts safe --level L` puts the counted rule at level `L`
+against an `'off'` baseline. The baseline never constructs a `TrumpMemory`, so it
+is the *same opponent at every level* — which is what makes two runs at different
+capacities comparable to each other and not just to zero. Self-tests first: both
+arms found exactly nothing against themselves (200 pairs, every pair split, paired
+margin 0.00), and the two arms were confirmed to return different cards from one
+fixed position before any number was believed (`A♥` against `K♥`, pinned in
+`tracker.test.ts`).
+
+**Measured against auto-SET (#178), which landed while this was in review.**
+That rule ends a mathematically dead contract before the first lead, and it fires
+on **6.8–6.9% of contracts** — roughly one in fourteen — so it changes which
+deals reach trick play at all, and every number below was re-run on top of it
+rather than carried over. #177's bid-floor fix (321 → 330) is in the same
+re-run. Both arms of every row carry `autoSetPolicy: 'forced'`, and the harness
+reports the same auto-SET rate on each side, which is the check that the two
+arms are being dealt the same population.
+
+The ladder was run at all five capacities on the pre-#178 baseline and rises
+monotonically there; the two ends of it were re-run against auto-SET, which is
+where the claim rests. 5000 paired deals / 10 000 games per cell:
+
+| level | trump remembered | seed 1 margin (95% CI) | seed 2 margin (95% CI) |
+| --- | --- | --- | --- |
+| easy | 2 of 12 | **+3.71** (+0.46 to +6.90) | **+4.07** (+0.96 to +7.26) |
+| expert | 10 of 12 | **+8.93** (+5.86 to +11.90) | **+7.93** (+5.06 to +10.83) |
+
+Both intervals exclude zero at both ends of the dial, and the effect is if
+anything slightly *larger* under auto-SET than it was without it (easy +3.29 and
+expert +8.69 on seed 1 of the older baseline). That direction makes sense: the
+contracts auto-SET removes are ones the bidding side could not have made however
+it played, so they were dead weight in the average rather than deals the rule was
+winning.
+
+The full pre-#178 ladder, kept because monotonicity across all five capacities is
+the shape of the claim and re-running ten cells to restate it would say nothing
+new — a historical reading on the older baseline, not a current one:
+
+| level | trump remembered | seed 1 margin (95% CI) | seed 2 margin (95% CI) |
+| --- | --- | --- | --- |
+| easy | 2 of 12 | +3.29 (+0.08 to +6.53) | +3.85 (+0.69 to +7.10) |
+| medium | 4 | +3.43 (+0.27 to +6.71) | +4.44 (+1.31 to +7.74) |
+| hard | 6 | +4.94 (+1.86 to +8.13) | +5.60 (+2.49 to +8.81) |
+| proficient | 8 | +7.76 (+4.77 to +10.80) | +6.76 (+3.78 to +9.83) |
+| expert | 10 | +8.69 (+5.73 to +11.63) | +7.64 (+4.80 to +10.63) |
+
+Make-rate moves with margin rather than against it on every post-rebase cell
+(expert, seed 1: 71.54% against the baseline's 71.26%), which is the check #126
+exists to force.
+
+The ladder is evidence by subtraction against a shared baseline, so it was also
+checked head-to-head, with `cli.ts capacity --high expert --low easy`: both sides
+run the counted rule and differ in **nothing but the level they sit on**, which is
+the only comparison that isolates recall itself. Re-run against auto-SET:
+
+| seed | expert vs easy, margin per deal | 95% CI | swept | p |
+| --- | --- | --- | --- | --- |
+| 1 | **+6.50** | +4.86 to +8.13 | 42–12 | 0.00005 |
+| 2 | **+6.08** | +4.33 to +7.91 | 46–16 | 0.0002 |
+
+(Pre-#178 the same runs read +5.96 and +5.91, so auto-SET did not wash the
+divergence out — it widened it slightly.)
+
+So expert and easy do diverge, by about six points a deal, entirely through what
+they can remember. That is the first time the skill dial has changed a *card*
+rather than a bid, which is what #157 was built for and what epic #152 set out to
+find.
+
+Size in context: roughly the same as #159's opening lead (+7.6 to +9.8), four to
+five times #155's forced-beat fix (+1.8), and still two orders of magnitude under
+the dial's own span (#153's +121). Cost on the bundle is +1.58 kB raw / +0.55 kB
+gzipped (259.05 kB to 260.63 kB, measured against the tree this branch
+rebased onto).
+
+Shipped **enabled on all five levels**, not as a difficulty notch. The rule is
+identical everywhere — #156's settlement that trick play is shared competence
+stands — and only the recall behind it differs, which is exactly #157's model.
+`'off'` survives as the A/B arm, like `'simple'` and `'never'`.
+
+`pinochle_engine.py` has no trump-memory model at all, so this is not a ported
+behaviour that has drifted; porting it is its own issue on the Python side, the
+way #164 followed #154.
+
+Unlike the throwaway arms #153–#159 built and deleted, `safe` and `capacity`
+stay in `cli.ts`: the second one is not a temporary rig but the only way to ask
+whether the skill dial is worth having, and epic #152 closes with that question
+answered rather than retired.
+
 ### Checking that a dial can see a change
 
 A self-test proves a dial reports nothing when nothing differs. It does not

--- a/web/src/ab/ab.test.ts
+++ b/web/src/ab/ab.test.ts
@@ -22,10 +22,12 @@ import {
   DISTILLED_LEVEL,
   FOLD_AB_POLICIES,
   PLAY_AB_POLICIES,
+  SAFE_COUNTER_CONTROL,
   STATIC_LEVEL,
   analyse,
   installPolicies,
   runAb,
+  safeCounterAbPolicies,
 } from './abRun'
 import { type SideStats, makeRng, newSideStats, playHeadlessGame } from './headlessGame'
 import { binomialTwoSidedP, bootstrapMeanCi, percentile, wilsonInterval } from './stats'
@@ -94,11 +96,53 @@ describe('the policy override', () => {
     // in code: two sides differing in two fields produce a number nothing can be
     // attributed to. Cheap to assert, and it is the assertion that keeps the
     // next map (#154 onward) honest as the union of policies grows.
-    for (const policies of [BID_AB_POLICIES, FOLD_AB_POLICIES, PLAY_AB_POLICIES]) {
+    const safeCounter = safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)
+    const maps = [BID_AB_POLICIES, FOLD_AB_POLICIES, AUTO_SET_AB_POLICIES, PLAY_AB_POLICIES, safeCounter]
+    for (const policies of maps) {
       const [a, b] = Object.values(policies)
       const differing = (Object.keys(a) as (keyof typeof a)[]).filter((field) => a[field] !== b[field])
       expect(differing).toHaveLength(1)
     }
+  })
+
+  it('measures the safe-counter rule against a baseline that is the same at every level (#158)', () => {
+    // #158's map is the one where the *levels* are not inert: capacity is
+    // `2 x skill` and is keyed on the level, not on `SkillParams`, so the level
+    // carrying the `'counted'` arm is the capacity under test. That only works
+    // as a comparison if the other arm is unaffected by its own level — and it
+    // is, because `'off'` never constructs or consults a `TrumpMemory`.
+    //
+    // Asserted structurally rather than by running games: whichever level the
+    // baseline sits on, its row is identical. So two runs at different
+    // capacities are measured against the same opponent and can be compared to
+    // each other, which is the whole design of #158's measurement.
+    const easyRun = safeCounterAbPolicies('easy', SAFE_COUNTER_CONTROL.easy)
+    const expertRun = safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)
+    expect(easyRun.easy.safeCounterPolicy).toBe('counted')
+    expect(expertRun.expert.safeCounterPolicy).toBe('counted')
+    expect(easyRun[SAFE_COUNTER_CONTROL.easy]).toEqual(expertRun[SAFE_COUNTER_CONTROL.expert])
+    expect(easyRun[SAFE_COUNTER_CONTROL.easy].safeCounterPolicy).toBe('off')
+  })
+
+  it('refuses to run the safe-counter arms on one level, where they would overwrite each other', () => {
+    expect(() => safeCounterAbPolicies('expert', 'expert')).toThrow()
+  })
+
+  it('ships #158 on at every level, and keeps the baseline reachable (#158)', () => {
+    // `'counted'` measured positive at all five capacities (+3.3 at `easy`
+    // through +8.7 at `expert` per deal; `web/README.md`), so it ships enabled
+    // everywhere rather than as a difficulty notch — the rule is identical at
+    // every level and only the recall behind it differs, which is #156's
+    // settlement and #157's model, not an exception to either.
+    //
+    // The `'off'` arm survives for the reason `'simple'` and `'never'` do: it is
+    // the baseline the number above is measured against, and nothing else
+    // selects it.
+    for (const params of Object.values(SKILL_PARAMS)) {
+      expect(params.safeCounterPolicy).toBe('counted')
+    }
+    const map = safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)
+    expect(map[SAFE_COUNTER_CONTROL.expert].safeCounterPolicy).toBe('off')
   })
 
   it('puts the two card-play rules at one table (#153)', () => {
@@ -276,6 +320,9 @@ describe('the A/B self-test', () => {
     // the most scope to desynchronise dealer rotation or scoring between the
     // two orientations of a pair — exactly what a zero paired margin rules out.
     ['auto-set', DISTILLED_LEVEL, AUTO_SET_AB_POLICIES],
+    // #158's two arms, both of which now play behind auto-SET.
+    ['counted', 'expert', safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)],
+    ['uncounted', SAFE_COUNTER_CONTROL.expert, safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)],
   ] as const) {
     it(`finds nothing when ${name} plays itself`, () => {
       const report = runAb({ nPairs: 6, seed: 5, levelA: level, levelB: level, policies })

--- a/web/src/ab/abRun.ts
+++ b/web/src/ab/abRun.ts
@@ -69,6 +69,7 @@ export const BID_AB_POLICIES: Record<string, SkillParams> = {
     foldPolicy: 'model',
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -76,6 +77,7 @@ export const BID_AB_POLICIES: Record<string, SkillParams> = {
     foldPolicy: 'model',
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
   },
 }
 
@@ -95,6 +97,7 @@ export const FOLD_AB_POLICIES: Record<string, SkillParams> = {
     foldPolicy: 'never',
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -102,6 +105,7 @@ export const FOLD_AB_POLICIES: Record<string, SkillParams> = {
     foldPolicy: 'model',
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
   },
 }
 
@@ -129,6 +133,7 @@ export const AUTO_SET_AB_POLICIES: Record<string, SkillParams> = {
     foldPolicy: 'model',
     playPolicy: 'cascade',
     autoSetPolicy: 'off',
+    safeCounterPolicy: 'counted',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -136,6 +141,7 @@ export const AUTO_SET_AB_POLICIES: Record<string, SkillParams> = {
     foldPolicy: 'model',
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
   },
 }
 
@@ -169,6 +175,7 @@ export const PLAY_AB_POLICIES: Record<string, SkillParams> = {
     foldPolicy: 'model',
     playPolicy: 'simple',
     autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -176,7 +183,108 @@ export const PLAY_AB_POLICIES: Record<string, SkillParams> = {
     foldPolicy: 'model',
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
   },
+}
+
+/**
+ * Safe-counter A/B (#158): identical bidders, identical folders, both running
+ * the cascade, differing only in whether a seat forced to take a trick works out
+ * which counter will actually hold.
+ *
+ * **This is the one A/B in the file where the *levels* matter and not just the
+ * rows.** Everywhere else `installPolicies` writes both arms explicitly and the
+ * level names are inert carriers. Here `TRUMP_MEMORY_CAPACITY` is keyed on the
+ * level itself (`2 x skill`, #157) and is not part of `SkillParams`, so the
+ * level chosen for the `'counted'` arm *is* the capacity being measured. That is
+ * the mechanism, not a leak: the same `'counted'` rule at `easy` and at `expert`
+ * is exactly the comparison #158 asks for.
+ *
+ * The `'off'` arm never touches a `TrumpMemory` — `chooseFollowCard` passes
+ * `undefined` down when the policy is off — so its level is inert and its
+ * behaviour is identical whichever level carries it. Which is what makes two
+ * runs at different capacities comparable: both are measured against the *same*
+ * baseline, on the same deals from the same seed, so the difference between the
+ * two margins is attributable to the capacity and to nothing else.
+ *
+ * Both arms run `autoSetPolicy: 'forced'` (#178), because that is what ships and
+ * because auto-SET decides *which deals reach trick play at all* — it ends
+ * roughly one contract in fourteen before the first lead. Measuring a card-play
+ * rule with it off would describe a population of hands the game no longer
+ * deals. #158's original table was taken before #178 merged and was re-run
+ * against it for exactly this reason; see `web/README.md`.
+ *
+ * @param countedLevel - Carries the arm under test; its capacity is what is
+ *   being measured. `easy` = 2 trump remembered, `expert` = 10.
+ * @param offLevel - Carries the baseline. Must differ from `countedLevel`.
+ */
+export function safeCounterAbPolicies(
+  countedLevel: SkillLevel,
+  offLevel: SkillLevel,
+): Record<string, SkillParams> {
+  if (countedLevel === offLevel) throw new Error('safe-counter A/B needs two distinct levels')
+  return {
+    [countedLevel]: {
+      handValuation: 'base_bid',
+      bidPolicy: 'distilled',
+      foldPolicy: 'model',
+      playPolicy: 'cascade',
+      autoSetPolicy: 'forced',
+      safeCounterPolicy: 'counted',
+    },
+    [offLevel]: {
+      handValuation: 'base_bid',
+      bidPolicy: 'distilled',
+      foldPolicy: 'model',
+      playPolicy: 'cascade',
+      autoSetPolicy: 'forced',
+      safeCounterPolicy: 'off',
+    },
+  }
+}
+
+/** The level the `'off'` baseline sits on for a given `'counted'` level. Any
+ *  level would do — the baseline ignores capacity — so these are picked only to
+ *  be distinct from the arm under test. */
+export const SAFE_COUNTER_CONTROL: Record<SkillLevel, SkillLevel> = {
+  easy: 'medium',
+  medium: 'easy',
+  hard: 'medium',
+  proficient: 'medium',
+  expert: 'proficient',
+}
+
+/**
+ * Two `'counted'` seats at one table, differing in **nothing but the level they
+ * sit on** — and therefore in nothing but how much trump each can remember
+ * (#157's `2 x skill`, #158's consumer).
+ *
+ * The only map in this file where zero fields differ between the arms, and that
+ * is the point rather than an oversight. Every other comparison here holds the
+ * level inert and varies a rule; this one holds the rule fixed and varies the
+ * level, which is the only way to ask the question epic #152 raised directly:
+ * does remembering more trump actually win games, or does the skill dial just
+ * describe itself? Running each capacity against the shared `'off'` baseline
+ * answers it by subtraction; this answers it head-to-head, at one table, with
+ * the mirroring cancelling the seat effect exactly as usual.
+ *
+ * Do not add this to the "exactly one field differs" invariant in `ab.test.ts`.
+ * It would fail it, correctly.
+ */
+export function safeCounterCapacityPolicies(
+  highLevel: SkillLevel,
+  lowLevel: SkillLevel,
+): Record<string, SkillParams> {
+  if (highLevel === lowLevel) throw new Error('capacity A/B needs two distinct levels')
+  const counted: SkillParams = {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+    autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
+  }
+  return { [highLevel]: counted, [lowLevel]: counted }
 }
 
 /** Overwrites the two entries in `policies`, returning a function that restores

--- a/web/src/ab/cli.ts
+++ b/web/src/ab/cli.ts
@@ -1,4 +1,4 @@
-// CLI entry point for the A/B measurements (#115, #123, #153, #178).
+// CLI entry point for the A/B measurements (#115, #123, #153, #158, #178).
 //
 // Run through jiti, which is already a dependency (Tailwind pulls it in) and
 // executes TypeScript directly, so this needs no build step and no new package:
@@ -7,6 +7,8 @@
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts fold --pairs 400
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts play --pairs 400
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts autoset --pairs 5000
+//   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts safe --pairs 400 --level expert
+//   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts capacity --high expert --low easy
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts selftest --pairs 100
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts latency --positions 4000
 //
@@ -17,7 +19,8 @@
 //
 // `--policy` names which arm the self-test doubles up, and so also which dial
 // it exercises: `static`/`distilled` are the bidding pair, `simple`/`cascade`
-// the trick-play pair, `auto-set` the #178 one. Worth having each separately —
+// the trick-play pair, `auto-set` the #178 one, `counted`/`uncounted` the #158
+// one. Worth having each separately —
 // a self-test that never runs a policy cannot vouch for it, and the paths
 // differ in what could go wrong (the evaluator is the one that could be
 // non-deterministic; card play is the one reached tens of times per round
@@ -37,12 +40,17 @@ import {
   DISTILLED_LEVEL,
   FOLD_AB_POLICIES,
   PLAY_AB_POLICIES,
+  SAFE_COUNTER_CONTROL,
   STATIC_LEVEL,
   analyse,
   runAb,
+  safeCounterAbPolicies,
+  safeCounterCapacityPolicies,
   summarise,
 } from './abRun'
 import { formatLatency, runLatencyBenchmark } from './latency'
+
+const SKILL_LEVELS: readonly SkillLevel[] = ['easy', 'medium', 'hard', 'proficient', 'expert']
 
 /** Which level carries each named arm, and which override map has to be
  *  installed for that arm to exist at all. */
@@ -52,6 +60,15 @@ const SELFTEST_ARMS: Record<string, { level: SkillLevel; policies: Record<string
   simple: { level: STATIC_LEVEL, policies: PLAY_AB_POLICIES },
   cascade: { level: DISTILLED_LEVEL, policies: PLAY_AB_POLICIES },
   'auto-set': { level: DISTILLED_LEVEL, policies: AUTO_SET_AB_POLICIES },
+  // #158's two arms. `counted` doubles up the expert capacity against itself;
+  // `uncounted` doubles up the baseline, which is the control that says the
+  // safe-counter change is the only thing separating the two sides of a `safe`
+  // run rather than the level names being read somewhere unexpected.
+  counted: { level: 'expert', policies: safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert) },
+  uncounted: {
+    level: SAFE_COUNTER_CONTROL.expert,
+    policies: safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert),
+  },
 }
 
 const argv = (globalThis as { process?: { argv: string[] } }).process?.argv ?? []
@@ -103,6 +120,58 @@ if (command === 'fold') {
     policies: PLAY_AB_POLICIES,
   })
   console.log(summarise(report, analyse(report, seed)))
+} else if (command === 'safe') {
+  // #158's measurement: identical bidders, folders and cascades, one side
+  // picking the counter that cannot be beaten and the other spending the
+  // cheapest one. `--level` names the level the counted arm sits on, and so the
+  // trump-memory capacity it gets (2 x skill) — the whole point is to run it at
+  // more than one and see whether they separate. The baseline never consults a
+  // memory, so it is the same opponent at every level.
+  const pairs = flag('pairs', 400)
+  const seed = flag('seed', 1)
+  const levelArg = args.includes('--level') ? args[args.indexOf('--level') + 1] : 'expert'
+  const level = SKILL_LEVELS.find((l) => l === levelArg)
+  if (level === undefined) {
+    console.log(`unknown --level '${levelArg}'; expected one of ${SKILL_LEVELS.join(', ')}`)
+  } else {
+    const control = SAFE_COUNTER_CONTROL[level]
+    const report = runAb({
+      nPairs: pairs,
+      seed,
+      labelA: `counted@${level}`,
+      labelB: 'uncounted',
+      levelA: level,
+      levelB: control,
+      policies: safeCounterAbPolicies(level, control),
+    })
+    console.log(summarise(report, analyse(report, seed)))
+  }
+} else if (command === 'capacity') {
+  // #158's other measurement, and the direct one: both sides run the counted
+  // rule, and the only thing separating them is how much trump each remembers.
+  // `--high` and `--low` name the two levels; capacity is `2 x skill`.
+  const pairs = flag('pairs', 400)
+  const seed = flag('seed', 1)
+  const pick = (name: string, fallback: SkillLevel) => {
+    const raw = args.includes(`--${name}`) ? args[args.indexOf(`--${name}`) + 1] : fallback
+    return SKILL_LEVELS.find((l) => l === raw)
+  }
+  const high = pick('high', 'expert')
+  const low = pick('low', 'easy')
+  if (high === undefined || low === undefined || high === low) {
+    console.log(`--high/--low must be two distinct levels from ${SKILL_LEVELS.join(', ')}`)
+  } else {
+    const report = runAb({
+      nPairs: pairs,
+      seed,
+      labelA: `counted@${high}`,
+      labelB: `counted@${low}`,
+      levelA: high,
+      levelB: low,
+      policies: safeCounterCapacityPolicies(high, low),
+    })
+    console.log(summarise(report, analyse(report, seed)))
+  }
 } else if (command === 'ab' || command === 'selftest') {
   const pairs = flag('pairs', command === 'selftest' ? 100 : 400)
   const seed = flag('seed', 1)
@@ -131,7 +200,8 @@ if (command === 'fold') {
   console.log(formatLatency(runLatencyBenchmark(positions, repeats)))
 } else {
   console.log(
-    'usage: cli.ts [ab|fold|play|autoset|selftest|latency] [--pairs N] [--seed N] ' +
-      `[--policy ${Object.keys(SELFTEST_ARMS).join('|')}] [--positions N] [--repeats N]`,
+    'usage: cli.ts [ab|fold|play|autoset|safe|capacity|selftest|latency] [--pairs N] [--seed N] ' +
+      `[--policy ${Object.keys(SELFTEST_ARMS).join('|')}] [--level ${SKILL_LEVELS.join('|')}] ` +
+      '[--high LEVEL] [--low LEVEL] [--positions N] [--repeats N]',
   )
 }

--- a/web/src/ab/headlessGame.ts
+++ b/web/src/ab/headlessGame.ts
@@ -38,6 +38,7 @@ import { PASS_COUNT, choosePassCards } from '../engine/passing'
 import { type Hands, isAutoSet, playTrickTakingPhase, scoreRound, teamOf, type TeamId } from '../engine/round'
 import { SKILL_PARAMS } from '../engine/skills'
 import { PlayTracker, chooseFollowCard, chooseLeadCard } from '../engine/tracker'
+import { newTrumpMemories } from '../engine/trumpMemory'
 import type { PlayerIndex } from '../engine/trick'
 import type { SkillLevel } from '../persistence/options'
 
@@ -292,6 +293,12 @@ export function playHeadlessGame(options: HeadlessGameOptions): GameResult {
 
     // -- Trick play, round score --------------------------------------------
     const tracker = new PlayTracker()
+    // One capacity-limited trump view per seat (#157/#158), seeded from the
+    // meld the other three seats have just laid face up. Built here rather than
+    // inside `playTrickTakingPhase` because it is strategy input, like
+    // `tracker`, not a rule — and built from `state.hands` because that is the
+    // post-pass, post-meld hand the melds were scored from.
+    const trumpMemories = newTrumpMemories(state.hands, trumpSuit, (seat) => seatSkills[seat])
     let cardsPlayed = 0
     const { trickPointsByTeam } = playTrickTakingPhase(
       state.hands,
@@ -305,9 +312,30 @@ export function playHeadlessGame(options: HeadlessGameOptions): GameResult {
         const isBidderFirstLead = cardsPlayed === 0 && player === bidWinner
         const card =
           trick.plays.length === 0
-            ? chooseLeadCard(hand, trumpSuit, tracker, isBidderFirstLead, skill, teamOf(player) === teamOf(bidWinner))
-            : chooseFollowCard(hand, legal, trick.plays, trumpSuit, teammatesOf(player), tracker, skill)
+            ? chooseLeadCard(
+                hand,
+                trumpSuit,
+                tracker,
+                isBidderFirstLead,
+                skill,
+                teamOf(player) === teamOf(bidWinner),
+                trumpMemories[player],
+              )
+            : chooseFollowCard(
+                hand,
+                legal,
+                trick.plays,
+                trumpSuit,
+                teammatesOf(player),
+                tracker,
+                skill,
+                trumpMemories[player],
+              )
         tracker.record(card)
+        // Everyone at the table sees the card, including whoever played it —
+        // it has left their hand by then, so this cannot double-count against
+        // the hand tally `isBoss` keeps separately.
+        for (const seat of SEATS) trumpMemories[seat].see(card)
         cardsPlayed++
         return card
       },

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -4,6 +4,7 @@ import { shouldConcede } from '../engine/evaluator'
 import { isAutoSet, partnerOf, teamOf, type Hands, type TeamId } from '../engine/round'
 import { SKILL_PARAMS } from '../engine/skills'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from '../engine/tracker'
+import { newTrumpMemories } from '../engine/trumpMemory'
 import type { PlayerIndex } from '../engine/trick'
 import type { SkillLevel } from '../persistence/options'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
@@ -129,6 +130,19 @@ export function TrickPlayFlow({
   // rather than derived from reducer state, since it's an append-only
   // strategy input the AI reads, not something any render needs back.
   const trackerRef = useRef(new PlayTracker())
+  // Per-seat capacity-limited trump memory (#157), consumed by the safe-counter
+  // rule in `chooseForcedBeat` (#158). Built once, from the hands as dealt into
+  // trick play, so each seat starts holding what it could see of the other three
+  // melds. Same lifetime and same reasoning as `trackerRef`: append-only
+  // strategy input, never rendered.
+  //
+  // On a #54 resume the memories start empty of everything already played, which
+  // makes every seat *more* cautious than it would have been — the safe
+  // direction, since an under-count can only ever read as "this card can still
+  // be beaten" and never the other way round.
+  const trumpMemoriesRef = useRef(
+    newTrumpMemories(hands, trumpSuit, (seat) => skillForPlayer(seat, humanPlayer, options)),
+  )
   const completedRef = useRef(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   // Set when the auto-SET rule (#178) fires, cleared when the player
@@ -137,6 +151,14 @@ export function TrickPlayFlow({
   // (below) waits for this to clear before handing off, so the round summary
   // cannot appear before the explanation of why no cards were played.
   const [autoSetFired, setAutoSetFired] = useState(false)
+
+  // A card hits the table once and everyone sees it — the exact tracker and all
+  // four trump memories, the human's card included. Stable (`[]`), because it
+  // reaches only through refs and is handed to a `useMemo`'d table state.
+  const notePlayed = useCallback((card: Card) => {
+    trackerRef.current.record(card)
+    for (const seat of [0, 1, 2, 3] as PlayerIndex[]) trumpMemoriesRef.current[seat].see(card)
+  }, [])
 
   // Concede/fold for an AI bid winner (#123), in the same window the human's
   // fold button gets: after meld, before the first card of the round.
@@ -211,13 +233,30 @@ export function TrickPlayFlow({
       const isBiddingTeam = teamOf(player) === teamOf(state.bidWinner)
       const card =
         state.currentTrick.length === 0
-          ? chooseLeadCard(hand, state.trumpSuit, trackerRef.current, isBidderFirstLead, skill, isBiddingTeam)
-          : chooseFollowCard(hand, legal, state.currentTrick, state.trumpSuit, teammatesOf(player), trackerRef.current, skill)
-      trackerRef.current.record(card)
+          ? chooseLeadCard(
+              hand,
+              state.trumpSuit,
+              trackerRef.current,
+              isBidderFirstLead,
+              skill,
+              isBiddingTeam,
+              trumpMemoriesRef.current[player],
+            )
+          : chooseFollowCard(
+              hand,
+              legal,
+              state.currentTrick,
+              state.trumpSuit,
+              teammatesOf(player),
+              trackerRef.current,
+              skill,
+              trumpMemoriesRef.current[player],
+            )
+      notePlayed(card)
       dispatch({ type: 'PLAY_CARD', player, card })
     }, AI_PLAY_DELAY_MS)
     return () => clearTimeout(timer)
-  }, [state, humanPlayer])
+  }, [state, humanPlayer, notePlayed])
 
   // Once a trick completes, pause so the human can see all 4 cards and the
   // winner highlight before it's cleared for the next trick.
@@ -286,7 +325,7 @@ export function TrickPlayFlow({
       ? {
           legalCards: legalMovesForHuman,
           onPlay: (card: Card) => {
-            trackerRef.current.record(card)
+            notePlayed(card)
             dispatch({ type: 'PLAY_CARD', player: humanPlayer, card })
           },
         }
@@ -306,7 +345,7 @@ export function TrickPlayFlow({
       meldPoints: meldPointsByTeam[teamOf(state.bidWinner)],
       trickWinner: state.phase === 'trick-complete' ? (state.trickWinners.at(-1) ?? null) : null,
     }
-  }, [state, seatNames, humanPlayer, bid, scoresByTeam, teamNames, meldPointsByTeam, legalMovesForHuman])
+  }, [state, seatNames, humanPlayer, bid, scoresByTeam, teamNames, meldPointsByTeam, legalMovesForHuman, notePlayed])
 
   const handleConcede = useCallback(() => {
     dispatch({ type: 'CONCEDE' })

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -110,12 +110,39 @@ export type PlayPolicy = 'simple' | 'cascade'
  */
 export type AutoSetPolicy = 'forced' | 'off'
 
+/**
+ * Whether a seat forced to take a trick works out which counter is *safe* to
+ * take it with, or just spends the cheapest one (#158).
+ *
+ *   `'off'`      the state after #155: a forced beat goes to a non-counter if
+ *                one is legal, otherwise to the lowest counter, whatever is
+ *                still outstanding. Trump safety, where `chooseLeadCard` asks
+ *                it, is read from `PlayTracker`'s exact count.
+ *   `'counted'`  the lowest counter that **cannot itself be beaten in suit** —
+ *                every higher card of that suit already seen or held — falling
+ *                back to the lowest counter when nothing qualifies. Side-suit
+ *                safety comes from `PlayTracker` and is exact at every level;
+ *                trump safety comes from #157's `TrumpMemory`, whose capacity
+ *                is `2 x skill level`, so it is the one thing in trick play a
+ *                weak seat is genuinely worse at.
+ *
+ * This is the only field whose *effect* varies with the skill level rather than
+ * with the row: `'counted'` is the same rule everywhere, but at `easy` it is
+ * answered from 2 remembered trump and at `expert` from 10. That is deliberate
+ * and it is #157's whole point — same reasoning, worse recall — so it does not
+ * contradict #156's "identical rules at every level". A seat that cannot
+ * remember does not play a different rule, it plays the same rule
+ * conservatively, and conservative here means "assume the card can be beaten".
+ */
+export type SafeCounterPolicy = 'off' | 'counted'
+
 export interface SkillParams {
   readonly handValuation: HandValuation
   readonly bidPolicy: BidPolicy
   readonly foldPolicy: FoldPolicy
   readonly playPolicy: PlayPolicy
   readonly autoSetPolicy: AutoSetPolicy
+  readonly safeCounterPolicy: SafeCounterPolicy
 }
 
 /**
@@ -216,13 +243,57 @@ export interface SkillParams {
  * `autoSetPolicy` (#178) reads `'forced'` on every row for a stronger reason
  * than either of those: it is not a policy at all in a real game, it is a rule
  * of arithmetic that the human bid winner gets too. See `AutoSetPolicy`.
+ *
+ * `safeCounterPolicy` (#158) reads `'counted'` on every row, and is the one
+ * column where a uniform value still produces different play at different
+ * levels — the rule is identical everywhere and only the trump recall behind it
+ * scales (#157's `2 x skill level`). So it does not reopen #156: nobody plays a
+ * worse rule, a weak seat just answers the same question off less information.
+ * It ships enabled because it measured positive at every capacity; the rows
+ * grew a line each here rather than staying on one, because five fields no
+ * longer fit one readable line. See `SafeCounterPolicy` and `web/README.md`.
  */
 export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
-  easy: { handValuation: 'meld_only', bidPolicy: 'static', foldPolicy: 'model', playPolicy: 'cascade', autoSetPolicy: 'forced' },
-  medium: { handValuation: 'base_bid', bidPolicy: 'static', foldPolicy: 'model', playPolicy: 'cascade', autoSetPolicy: 'forced' },
-  hard: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model', playPolicy: 'cascade', autoSetPolicy: 'forced' },
-  proficient: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model', playPolicy: 'cascade', autoSetPolicy: 'forced' },
-  expert: { handValuation: 'base_bid', bidPolicy: 'distilled', foldPolicy: 'model', playPolicy: 'cascade', autoSetPolicy: 'forced' },
+  easy: {
+    handValuation: 'meld_only',
+    bidPolicy: 'static',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+    autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
+  },
+  medium: {
+    handValuation: 'base_bid',
+    bidPolicy: 'static',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+    autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
+  },
+  hard: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+    autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
+  },
+  proficient: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+    autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
+  },
+  expert: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+    autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
+  },
 }
 
 /** Flat trick-point estimate for meld-only bidding (skill 1), matching

--- a/web/src/engine/tracker.test.ts
+++ b/web/src/engine/tracker.test.ts
@@ -4,6 +4,7 @@ import { Card, Suit } from './card'
 import { SKILL_PARAMS } from './skills'
 import { Trick, type TrickPlay } from './trick'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from './tracker'
+import { TrumpMemory } from './trumpMemory'
 
 /**
  * Runs `play` with one level temporarily moved onto `'simple'` card play,
@@ -30,6 +31,39 @@ function withSimplePlay<T>(play: (skill: SkillLevel) => T): T {
   } finally {
     SKILL_PARAMS[level] = saved
   }
+}
+
+/**
+ * Runs `play` with one level temporarily switched **back** onto
+ * `safeCounterPolicy: 'off'` — the state #155 left the forced-beat tier in,
+ * before #158 taught it which counter would actually hold.
+ *
+ * The inverse of `withSimplePlay`, and for the inverse reason: `'counted'` ships
+ * on every row (#158 measured positive at all five capacities), so it is
+ * `'off'` that is now reachable only through an override. It stays live as
+ * `SAFE_COUNTER_AB_POLICIES`' baseline arm, and the tests using this pin what
+ * that baseline still does, so the A/B has a ruler that the suite vouches for.
+ *
+ * Note that the level is fixed at `hard` here while `withSafeCounter`'s
+ * replacement below takes it as an argument — the `'off'` arm ignores the
+ * capacity entirely, so one level is as good as another for it.
+ */
+function withSafeCounterOff<T>(play: (skill: SkillLevel) => T): T {
+  const level: SkillLevel = 'hard'
+  const saved = SKILL_PARAMS[level]
+  SKILL_PARAMS[level] = { ...saved, safeCounterPolicy: 'off' }
+  try {
+    return play(level)
+  } finally {
+    SKILL_PARAMS[level] = saved
+  }
+}
+
+/** A trump memory that has watched `seen` go by, in that order. */
+function memoryOf(level: SkillLevel, trump: Suit, seen: readonly Card[]): TrumpMemory {
+  const memory = new TrumpMemory(trump, level)
+  memory.seeAll(seen)
+  return memory
 }
 
 describe('PlayTracker', () => {
@@ -302,6 +336,46 @@ describe('chooseLeadCard', () => {
     expect(led.rank).toBe('10')
   })
 
+  // -- Leading a counter that is provably boss (#158) -------------------------
+
+  it('counted: an expert cashes a trump 10 it knows is boss, on an all-trump hand', () => {
+    // The leading half of #158 — "a counter that is provably boss is safe to
+    // lead; one that is not, is not." Both trump Aces have gone past this seat,
+    // so the 10 is the highest trump left and tier 3 of the cascade leads it.
+    //
+    // Trump reaches the cascade only on an all-trump hand: `offenseTrumpLead`
+    // and `defenderLead` both strip trump out first whenever the hand holds
+    // anything else, which is why this position looks contrived. It is the one
+    // that exists.
+    const trump = Suit.Spades
+    const hand = [new Card(trump, '10', 1), new Card(trump, 'K', 1), new Card(trump, '9', 1)]
+    const seen = [
+      new Card(trump, 'A', 1),
+      new Card(trump, 'A', 2),
+      new Card(trump, '9', 2), // two later sightings, to crowd an `easy` memory
+      new Card(trump, 'J', 1),
+    ]
+    const led = chooseLeadCard(hand, trump, new PlayTracker(), false, 'expert', true, memoryOf('expert', trump, seen))
+    expect(led.rank).toBe('10')
+  })
+
+  it('counted: an easy seat cannot recall the Aces and leads junk instead', () => {
+    // Same hand, same cards gone by, capacity 2. It does not know the 10 is
+    // boss, so no card qualifies as safe, and the cascade drops through to the
+    // junk tier and surrenders the 9. Ten points left in hand that an expert
+    // would have banked — the cost of not counting, made visible.
+    const trump = Suit.Spades
+    const hand = [new Card(trump, '10', 1), new Card(trump, 'K', 1), new Card(trump, '9', 1)]
+    const seen = [
+      new Card(trump, 'A', 1),
+      new Card(trump, 'A', 2),
+      new Card(trump, '9', 2),
+      new Card(trump, 'J', 1),
+    ]
+    const led = chooseLeadCard(hand, trump, new PlayTracker(), false, 'easy', true, memoryOf('easy', trump, seen))
+    expect(led.rank).toBe('9')
+  })
+
   it('changes nothing after the opening trick — the bidding side still cashes a trump Ace', () => {
     // #159's other half, "hold trump back", was measured and did not ship: over
     // 5000 paired deals, suppressing this tier costs 13.6 points a deal. The
@@ -325,15 +399,28 @@ describe('chooseFollowCard', () => {
     expect(played).toBe(onlyCard)
   })
 
-  it('forced beat: every legal card already beats the winner - plays the lowest one that still wins', () => {
-    // Opponent (player 1) is winning with a weak 9 of the lead suit; both
-    // legal cards outrank it, so this is a forced beat regardless of who's
-    // winning - the cheapest winner is played to save bigger cards.
+  it('forced beat: takes with the cheapest card that will still be standing at the end of the trick', () => {
+    // Opponent (player 1) is winning with a weak 9 of the lead suit; both legal
+    // cards outrank it, so this is a forced beat regardless of who is winning.
+    //
+    // This asserted the 10 until #158. "The lowest one that still wins" is only
+    // the right reading if nothing behind can take it back, and here the second
+    // Ace of Hearts is unaccounted for with two seats still to play — so the 10
+    // does not win, it loses 20 points to whoever holds that Ace. The Ace is the
+    // cheapest card in this legal set that cannot be beaten in suit, and the
+    // rule is now stated in those terms.
     const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, '9', 1) }]
     const legalMoves = [new Card(Suit.Hearts, '10', 1), new Card(Suit.Hearts, 'A', 1)]
     const hand = legalMoves
     const played = chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2])
-    expect(played.rank).toBe('10')
+    expect(played.rank).toBe('A')
+
+    // ...and with the other Ace gone, the 10 *is* the boss card and the Ace
+    // stays in hand. Same rule, different information — which is the whole
+    // difference between this and the assertion it replaces.
+    const tracker = new PlayTracker()
+    tracker.record(new Card(Suit.Hearts, 'A', 2))
+    expect(chooseFollowCard(hand, legalMoves, trickPlays, Suit.Spades, [0, 2], tracker).rank).toBe('10')
   })
 
   // -- Forced-beat selection (#155) -----------------------------------------
@@ -352,17 +439,21 @@ describe('chooseFollowCard', () => {
     expect(played.rank).toBe('Q')
   })
 
-  it('forced beat with only counters legal: spends the cheapest one (King before 10 before Ace)', () => {
-    // Step 3. There is no free beat available, so a counter has to go in; the
-    // King is the one to spend, for #154's reason — every counter pays the same
-    // 10, and the 10 it keeps loses to nothing but an Ace.
+  it("the 'off' arm still spends the cheapest counter, whatever is outstanding", () => {
+    // #155's step 3, pinned on the baseline arm rather than on the shipped dial.
+    // No free beat is available, so a counter has to go in, and this arm spends
+    // the King without asking whether it will hold — which is exactly the
+    // behaviour #158 measured against and beat, so it has to stay reachable and
+    // has to stay asserted.
     const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'Q', 1) }]
     const legalMoves = [
       new Card(Suit.Hearts, '10', 1),
       new Card(Suit.Hearts, 'A', 1),
       new Card(Suit.Hearts, 'K', 1),
     ]
-    const played = chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2])
+    const played = withSafeCounterOff((skill) =>
+      chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2], new PlayTracker(), skill),
+    )
     expect(played.rank).toBe('K')
   })
 
@@ -552,6 +643,161 @@ describe('chooseFollowCard', () => {
       chooseFollowCard(legalMoves, legalMoves, trickPlays, Suit.Spades, [0, 2], undefined, skill),
     )
     expect(played.rank).toBe('9')
+  })
+
+  // -- "Cannot be beaten" (#158) --------------------------------------------
+
+  it('the two arms answer one position differently, which is what makes the A/B a comparison', () => {
+    // The dial-is-read check, before any A/B number is believed. One position,
+    // forced to beat, only counters legal, the King beatable by an unseen 10 or
+    // Ace with two seats still to come. The shipped `'counted'` rule takes with
+    // the Ace because it is the only card here that cannot be beaten in suit;
+    // the `'off'` baseline spends the King and hopes.
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const hand = [new Card(Suit.Hearts, 'K', 1), new Card(Suit.Hearts, '10', 1), new Card(Suit.Hearts, 'A', 1)]
+    const counted = chooseFollowCard(hand, hand, trickPlays, Suit.Spades, [0, 2], new PlayTracker())
+    const off = withSafeCounterOff((skill) =>
+      chooseFollowCard(hand, hand, trickPlays, Suit.Spades, [0, 2], new PlayTracker(), skill),
+    )
+    expect(counted.rank).toBe('A')
+    expect(off.rank).toBe('K')
+  })
+
+  it('counted: takes with the cheapest counter that cannot be beaten in suit', () => {
+    // #158's rule, in a side suit, where `PlayTracker` is exact at every level.
+    // The King is boss here: this hand holds one copy of the 10 and one of the
+    // Ace, and the other copy of each has been played, so nothing outstanding in
+    // Hearts can take the trick off it. Spend the King and keep the Ace.
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const hand = [new Card(Suit.Hearts, 'K', 1), new Card(Suit.Hearts, '10', 1), new Card(Suit.Hearts, 'A', 1)]
+    const tracker = new PlayTracker()
+    tracker.record(new Card(Suit.Hearts, '10', 2))
+    tracker.record(new Card(Suit.Hearts, 'A', 2))
+    const played = chooseFollowCard(hand, hand, trickPlays, Suit.Spades, [0, 2], tracker, 'hard')
+    expect(played.rank).toBe('K')
+  })
+
+  it('counted: an unknown resolves to "beatable", so the boss card goes in instead', () => {
+    // The same position with nothing played. The King *might* hold and the 10
+    // *might* hold, and #158 is explicit that a seat must not play the best case
+    // — spending a King into a trick an opponent's Ace then takes gives away 20
+    // points rather than 10. The Ace is the only card here that cannot lose in
+    // suit, so it is the one that takes the trick.
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const hand = [new Card(Suit.Hearts, 'K', 1), new Card(Suit.Hearts, '10', 1), new Card(Suit.Hearts, 'A', 1)]
+    const played = chooseFollowCard(hand, hand, trickPlays, Suit.Spades, [0, 2], new PlayTracker(), 'hard')
+    expect(played.rank).toBe('A')
+  })
+
+  it('counted: last to the trick, nothing is outstanding, so the cheapest counter wins it', () => {
+    // Three cards already down means no seat is left to beat anything, and
+    // "cannot be beaten by anything still outstanding" is trivially true of
+    // every card. The King takes it and the Ace stays in hand — the same card
+    // the `'off'` arm plays, which is why switching #158 on cannot cost the
+    // fourth seat anything.
+    const trickPlays: TrickPlay[] = [
+      { player: 1, card: new Card(Suit.Hearts, 'Q', 1) },
+      { player: 2, card: new Card(Suit.Hearts, '9', 1) },
+      { player: 3, card: new Card(Suit.Hearts, 'J', 1) },
+    ]
+    const hand = [new Card(Suit.Hearts, 'K', 1), new Card(Suit.Hearts, '10', 1), new Card(Suit.Hearts, 'A', 1)]
+    const played = chooseFollowCard(hand, hand, trickPlays, Suit.Spades, [0, 2], new PlayTracker(), 'hard')
+    expect(played.rank).toBe('K')
+  })
+
+  it('counted: a free beat still outranks the whole question', () => {
+    // Tier 1 is untouched — if a non-counter takes the trick, no counter needs
+    // to be evaluated at all. #158 only ever fires where #155 left a gap.
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'J', 1) }]
+    const hand = [new Card(Suit.Hearts, 'Q', 1), new Card(Suit.Hearts, 'K', 1), new Card(Suit.Hearts, 'A', 1)]
+    const played = chooseFollowCard(hand, hand, trickPlays, Suit.Spades, [0, 2], new PlayTracker(), 'hard')
+    expect(played.rank).toBe('Q')
+  })
+
+  it('counted: with no boss counter and no Ace, it falls back to the cheapest', () => {
+    // Tier 3. The King and the 10 can both be beaten by an unaccounted Ace, and
+    // there is no Ace in hand to take with, so there is nothing safe to pick and
+    // the rule degrades to #155's answer rather than inventing a preference.
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, 'Q', 1) }]
+    const hand = [new Card(Suit.Hearts, 'K', 1), new Card(Suit.Hearts, '10', 1)]
+    const played = chooseFollowCard(hand, hand, trickPlays, Suit.Spades, [0, 2], new PlayTracker(), 'hard')
+    expect(played.rank).toBe('K')
+  })
+
+  it('counted: forced to overtrump, expert remembers both Aces are gone and the King is boss', () => {
+    // The issue's own worked example, and the only place the skill dial decides
+    // a card. Trump was led with the Queen, so `Trick.legalMoves` restricts this
+    // seat to beaters and every one of them is a counter. Both trump 10s and
+    // both trump Aces are accounted for — one of each in hand, the other of each
+    // seen — so the King cannot be beaten in trump and is what takes the trick.
+    const trump = Suit.Spades
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(trump, 'Q', 1) }]
+    const hand = [new Card(trump, 'K', 1), new Card(trump, '10', 1), new Card(trump, 'A', 1)]
+    const seen = [
+      new Card(trump, '10', 2),
+      new Card(trump, 'A', 2),
+      new Card(trump, '9', 1), // two later sightings, to crowd an `easy` memory
+      new Card(trump, 'J', 1),
+    ]
+    const played = chooseFollowCard(hand, hand, trickPlays, trump, [0, 2], new PlayTracker(), 'expert', memoryOf('expert', trump, seen))
+    expect(played.rank).toBe('K')
+  })
+
+  it('counted: the same position at easy, which has forgotten, plays the Ace instead', () => {
+    // Identical cards, identical rule, capacity 2 instead of 10. The two Aces
+    // and the second 10 went past four sightings ago and are gone, so as far as
+    // this seat knows the King and the 10 can both still be beaten — and #158
+    // says an unknown is played as beatable. It takes the trick with the card it
+    // is sure of and gives up the Ace to do it.
+    //
+    // This assertion is the skill dial during trick play. If it ever stops
+    // differing from the expert case above, the capacity model has stopped
+    // reaching a decision and #157 is inert again.
+    const trump = Suit.Spades
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(trump, 'Q', 1) }]
+    const hand = [new Card(trump, 'K', 1), new Card(trump, '10', 1), new Card(trump, 'A', 1)]
+    const seen = [
+      new Card(trump, '10', 2),
+      new Card(trump, 'A', 2),
+      new Card(trump, '9', 1),
+      new Card(trump, 'J', 1),
+    ]
+    const played = chooseFollowCard(hand, hand, trickPlays, trump, [0, 2], new PlayTracker(), 'easy', memoryOf('easy', trump, seen))
+    expect(played.rank).toBe('A')
+  })
+
+  it('counted: an exact tracker does not stand in for a forgotten trump', () => {
+    // The trap this would have fallen into. `PlayTracker` is handed the same
+    // four cards the memory saw and still counts them all, because #157 left it
+    // counting perfectly on purpose. If trump safety read the tracker rather
+    // than the memory, `easy` would answer this exactly like `expert` and the
+    // capacity model would be decorative. It plays the Ace, so it does not.
+    const trump = Suit.Spades
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(trump, 'Q', 1) }]
+    const hand = [new Card(trump, 'K', 1), new Card(trump, '10', 1), new Card(trump, 'A', 1)]
+    const seen = [
+      new Card(trump, '10', 2),
+      new Card(trump, 'A', 2),
+      new Card(trump, '9', 1),
+      new Card(trump, 'J', 1),
+    ]
+    const tracker = new PlayTracker()
+    for (const card of seen) tracker.record(card)
+    const played = chooseFollowCard(hand, hand, trickPlays, trump, [0, 2], tracker, 'easy', memoryOf('easy', trump, seen))
+    expect(played.rank).toBe('A')
+  })
+
+  it('counted: a plain ruff is not a forced overtrump and keeps its own tier', () => {
+    // Void in Hearts with no trump yet on the table. Every trump in hand beats
+    // the Heart winner, but the rules restricted nothing — the seat chose to
+    // ruff — so this is not the position #158 is about, and the existing
+    // "surrender the lowest point trump" tier still answers it. Pinned because
+    // the `Card.beats` test alone would have swallowed this case.
+    const trump = Suit.Spades
+    const trickPlays: TrickPlay[] = [{ player: 1, card: new Card(Suit.Hearts, '9', 1) }]
+    const hand = [new Card(trump, 'J', 1), new Card(trump, 'K', 1)]
+    const played = chooseFollowCard(hand, hand, trickPlays, trump, [0, 2], new PlayTracker(), 'expert', new TrumpMemory(trump, 'expert'))
+    expect(played.rank).toBe('K')
   })
 
   it('every level follows with the cascade, easy included (#156)', () => {

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -6,11 +6,19 @@
 // lead-card strategy and the follow-card strategy here consume the same
 // tracker instance. Its public shape is kept deliberately small -
 // `record` / `playedCount` are all either strategy currently needs.
+//
+// Since #158 there is a second, weaker source of the same kind of fact:
+// `TrumpMemory` (trumpMemory.ts), one per *seat* rather than one per round,
+// capacity-limited to `2 x skill level` trump. `seenCount` below routes each
+// question to whichever of the two owns it — the exact tracker for side suits,
+// the seat's memory for trump — and that split is the only thing in this file
+// that behaves differently at different skill levels.
 
 import type { SkillLevel } from '../persistence/options'
 import { type Card, RANK_VALUE, RANKS, type Rank, type Suit } from './card'
 import type { PlayerIndex, TrickPlay } from './trick'
 import { SKILL_PARAMS } from './skills'
+import type { TrumpMemory } from './trumpMemory'
 
 const POINT_RANKS = new Set(['A', '10', 'K'])
 /** 6 ranks x 2 copies, matching Python's `TOTAL_TRUMP_COPIES`. `chooseFollowCard`
@@ -44,17 +52,66 @@ function suitLength(hand: readonly Card[], suit: Suit): number {
 }
 
 /**
- * A card is safe to lead once every higher-ranked card in its suit is
- * accounted for - either already played, or still in your own hand (a
- * card you hold yourself can't beat you).
+ * What one seat believes it has seen of a given card (#158) — the input to
+ * every "can this still be beaten" question below.
+ *
+ *   **Side suits** come from `PlayTracker`, which counts perfectly and is not
+ *   capacity-limited (#157 scoped the cap to trump), so side-suit safety is
+ *   exact at every skill level.
+ *
+ *   **Trump** comes from the seat's `TrumpMemory` when it has one: capacity
+ *   `2 x skill level`, most-recent-wins. `undefined` means either the caller
+ *   supplied no memory or `safeCounterPolicy` is `'off'`, and then this falls
+ *   back to the exact count — the pre-#158 reading, and what the `'off'` A/B
+ *   arm has to reproduce byte for byte to be a baseline.
+ *
+ * The direction of the error matters more than its size. `TrumpMemory.seenCount`
+ * can only ever *under*-report, because forgetting removes sightings and never
+ * invents them, and an under-report makes `isBoss` below answer "beatable".
+ * So a seat that cannot remember plays as though the card can be beaten, which
+ * is the conservative resolution #158 asks for, and it is structural rather
+ * than a branch someone has to remember to write.
  */
-function isSafe(card: Card, hand: readonly Card[], tracker: PlayTracker): boolean {
+function seenCount(
+  suit: Suit,
+  rank: Rank,
+  trump: Suit,
+  tracker: PlayTracker | undefined,
+  memory: TrumpMemory | undefined,
+): number {
+  if (suit === trump && memory !== undefined) return memory.seenCount(rank)
+  return tracker?.playedCount(suit, rank) ?? 0
+}
+
+/**
+ * Whether this card **cannot be beaten in its own suit**: every higher-ranked
+ * card of that suit is accounted for, either seen already or sitting in your own
+ * hand (a card you hold yourself cannot beat you).
+ *
+ * "In its own suit" is the whole caveat and it is not a shortcut (#158). A card
+ * that is boss in a side suit can still be ruffed by an opponent who happens to
+ * be void, and no amount of counting tells you whether they are — `PlayTracker`
+ * records what was played, not who is out of what. So this predicate is never
+ * a promise that the trick will be won; it is a promise that nobody takes it
+ * *with a bigger card of this suit*. Callers must not read more into it.
+ *
+ * Formerly `isSafe`, unchanged in arithmetic and renamed because #158 gave it a
+ * second caller with a different question in mind — leading a card safely, and
+ * taking a trick with a counter that will hold.
+ */
+function isBoss(
+  card: Card,
+  hand: readonly Card[],
+  trump: Suit,
+  tracker: PlayTracker | undefined,
+  memory: TrumpMemory | undefined,
+): boolean {
   if (card.rank === 'A') return true
   const idx = RANK_VALUE[card.rank]
   for (const rank of RANKS) {
     const value = RANK_VALUE[rank]
     if (value > idx) {
-      const accounted = tracker.playedCount(card.suit, rank) + handCount(hand, card.suit, rank)
+      const accounted = seenCount(card.suit, rank, trump, tracker, memory) + handCount(hand, card.suit, rank)
       if (accounted < 2) return false
     }
   }
@@ -66,10 +123,16 @@ function isSafe(card: Card, hand: readonly Card[], tracker: PlayTracker): boolea
  * played yet - a live liability that needs to move before someone else's
  * lead traps you into losing it to the tie-break rule.
  */
-function isUnsecuredAce(card: Card, hand: readonly Card[], tracker: PlayTracker): boolean {
+function isUnsecuredAce(
+  card: Card,
+  hand: readonly Card[],
+  trump: Suit,
+  tracker: PlayTracker,
+  memory: TrumpMemory | undefined,
+): boolean {
   if (card.rank !== 'A') return false
   if (handCount(hand, card.suit, 'A') !== 1) return false // 0 copies (n/a) or 2 copies (secure double, no rush)
-  return tracker.playedCount(card.suit, 'A') === 0
+  return seenCount(card.suit, 'A', trump, tracker, memory) === 0
 }
 
 /**
@@ -98,12 +161,17 @@ function isUnsecuredAce(card: Card, hand: readonly Card[], tracker: PlayTracker)
  * branch before it ever gets here, and nobody on the bidding side is on lead
  * before trick 2.
  */
-function offenseTrumpLead(hand: readonly Card[], trump: Suit, tracker: PlayTracker): Card {
+function offenseTrumpLead(
+  hand: readonly Card[],
+  trump: Suit,
+  tracker: PlayTracker,
+  memory: TrumpMemory | undefined,
+): Card {
   const trumpAces = hand.filter((c) => c.suit === trump && c.rank === 'A')
   if (trumpAces.length > 0) return trumpAces[0]
   const nonTrump = hand.filter((c) => c.suit !== trump)
-  if (nonTrump.length > 0) return leadSafeCascade(nonTrump, trump, tracker)
-  return leadSafeCascade(hand, trump, tracker)
+  if (nonTrump.length > 0) return leadSafeCascade(nonTrump, trump, tracker, memory)
+  return leadSafeCascade(hand, trump, tracker, memory)
 }
 
 /**
@@ -123,10 +191,15 @@ function offenseTrumpLead(hand: readonly Card[], trump: Suit, tracker: PlayTrack
  * only mode reachable from the ported Proficient `choose_lead_card`, it
  * restricts to non-trump unconditionally.
  */
-function defenderLead(hand: readonly Card[], trump: Suit, tracker: PlayTracker): Card {
+function defenderLead(
+  hand: readonly Card[],
+  trump: Suit,
+  tracker: PlayTracker,
+  memory: TrumpMemory | undefined,
+): Card {
   const nonTrump = hand.filter((c) => c.suit !== trump)
-  if (nonTrump.length > 0) return leadSafeCascade(nonTrump, trump, tracker)
-  return leadSafeCascade(hand, trump, tracker)
+  if (nonTrump.length > 0) return leadSafeCascade(nonTrump, trump, tracker, memory)
+  return leadSafeCascade(hand, trump, tracker, memory)
 }
 
 /**
@@ -137,20 +210,35 @@ function defenderLead(hand: readonly Card[], trump: Suit, tracker: PlayTracker):
  *   3. Safe cards, cascading top-down by rank (longest suit first within a rank)
  *   4. Junk lead (non-point, non-trump) to surrender — shortest suit first
  *   5. Non-point trump as a last resort before giving up a point card
+ *
+ * Tier 3 is the leading half of #158: *"a counter that is provably boss is safe
+ * to lead; one that is not, is not."* That was already true of side suits, where
+ * `PlayTracker` counts exactly. What #158 adds is that when the card in question
+ * is **trump**, the count comes from this seat's `TrumpMemory` instead — so an
+ * `easy` seat holding the trump 10 with both Aces long gone often does not know
+ * it, and drops to the junk tier rather than cashing it. That is the skill dial
+ * during trick play, and it is reached here only on an all-trump hand:
+ * `offenseTrumpLead` and `defenderLead` both filter trump out first whenever the
+ * hand has anything else.
  */
-function leadSafeCascade(hand: readonly Card[], trump: Suit, tracker: PlayTracker): Card {
-  const trumpAces = hand.filter((c) => c.suit === trump && c.rank === 'A' && isUnsecuredAce(c, hand, tracker))
+function leadSafeCascade(
+  hand: readonly Card[],
+  trump: Suit,
+  tracker: PlayTracker,
+  memory: TrumpMemory | undefined,
+): Card {
+  const trumpAces = hand.filter((c) => c.suit === trump && c.rank === 'A' && isUnsecuredAce(c, hand, trump, tracker, memory))
   if (trumpAces.length > 0) return trumpAces[0]
 
   const otherUnsecuredAces = hand.filter(
-    (c) => c.rank === 'A' && c.suit !== trump && isUnsecuredAce(c, hand, tracker),
+    (c) => c.rank === 'A' && c.suit !== trump && isUnsecuredAce(c, hand, trump, tracker, memory),
   )
   if (otherUnsecuredAces.length > 0) {
     otherUnsecuredAces.sort((a, b) => suitLength(hand, b.suit) - suitLength(hand, a.suit))
     return otherUnsecuredAces[0]
   }
 
-  const safeCards = hand.filter((c) => isSafe(c, hand, tracker))
+  const safeCards = hand.filter((c) => isBoss(c, hand, trump, tracker, memory))
   if (safeCards.length > 0) {
     safeCards.sort((a, b) => {
       const byRank = RANK_VALUE[b.rank] - RANK_VALUE[a.rank]
@@ -195,10 +283,15 @@ function leadSafeCascade(hand: readonly Card[], trump: Suit, tracker: PlayTracke
  *   round), forces a trump lead if the player has any trump cards remaining.
  * @param skill - Skill level, read for `playPolicy` (#153). Since #156 every
  *   shipped row is `'cascade'` — the full Proficient cascade — so this argument
- *   no longer varies the strategy in a real game. `'simple'` (low non-trump
- *   non-counter) survives as an A/B arm, reachable only through an override.
- *   Defaults to 'hard'.
+ *   no longer varies the strategy in a real game — except through
+ *   `safeCounterPolicy`, which does not change the rule but does change how well
+ *   this seat can answer it (#158). `'simple'` (low non-trump non-counter)
+ *   survives as an A/B arm, reachable only through an override. Defaults to
+ *   'hard'.
  * @param isBiddingTeam - Which side this seat is on. Undefined = fallback.
+ * @param trumpMemory - This seat's capacity-limited view of the trump seen so
+ *   far (#157), consulted only when `safeCounterPolicy` is `'counted'`. Omit it
+ *   and trump safety is read from the exact `tracker`, as before #158.
  */
 export function chooseLeadCard(
   hand: readonly Card[],
@@ -207,7 +300,13 @@ export function chooseLeadCard(
   isBidderFirstLead = false,
   skill: SkillLevel = 'hard',
   isBiddingTeam?: boolean,
+  trumpMemory?: TrumpMemory,
 ): Card {
+  // The one gate. `undefined` here means every question below about trump is
+  // answered from `PlayTracker`'s exact count, which is what the pre-#158 code
+  // did and what the `'off'` A/B arm must keep doing.
+  const memory = SKILL_PARAMS[skill].safeCounterPolicy === 'counted' ? trumpMemory : undefined
+
   // Simplified leading — prefer low non-trump non-count cards. No shipped
   // `SKILL_PARAMS` row selects this since #156 moved `easy` onto the cascade
   // with everyone else, so nothing reaches it in a real game; it stays as the
@@ -223,7 +322,7 @@ export function chooseLeadCard(
   if (isBidderFirstLead) {
     const trumps = hand.filter((c) => c.suit === trump)
     if (trumps.length > 0) {
-      const unsecuredAce = trumps.find((c) => c.rank === 'A' && isUnsecuredAce(c, hand, tracker))
+      const unsecuredAce = trumps.find((c) => c.rank === 'A' && isUnsecuredAce(c, hand, trump, tracker, memory))
       if (unsecuredAce) return unsecuredAce
       const ace = trumps.find((c) => c.rank === 'A')
       if (ace) return ace
@@ -241,11 +340,11 @@ export function chooseLeadCard(
   }
 
   // Dispatch by side when known: bidding team draws trump, defending team avoids it
-  if (isBiddingTeam === true) return offenseTrumpLead(hand, trump, tracker)
-  if (isBiddingTeam === false) return defenderLead(hand, trump, tracker)
+  if (isBiddingTeam === true) return offenseTrumpLead(hand, trump, tracker, memory)
+  if (isBiddingTeam === false) return defenderLead(hand, trump, tracker, memory)
 
   // Fallback when side is unknown (old callers): original safe-card cascade
-  return leadSafeCascade(hand, trump, tracker)
+  return leadSafeCascade(hand, trump, tracker, memory)
 }
 
 function minByRank(cards: readonly Card[]): Card {
@@ -291,25 +390,63 @@ function feedPartner(legalMoves: readonly Card[]): Card {
  *
  *   1. A non-counter (Q, J, 9) if any legal beater is one — take the trick
  *      without also donating 10 points into it.
- *   2. Otherwise the lowest counter that cannot itself be beaten. **Not
- *      implemented here.** Knowing a counter is safe means knowing what is still
- *      outstanding, which is #158 on top of #157's trump memory; this gap is the
- *      seam it slots into, left deliberately rather than approximated.
+ *   2. Otherwise the lowest counter that cannot itself be beaten (#158).
  *   3. Otherwise the lowest counter.
  *
- * Tiers 1 and 3 pick the card `minByRank` picked before this function existed,
- * and that is worth stating rather than relying on silently: pinochle's rank
- * order (9 J Q K 10 A) happens to put every non-counter strictly below every
- * counter, so "lowest legal card" already reads as "cheapest free beat, else
- * cheapest counter". Spelling the tiers out costs nothing, makes the preference
- * a tested property instead of a side effect of `RANK_VALUE`, and means #158
- * inserts one branch rather than re-deriving the rule. The behaviour #155
- * measured is all in `chooseFollowCard`'s *detection* of the forced beat below,
- * not in this selection.
+ * Tiers 1 and 3 pick the card `minByRank` picked before this function existed:
+ * pinochle's rank order (9 J Q K 10 A) happens to put every non-counter strictly
+ * below every counter, so "lowest legal card" already read as "cheapest free
+ * beat, else cheapest counter". Tier 2 is the one that changes a card, and it is
+ * #158's whole content.
+ *
+ * ## What tier 2 does, and what it deliberately does not claim
+ *
+ * Every legal move here is a counter, and they are all of one suit — the branch
+ * above only reaches this with a single-suit legal set. So the candidates are
+ * some subset of {K, 10, A} and the question is which of them will still be
+ * standing when the trick closes. `isBoss` answers it *in suit*, and that is the
+ * strongest claim available: an opponent who is void and holds a trump takes the
+ * trick whatever is played here, and nothing in `PlayTracker` says who is void.
+ * Playing the boss card is therefore not "winning the trick", it is "not losing
+ * it to a bigger card of this suit" — which is the loss this rule exists to
+ * avoid, since spending a King into a trick an opponent's Ace then takes hands
+ * over 20 points rather than 10.
+ *
+ * Two consequences of that, both intended:
+ *
+ *   - **The Ace always qualifies**, so whenever an Ace is legal this tier picks
+ *     something, and it degenerates to "the cheapest counter that holds, else
+ *     the Ace". With nothing known that is the Ace — spending the boss to be
+ *     certain, rather than gambling a King on information the seat does not
+ *     have. That is the conservative direction #158 asks for.
+ *   - **Nobody left to play means nothing is outstanding.** Last to the trick,
+ *     no card can be beaten, so the tier collapses to the cheapest counter — the
+ *     King — instead of throwing an Ace at a trick already won. This is a
+ *     property of the position, not of the counting, so it holds at every skill
+ *     level, and it is why turning #158 on cannot make the fourth seat worse.
+ *
+ * @param seatsStillToPlay - How many seats follow this one in the trick, 0-3.
+ * @param counted - `safeCounterPolicy === 'counted'`. When false this is exactly
+ *   the post-#155 function, which is what makes the A/B a one-field comparison.
  */
-function chooseForcedBeat(legalMoves: readonly Card[]): Card {
+function chooseForcedBeat(
+  legalMoves: readonly Card[],
+  hand: readonly Card[],
+  trump: Suit,
+  tracker: PlayTracker | undefined,
+  memory: TrumpMemory | undefined,
+  seatsStillToPlay: number,
+  counted: boolean,
+): Card {
   const nonCounters = legalMoves.filter((c) => !POINT_RANKS.has(c.rank))
   if (nonCounters.length > 0) return minByRank(nonCounters)
+
+  if (counted) {
+    if (seatsStillToPlay <= 0) return minByRank(legalMoves)
+    const boss = legalMoves.filter((c) => isBoss(c, hand, trump, tracker, memory))
+    if (boss.length > 0) return minByRank(boss)
+  }
+
   return minByRank(legalMoves)
 }
 
@@ -339,14 +476,20 @@ function currentWinner(trickPlays: readonly TrickPlay[], trump: Suit): TrickPlay
  *       1. Forced beat (every legal card already beats the current
  *          winner, measured as trick-winning power rather than raw rank
  *          - #155) - take it with a non-counter if one is legal, else
- *          with the cheapest counter. See `chooseForcedBeat`.
+ *          with the cheapest counter that cannot itself be beaten in
+ *          suit (#158). See `chooseForcedBeat`.
  *       2. Partner is currently winning - feed them points: the lowest
  *          King/10 available (#154 - every counter pays 10, so spend the
  *          weakest), or (if none) the lowest card, to avoid donating a
  *          live Ace unless forced.
  *       3. Otherwise - play the lowest non-point card, falling back to
  *          the lowest legal card if only point cards are available.
- *   - Forced to play trump (void in the lead suit):
+ *   - Forced to play trump (void in the lead suit, or trump was led):
+ *       0. Forced to *overtrump* - a trump is already winning the trick
+ *          and every legal move beats it, so the rules have restricted
+ *          this seat to beaters. Same selection as the lead-suit forced
+ *          beat above, and the one place #157's capacity-limited trump
+ *          memory decides a card (#158).
  *       1. Trump is secure (every copy - in hand plus already played -
  *          is accounted for, i.e. no trump left unseen) - play the
  *          lowest trump, conserving high trump for later control.
@@ -357,11 +500,33 @@ function currentWinner(trickPlays: readonly TrickPlay[], trump: Suit): TrickPlay
  *     suits - work toward voiding the shortest suit, lowest rank within
  *     it.
  *
- * @param skill Skill level, read for `playPolicy` (#153). Since #156 every
- *   shipped row is `'cascade'` — the tiered logic above — so this argument no
- *   longer varies the strategy in a real game. `'simple'` (play the lowest legal
- *   card) survives as an A/B arm, reachable only through an override. Defaults
- *   to 'hard'.
+ * Tier 0 of the trump branch is new in #158 and is worth saying why it is not
+ * scope creep. #155 wrote the forced-beat selection rule but could only reach
+ * the *lead-suit* branch, because that is where the detection lived; the trump
+ * branch had no notion of a forced beat at all and answered an overtrump with
+ * "surrender the lowest point trump", which spends a King into a trick an
+ * opponent's Ace is about to take. The issue's own worked example — both trump
+ * Aces gone makes the 10 boss, then the Kings after the 10s — is a *trump*
+ * example, so tier 2 of `chooseForcedBeat` cannot be implemented as specified
+ * without a forced beat in trump to implement it in. Tier 1 comes along with it
+ * because a rule that prefers a free beat everywhere except trump would be
+ * incoherent, not because it was measured separately.
+ *
+ * Note what is deliberately left alone: `trumpSecure` below still reads
+ * `PlayTracker`'s exact count, not the memory. "Is every trump accounted for"
+ * is a different question from "can this card be beaten", #157 recorded the
+ * exact tracker as load-bearing for the parity fixtures, and degrading that one
+ * is its own issue with its own measurement.
+ *
+ * @param skill Skill level, read for `playPolicy` (#153) and
+ *   `safeCounterPolicy` (#158). Since #156 every shipped row is `'cascade'`, so
+ *   the tiers themselves are the same at every level; what the level changes is
+ *   how much of the trump this seat can still recall when tier 2 of
+ *   `chooseForcedBeat` asks. `'simple'` (play the lowest legal card) survives as
+ *   an A/B arm, reachable only through an override. Defaults to 'hard'.
+ * @param trumpMemory This seat's capacity-limited trump view (#157). Consulted
+ *   only when `safeCounterPolicy` is `'counted'`; omitted, trump questions fall
+ *   back to the exact `tracker`, which is the pre-#158 reading.
  */
 export function chooseFollowCard(
   hand: readonly Card[],
@@ -371,6 +536,7 @@ export function chooseFollowCard(
   myTeamPlayers: readonly PlayerIndex[],
   tracker?: PlayTracker,
   skill: SkillLevel = 'hard',
+  trumpMemory?: TrumpMemory,
 ): Card {
   if (legalMoves.length === 1) return legalMoves[0]
 
@@ -380,6 +546,11 @@ export function chooseFollowCard(
   if (SKILL_PARAMS[skill].playPolicy === 'simple') {
     return legalMoves.reduce((lowest, c) => (c.rankValue < lowest.rankValue ? c : lowest))
   }
+
+  const counted = SKILL_PARAMS[skill].safeCounterPolicy === 'counted'
+  const memory = counted ? trumpMemory : undefined
+  /** Seats still to follow this one, 0-3. Zero means nothing is outstanding. */
+  const seatsStillToPlay = 3 - trickPlays.length
 
   const leadSuit = trickPlays.length > 0 ? trickPlays[0].card.suit : undefined
   const winner = trickPlays.length > 0 ? currentWinner(trickPlays, trump) : undefined
@@ -400,7 +571,9 @@ export function chooseFollowCard(
     // returns false against any trump — correctly, since no card of the lead
     // suit can take a trick a trump is winning.
     const forcedBeat = winner !== undefined && legalMoves.every((c) => c.beats(winner.card, trump))
-    if (forcedBeat) return chooseForcedBeat(legalMoves)
+    if (forcedBeat) {
+      return chooseForcedBeat(legalMoves, hand, trump, tracker, memory, seatsStillToPlay, counted)
+    }
 
     if (partnerWinning) return feedPartner(legalMoves)
 
@@ -410,6 +583,27 @@ export function chooseFollowCard(
   }
 
   if (allTrump) {
+    // Tier 0 (#158): forced to overtrump. A trump is already winning and every
+    // legal move beats it, which `Trick.legalMoves` only produces by restricting
+    // this seat to beaters — rule 3 when trump was led, rule 5 when a ruff has
+    // to be over-ruffed. Both are the same decision as the lead-suit forced beat
+    // above, so they take the same selection.
+    //
+    // The `winner.card.suit === trump` test is what keeps a plain ruff out of
+    // here: with no trump yet on the table every trump in hand "beats" the
+    // side-suit winner, but the rules restricted nothing and the seat is free to
+    // choose. That position keeps its existing tiers, where "surrender the
+    // lowest point trump" is a deliberate get-the-liability-out heuristic rather
+    // than a way of taking a trick.
+    const forcedOvertrump =
+      counted &&
+      winner !== undefined &&
+      winner.card.suit === trump &&
+      legalMoves.every((c) => c.beats(winner.card, trump))
+    if (forcedOvertrump) {
+      return chooseForcedBeat(legalMoves, hand, trump, tracker, memory, seatsStillToPlay, counted)
+    }
+
     let trumpSecure = true
     if (tracker !== undefined) {
       const playedTrump = RANKS.reduce((sum, r) => sum + tracker.playedCount(trump, r), 0)

--- a/web/src/engine/trumpMemory.test.ts
+++ b/web/src/engine/trumpMemory.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { SkillLevel } from '../persistence/options'
-import { Card, RANKS, Suit } from './card'
-import { TRUMP_MEMORY_CAPACITY, TrumpMemory } from './trumpMemory'
+import { type CopyId, Card, RANKS, Suit } from './card'
+import { TRUMP_MEMORY_CAPACITY, TrumpMemory, newTrumpMemories } from './trumpMemory'
 
 const TRUMP = Suit.Spades
 
@@ -181,5 +181,60 @@ describe('TrumpMemory and meld', () => {
     expect(memory.size).toBe(4)
     expect(memory.forgottenCount).toBe(0)
     expect(memory.seenCount('A')).toBe(1) // one Ace copy accounted for, not two
+  })
+})
+
+describe('newTrumpMemories (#158)', () => {
+  /** A hand melding a Royal Marriage in trump (K+Q) plus filler that melds
+   *  nothing, so `extractMeldCards` returns exactly the two trump cards. */
+  function royalMarriageHand(copy: CopyId): Card[] {
+    return [
+      new Card(TRUMP, 'K', copy),
+      new Card(TRUMP, 'Q', copy),
+      new Card(Suit.Hearts, '9', copy),
+    ]
+  }
+
+  const hands = [
+    royalMarriageHand(1), // seat 0 melds K+Q of trump, copy 1
+    royalMarriageHand(2), // seat 1 melds K+Q of trump, copy 2
+    [new Card(Suit.Hearts, 'J', 1)], // seats 2 and 3 meld nothing
+    [new Card(Suit.Clubs, 'J', 1)],
+  ]
+
+  it('seeds each seat with the trump the other three melded', () => {
+    const memories = newTrumpMemories(hands, TRUMP, () => 'expert')
+    // Seat 2 melded nothing and can see all four trump laid out opposite it.
+    expect(memories[2].seenCount('K')).toBe(2)
+    expect(memories[2].seenCount('Q')).toBe(2)
+    expect(memories[2].size).toBe(4)
+  })
+
+  it('does not show a seat its own meld, because its own cards are counted from its hand', () => {
+    // The invariant that keeps the model from ever over-counting. `tracker.ts`
+    // reads "accounted for" as *seen + still held >= 2 copies*, tallying the
+    // hand separately, so a seat fed its own melded King would count one
+    // physical card twice and conclude a Queen was boss when it is not. An
+    // under-count only ever reads as "still beatable", which is safe; an
+    // over-count invents certainty, which is not.
+    const memories = newTrumpMemories(hands, TRUMP, () => 'expert')
+    expect(memories[0].seenCount('K')).toBe(1) // seat 1's copy only, not its own
+    expect(memories[0].remembered().map((s) => s.copyId)).toEqual([2, 2])
+    expect(memories[1].seenCount('K')).toBe(1) // seat 0's copy only
+    expect(memories[1].remembered().map((s) => s.copyId)).toEqual([1, 1])
+  })
+
+  it('gives each seat the capacity its own level buys', () => {
+    const memories = newTrumpMemories(hands, TRUMP, (seat) => (seat === 0 ? 'easy' : 'expert'))
+    expect(memories[0].capacity).toBe(TRUMP_MEMORY_CAPACITY.easy)
+    expect(memories[1].capacity).toBe(TRUMP_MEMORY_CAPACITY.expert)
+  })
+
+  it('spends capacity on the meld, so a weak seat arrives at trick 1 already short', () => {
+    // Seat 2 can see four melded trump and can hold two of them. Meld is not a
+    // free look — it consumes the memory exactly as played cards do (#157).
+    const memories = newTrumpMemories(hands, TRUMP, () => 'easy')
+    expect(memories[2].size).toBe(TRUMP_MEMORY_CAPACITY.easy)
+    expect(memories[2].forgottenCount).toBe(2)
   })
 })

--- a/web/src/engine/trumpMemory.ts
+++ b/web/src/engine/trumpMemory.ts
@@ -22,14 +22,17 @@
 // a bug to be fixed in passing — if side-suit memory should degrade too, that is
 // its own issue with its own measurement.
 //
-// INERT ON ARRIVAL. Nothing constructs a `TrumpMemory` yet; the consumer is
-// #158, which uses it to answer "is my 10 the boss card now" instead of
-// guessing. Landing it unwired keeps the eventual behaviour change measurable on
-// its own, the way #114 landed the bid evaluator switched on for nobody so #115
-// could measure it, and the way #153 landed the play-policy dial.
+// WIRED BY #158, which is what this was built for. `tracker.ts` now asks a
+// seat's memory "is this counter still beatable in its own suit?" before
+// spending it, and `newTrumpMemories` at the bottom of this file is what builds
+// one memory per seat at the top of a round. Until #158 the module was reachable
+// only from its own test, on purpose — #114 and #153's pattern of landing the
+// machinery inert so the behaviour change can be measured on its own.
 
 import type { SkillLevel } from '../persistence/options'
 import type { Card, CopyId, Rank, Suit } from './card'
+import { extractMeldCards } from './melds'
+import type { PlayerIndex } from './trick'
 
 /**
  * How many of the 12 trump a seat can hold in mind at once: **2 x skill level**,
@@ -144,4 +147,49 @@ export class TrumpMemory {
   remembered(): readonly TrumpSighting[] {
     return [...this.recent]
   }
+}
+
+/**
+ * One memory per seat for a round about to be played, pre-loaded with the trump
+ * each seat can see in **the other three seats' meld** (#158).
+ *
+ * Two things about the seeding are load-bearing rather than incidental:
+ *
+ *   **A seat is not shown its own meld.** #157 says meld consumes capacity like
+ *   anything else, and it does — but only for cards the seat does not already
+ *   hold. `tracker.ts` answers "is this card still beatable" as *seen +
+ *   held >= 2 copies*, counting the hand separately, so feeding a seat its own
+ *   melded trump would count that one physical card twice and manufacture
+ *   certainty out of nothing. Over-counting is the one failure mode this model
+ *   must not have: an unknown has to resolve to "beatable", never to "boss".
+ *   Under-counting is fine, and is exactly what forgetting already does.
+ *
+ *   **Nothing else here is in a seat's own hand either**, so the same
+ *   invariant holds for the rest of the round: every later sighting is a card
+ *   played to a trick, which by then has left whoever's hand it came from.
+ *
+ * The caller drives it from there — feed every card played to a trick through
+ * `see` on all four memories, after it is chosen. A card melded by one seat and
+ * played later is deduplicated by rank + copy id, so it still costs one slot.
+ *
+ * @param hands - Hands as of the start of trick play, i.e. after the 3-card
+ *   pass and the meld reveal. Melds are derived from these.
+ * @param skillOf - The level each seat plays at, which fixes its capacity.
+ */
+export function newTrumpMemories(
+  hands: readonly (readonly Card[])[],
+  trump: Suit,
+  skillOf: (seat: PlayerIndex) => SkillLevel,
+): Record<PlayerIndex, TrumpMemory> {
+  const seats: readonly PlayerIndex[] = [0, 1, 2, 3]
+  const meldBySeat = seats.map((seat) => extractMeldCards(hands[seat] ?? [], trump).meldCards)
+  const memories = {} as Record<PlayerIndex, TrumpMemory>
+  for (const seat of seats) {
+    const memory = new TrumpMemory(trump, skillOf(seat))
+    for (const other of seats) {
+      if (other !== seat) memory.seeAll(meldBySeat[other])
+    }
+    memories[seat] = memory
+  }
+  return memories
 }


### PR DESCRIPTION
Closes #158 — the **final child of epic #152**. With this merged, every item on that epic's list is done.

> **Rebased onto `main` after #179 (issue #177) and #181 (issue #178) landed, and re-measured against them.** Auto-SET ends a mathematically dead contract before the first lead and fires on ~6.9% of contracts, so it changes which deals reach trick play at all. Every headline number below was re-run on top of it; the earlier table is kept in `web/README.md`, clearly labelled as a reading on the older baseline. **The effect survived and the divergence widened slightly.** Conflict resolution is described at the bottom.

## What #155 left, and what fills it

#155 wrote the forced-beat rule as three tiers and could only build two:

1. beat with a non-counter (Q, J, 9) if one is legal — take the trick for free;
2. else the lowest counter that **cannot itself be beaten**;
3. else the lowest counter.

Tier 2 needed to know what was still outstanding, so it landed as a documented gap with a clean seam. It is now `isBoss` in `tracker.ts` — the old `isSafe`, unchanged in arithmetic, renamed because it now answers two questions. The second one is the leading half of the same rule, which was already there: *a counter that is provably boss is safe to lead, one that is not is not.*

## How the capped view is consumed

One helper, `seenCount(suit, rank, trump, tracker, memory)`, routes every "has this card gone?" question to whichever source owns it:

- **Side suits** → `PlayTracker`, which counts perfectly. #157 scoped its cap to trump, so side-suit safety is exact at every skill level and an `easy` seat answers exactly as an `expert` does.
- **Trump** → that seat's `TrumpMemory` (#157), capacity `2 × skill level`.

`memory` is `undefined` when the caller supplies none *or* when `safeCounterPolicy` is `'off'`, and then it falls back to the exact count — the pre-#158 reading, which is what makes the `'off'` A/B arm a real baseline rather than an approximation of one.

`newTrumpMemories` (new, in `trumpMemory.ts`) builds one memory per seat at the top of a round, seeded from **the other three seats' meld**. Both `headlessGame.ts` and `TrickPlayFlow.tsx` then feed every card played through all four memories, the human's card included.

## How unknowns resolve conservatively

**By construction, not by a branch.** `TrumpMemory.seenCount` can only ever *under*-report — forgetting removes sightings and never invents them — and an under-report makes `isBoss` answer "beatable". So a seat that cannot remember plays as though the card can be beaten. There is no code path where an unknown becomes an assumed best case, and there is nothing a future edit has to remember to preserve.

`newTrumpMemories` guards the same invariant from the other end, and this is the one modelling decision worth arguing with. A seat is **not** shown its own meld. `isBoss` reads "accounted for" as *seen + still held >= 2 copies*, counting the hand separately, so a seat fed its own melded King would count one physical card twice and conclude a Queen was boss when it is not. Over-counting is the single failure this model must not have; under-counting is already what forgetting does, and it is safe. Two tests pin it.

**"Cannot be beaten" means in suit and nothing more.** A card that is boss in a side suit can still be ruffed by an opponent who happens to be void, and `PlayTracker` records what was played, not who is out of what. The predicate's docstring says so explicitly, because the tempting misreading is that it promises the trick.

## Two positions changed, two deliberately did not

- **Forced to beat in a side suit.** With only counters legal, the cheapest one that will still be standing goes in. Nobody left to play collapses the tier to the cheapest counter — nothing is outstanding — so the fourth seat cannot be made worse by this change. That is a property of the position, not of the counting, and holds at every level.
- **Forced to overtrump.** A trump is already winning and `Trick.legalMoves` has restricted the seat to beaters (rule 3 when trump was led, rule 5 over a ruff). The trump branch had **no notion of a forced beat at all** and answered this with "surrender the lowest point trump" — a King into a trick an opponent's Ace is about to take. The issue's own worked example (both trump Aces gone makes the 10 boss, then the Kings) is a *trump* example, so tier 2 could not be implemented as specified without a forced beat in trump to implement it in. Tier 1 comes along because a rule that prefers a free beat everywhere except trump would be incoherent, not because it was measured separately.
- **A plain ruff is left alone.** Void in the lead suit with no trump yet on the table: every trump in hand "beats" the winner, but the rules restricted nothing and the seat chose to ruff. Existing tiers, pinned by a test so the `Card.beats` check alone cannot swallow it.
- **`trumpSecure` still reads the exact count.** "Is every trump accounted for" is a different question from "can this card be beaten", and #157 recorded the exact `PlayTracker` as load-bearing for the parity fixtures. Its own issue, its own measurement.

## Measurement, against auto-SET

`cli.ts safe --level L` puts the counted rule at level `L` against an `'off'` baseline. **The baseline never constructs a `TrumpMemory`, so it is the same opponent at every level** — which is what makes two runs at different capacities comparable to each other and not merely to zero. Both arms carry `autoSetPolicy: 'forced'`, and the harness reports the same auto-SET rate on each side (6.8–6.9% of contracts), which is the check that the two arms are dealt the same population.

Controls first. Self-test on both arms, re-run post-rebase: 200 pairs, every pair split, paired margin exactly 0.00. Then the dial-is-read check — the two arms return different cards from one fixed position (`A♥` against `K♥`), pinned in `tracker.test.ts` rather than dumped and discarded.

5000 paired deals / 10 000 games per cell, both ends of the dial, two seeds:

| level | trump remembered | seed 1 margin (95% CI) | seed 2 margin (95% CI) |
| --- | --- | --- | --- |
| easy | 2 of 12 | **+3.71** (+0.46 to +6.90) | **+4.07** (+0.96 to +7.26) |
| expert | 10 of 12 | **+8.93** (+5.86 to +11.90) | **+7.93** (+5.06 to +10.83) |

Every interval excludes zero. Against the older pre-#178 baseline the same cells read +3.29/+3.85 and +8.69/+7.64, so **the effect is slightly larger under auto-SET, not smaller** — which makes sense: the contracts auto-SET removes could not have been made however they were played, so they were dead weight in the average rather than deals the rule was winning. Make-rate moves with margin (expert seed 1: 71.54% against the baseline's 71.26%), which is #126's check.

The full five-capacity ladder (medium +3.43/+4.44, hard +4.94/+5.60, proficient +7.76/+6.76) was measured on the pre-#178 baseline and rises monotonically there. It stays in `web/README.md` as a historical reading rather than being re-run — monotonicity across five capacities is the shape of the claim, and the two ends of it are what the claim rests on.

### Did easy and expert still diverge? Yes — slightly more

The ladder is evidence by subtraction against a shared baseline, so it was also run head-to-head with `cli.ts capacity --high expert --low easy`: both sides run the counted rule and differ in **nothing but the level they sit on**. It is the only comparison in `src/ab/` where zero `SkillParams` fields differ, and that is the point — it isolates recall itself. Re-run against auto-SET:

| seed | expert vs easy, margin per deal | 95% CI | swept | p |
| --- | --- | --- | --- | --- |
| 1 | **+6.50** | +4.86 to +8.13 | 42–12 | 0.00005 |
| 2 | **+6.08** | +4.33 to +7.91 | 46–16 | 0.0002 |

Pre-#178 the same runs read +5.96 and +5.91. Auto-SET did not wash the divergence out; it widened it a little. About six points a deal, entirely through what the two seats can remember — the first time the skill dial has changed a *card* rather than a bid.

## Shipped enabled

Positive at every capacity on both seeds and on both baselines, so `safeCounterPolicy: 'counted'` ships on all five `SKILL_PARAMS` rows — not as a difficulty notch. The rule is identical everywhere, so #156's settlement that trick play is shared competence stands; only the recall behind it differs, which is exactly #157's model. `'off'` survives as the A/B arm, for the reason `'simple'`, `'never'` and #178's `'off'` do.

Three existing tests changed answer, all in the positions #158 is about, each carrying a comment saying what it used to assert and why:

- #155's "forced beat with only counters legal: spends the cheapest one" is now pinned on the `'off'` arm via `withSafeCounterOff`, keeping the baseline exercised.
- The original "plays the lowest one that still wins" now asserts the Ace with the twin outstanding, *and* the 10 once the twin has gone — the same rule under different information, which is the whole difference.
- `ab.test.ts`'s shipped-default assertion flipped from "off everywhere" to "counted everywhere".

## Rebase / conflict resolution

Four files conflicted, all because #181 extended the same harness in the same places. Resolved so **both dials coexist and both stay independently selectable**:

- **`skills.ts`** — `SkillParams` carries both `autoSetPolicy` and `safeCounterPolicy`; both docstrings kept. The five `SKILL_PARAMS` rows no longer fit one readable line at six fields, so they are one field per line now. Added a note that `safeCounterPolicy` is the one column where a uniform value still produces different play at different levels, so it does not reopen #156.
- **`abRun.ts`** — `AUTO_SET_AB_POLICIES` and `safeCounterAbPolicies` / `safeCounterCapacityPolicies` all present. The four maps that are *not* measuring #158 now carry `safeCounterPolicy: 'counted'`, matching how they carry `foldPolicy: 'model'` and `autoSetPolicy: 'forced'` — a map's unchanging fields have to track the shipped dial or it stops describing the game. Documented, with the note that their recorded numbers are historical readings on the baseline of their day. #158's own builders carry `autoSetPolicy: 'forced'` on both arms.
- **`cli.ts`** — `autoset`, `safe` and `capacity` all present, all five self-test arms (`static`, `distilled`, `simple`, `cascade`, `auto-set`, plus `counted`/`uncounted`) registered, usage line lists everything.
- **`ab.test.ts`** — every self-test arm runs. Also caught a silent (non-textual) conflict: my edit to the "varies exactly one field per policy map" loop would have replaced the list wholesale, and #181 had not added its map to it. `AUTO_SET_AB_POLICIES` is now in that loop alongside the rest; it passes.
- **`web/README.md`** — #177's section and #158's section both kept.
- `headlessGame.ts` and `TrickPlayFlow.tsx` auto-merged cleanly and were checked by hand: auto-SET short-circuits before trick play, so an auto-SET round never builds trump memories, which is correct.

Per the coordinator's note, `tracker.ts` now imports `POINT_RANKS` from `trick.ts` (newly exported by #181) instead of keeping its own module-local copy. It did not open-code a counter *value* anywhere.

## Checks

- `npm test` 406 passed (385 on `main` + 21 new), `npx tsc -b` clean, `oxlint` clean apart from the three pre-existing `exhaustive-deps` warnings — the two `notePlayed` call sites were added to their dep arrays so the warning list did not grow.
- `python -m pytest -q` 298 passed. `pinochle_engine.py` is untouched, and has no trump-memory model at all, so this is not a ported behaviour that has drifted — porting it is its own issue on the Python side, the way #164 followed #154.
- `npm run build` clean. Bundle +1.58 kB raw / +0.60 kB gzipped (259.05 kB to 260.63 kB, measured against `d5465d9`, the commit this branch now sits on).

Reproduce:

    node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts selftest --pairs 200 --policy counted --seed 1
    node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts safe --pairs 5000 --seed 1 --level expert
    node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts capacity --pairs 5000 --seed 1 --high expert --low easy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
