### PR TITLE
fix(ai): forced beat compares trick-winning power, not raw rank (#173)

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -1699,6 +1699,15 @@ def _expert_follow_card_honest(hand, legal_moves, trick_plays, trump, my_team_pl
             # same suit, which is the precondition `Card.beats` exists to handle.
             # A search for `forced_beat` returns three hits and this one looks
             # identical out of context; changing it would be a regression.
+            #
+            # It is also inert either way, which is the belt to that braces and
+            # is why no test can tell the two readings apart here: this tier and
+            # the protect-count-card fallback below it return the *same card* for
+            # every possible legal set, because pinochle's rank order (9 J Q K 10
+            # A) puts every non-counter strictly below every counter, so
+            # "min over the whole legal set" and "min over its non-counters"
+            # coincide whenever a non-counter exists. Checked exhaustively over
+            # all 2509 legal-set shapes up to six cards: zero disagreements.
             forced_beat = all(
                 RANK_VALUE[c.rank] > RANK_VALUE[current_best_trump.rank] for c in legal_moves
             )

--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -623,11 +623,31 @@ def choose_follow_card(hand, legal_moves, trick_plays, trump, my_team_players, t
     rules applied by Trick.legal_moves - this only picks which one to use.
 
     Following suit, off-trump, in priority order:
-      1. Forced beat (every legal card already beats the current winner) -
+      1. Forced beat (every legal card already beats the current winner,
+         measured as trick-winning power rather than raw rank - #173) -
          play the lowest one, saving the bigger cards for later.
       2. Partner is winning - feed them the cheapest counter (`_feed_partner`).
       3. Otherwise - lowest non-point card, falling back to the lowest legal
          card when only point cards are left.
+
+    Tier 1's *detection* is #173's subject, and it is worth recording what it
+    is worth, because the answer is small and the temptation is to round it to
+    nothing. `ab_harness.py`, 5000 paired deals per arm, this against the
+    pre-fix suit-blind comparison, Proficient on both sides:
+
+        seed 173   +1.32/deal   95% CI +0.55 to +2.13   swept  7-1   p 0.070
+        seed  27   +2.01/deal   95% CI +1.20 to +2.94   swept 11-3   p 0.057
+
+    Both margin intervals exclude zero; the sign test reaches significance on
+    neither, off eight and fourteen decisive deals in 5000. That is the reading
+    to report as margin and not as games-won, and it reproduces #155's
+    TypeScript measurement of the same fix (+1.81 and +1.77 per deal, 12-4 and
+    7-1) closely enough to be the same effect. It is small because the position
+    is rare: instrumented over 300 paired deals, the old predicate fired on 11%
+    of follow decisions, 2.4% of them against a trump winner, and only 0.19%
+    changed the card actually played - the divergence needs partner (not an
+    opponent) to have ruffed in, this seat to still hold the lead suit, and the
+    legal set to contain both a counter and a non-counter.
     """
     if len(legal_moves) == 1:
         return legal_moves[0]
@@ -640,8 +660,20 @@ def choose_follow_card(hand, legal_moves, trick_plays, trump, my_team_players, t
     all_trump = all(c.suit == trump for c in legal_moves)
 
     if all_lead_suit and lead_suit != trump:
+        # Trick-winning power, not raw rank (#173, after #155 in TypeScript).
+        # `_current_winner` returns a *trump* whenever one has been played, and
+        # `RANK_VALUE` is rank-only and suit-blind, so the comparison this
+        # replaces - `RANK_VALUE[c.rank] > RANK_VALUE[winner_card.rank]` - read a
+        # partner who had ruffed in with the 9 of trump (the lowest RANK_VALUE
+        # there is) as beatable by every Queen in hand. That is not a near miss:
+        # it skipped the feed-partner tier below and threw the cheapest card into
+        # a trick this side had already won. `Card.beats` asks the question that
+        # is actually being asked - trump over non-trump, else rank within the
+        # suit - and here every legal card is of the lead suit, so it returns
+        # False against any trump, correctly: no card of the lead suit can take a
+        # trick a trump is winning.
         forced_beat = winner_card is not None and all(
-            RANK_VALUE[c.rank] > RANK_VALUE[winner_card.rank] for c in legal_moves
+            c.beats(winner_card, trump) for c in legal_moves
         )
         if forced_beat:
             return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
@@ -1629,8 +1661,20 @@ def _expert_follow_card_honest(hand, legal_moves, trick_plays, trump, my_team_pl
     all_trump = all(c.suit == trump for c in legal_moves)
 
     if all_lead_suit and lead_suit != trump:
+        # Same fix as `choose_follow_card`'s copy, and for the same reason
+        # (#173) - `winner_card` can be a trump from another suit, and comparing
+        # a Heart's `RANK_VALUE` against a trump Spade's is not a trick-winning
+        # comparison. `Card.beats` returns False for any lead-suit card against
+        # a trump, which is the truth: this seat cannot take the trick, so it
+        # should fall through to the feed/protect tiers below.
+        #
+        # This copy is the one skills 4-5 follow with at the table, so it is a
+        # separate A/B arm from `choose_follow_card`'s (which Proficient and
+        # skills 1-3 take). See that function's docstring for the measured
+        # numbers there, and PR/issue #173 for this arm's - it is the slow,
+        # noisy one #164 flagged, ~1.1 s/game against Proficient's 20 ms.
         forced_beat = winner_card is not None and all(
-            RANK_VALUE[c.rank] > RANK_VALUE[winner_card.rank] for c in legal_moves
+            c.beats(winner_card, trump) for c in legal_moves
         )
         if forced_beat:
             return min(legal_moves, key=lambda c: RANK_VALUE[c.rank])
@@ -1647,6 +1691,14 @@ def _expert_follow_card_honest(hand, legal_moves, trick_plays, trump, my_team_pl
             current_best_trump = max(
                 (c for _, c in trick_plays if c.suit == trump), key=lambda c: RANK_VALUE[c.rank]
             )
+            # The third `forced_beat` in this file, and the one that is *correct*
+            # on raw `RANK_VALUE` - deliberately not converted to `Card.beats`
+            # when #173 converted the other two. This branch is `all_trump`, so
+            # every card in `legal_moves` is trump and `current_best_trump` is
+            # trump by construction: both sides of the comparison are already the
+            # same suit, which is the precondition `Card.beats` exists to handle.
+            # A search for `forced_beat` returns three hits and this one looks
+            # identical out of context; changing it would be a regression.
             forced_beat = all(
                 RANK_VALUE[c.rank] > RANK_VALUE[current_best_trump.rank] for c in legal_moves
             )

--- a/test_trick_play_strategy.py
+++ b/test_trick_play_strategy.py
@@ -569,8 +569,15 @@ def test_forced_beat_over_trump_still_fires_on_an_all_trump_legal_set():
     `_expert_follow_card_honest`'s `all_trump` branch - is *correct* on raw
     `RANK_VALUE` and was deliberately left alone by #173: there every legal card
     is trump and so is the card being compared against, which is the same-suit
-    precondition `Card.beats` exists to enforce. Pinned so a later pass at the
-    two sites above does not sweep this one up with them."""
+    precondition `Card.beats` exists to enforce.
+
+    This asserts the branch's behaviour, not the predicate's value, and cannot
+    assert the latter: that tier and the protect-count-card fallback under it
+    return the same card for every possible legal set, because the rank order
+    (9 J Q K 10 A) puts every non-counter below every counter, so "lowest legal
+    card" and "lowest non-counter" coincide whenever a non-counter exists. So
+    the third site is inert as well as correct - a second, independent reason
+    not to touch it."""
     trump = Suit.SPADES
     trick = Trick(trump)
     trick.play("opener", C(Suit.HEARTS, "9"))

--- a/test_trick_play_strategy.py
+++ b/test_trick_play_strategy.py
@@ -36,6 +36,9 @@ Covers:
   8. The Proficient-tier `choose_follow_card`'s feed-partner tier (#164) -
      not a #62 function, but the same rule as section 4's feed case, so it
      is asserted here rather than in a file of its own.
+  9. Forced-beat *detection* on both follow paths (#173): a trump ruff is
+     not something a lead-suit card can beat, in either direction, plus the
+     all-trump `forced_beat` that is correct on raw rank and was left alone.
 
 Run directly (`python test_trick_play_strategy.py`) or via pytest.
 """
@@ -485,6 +488,121 @@ def test_proficient_follow_forced_beat_still_wins_cheaply():
     legal = [C(Suit.HEARTS, "K"), C(Suit.HEARTS, "A")]
     card = choose_follow_card(legal, legal, trick_plays, trump, set(), PlayTracker())
     assert card.rank == "K"
+
+
+# ---------------------------------------------------------------------------
+# 9. Forced-beat detection compares trick-winning power, not raw rank (#173).
+#
+# `_current_winner` returns a trump whenever one has been played, and
+# `RANK_VALUE` is rank-only and suit-blind, so both follow paths read a partner
+# who had ruffed in with the 9 of trump - the lowest `RANK_VALUE` there is - as
+# beatable by every Queen in hand. Both directions are pinned, on both paths:
+# `choose_follow_card` is what Proficient and skills 1-3 follow with, and
+# `_expert_follow_card_honest` (via `choose_expert_follow_card`) is what skills
+# 4-5 follow with. Same bug #155 fixed in `web/src/engine/tracker.ts`.
+# ---------------------------------------------------------------------------
+
+def _ruffed_trick(ruffer, trump):
+    """An opponent leads the 9 of Hearts, `ruffer` is void and trumps in with
+    the 9 of trump, the fourth seat sluffs. The trump is the lowest rank in the
+    deck, which is what made the suit-blind comparison fire."""
+    trick = Trick(trump)
+    trick.play("opener", C(Suit.HEARTS, "9"))
+    trick.play(ruffer, C(trump, "9"))
+    trick.play("sluffer", C(Suit.DIAMONDS, "9"))
+    return trick
+
+
+def test_proficient_follow_partner_ruff_is_not_a_forced_beat():
+    """The #173 bug, on the path Proficient and skills 1-3 take. A Heart cannot
+    beat a Spade at any rank, so this is not a forced beat and the seat must
+    fall through to the feed-partner tier and bank the King into a trick its own
+    side has already won. The old comparison fired here and threw the Queen."""
+    trump = Suit.SPADES
+    partner = "partner"
+    trick = _ruffed_trick(partner, trump)
+    hand = [C(Suit.HEARTS, "Q"), C(Suit.HEARTS, "K")]
+    legal = trick.legal_moves(hand)
+    assert len(legal) == 2, "both Hearts beat the led 9, so the beat is mandatory"
+    card = choose_follow_card(hand, legal, trick.plays, trump, {partner}, PlayTracker())
+    assert card.rank == "K", card
+
+
+def test_proficient_follow_opponent_ruff_changes_nothing():
+    """The other direction, pinned because it is the half that must *not* move.
+    Pinochle's rank order (9 J Q K 10 A) puts every non-counter strictly below
+    every counter, so the forced-beat tier and the dump-low tier pick the same
+    Queen - the fix is a null on the opponent side by construction, and this
+    records that rather than leaving it to be re-derived."""
+    trump = Suit.SPADES
+    trick = _ruffed_trick("opponent", trump)
+    hand = [C(Suit.HEARTS, "Q"), C(Suit.HEARTS, "K")]
+    legal = trick.legal_moves(hand)
+    card = choose_follow_card(hand, legal, trick.plays, trump, {"partner"}, PlayTracker())
+    assert card.rank == "Q", card
+
+
+def test_expert_follow_partner_ruff_is_not_a_forced_beat():
+    """The same bug in `_expert_follow_card_honest`, the copy skills 4-5 follow
+    with at the table (as opposed to only inside their rollouts)."""
+    trump = Suit.SPADES
+    partner = "partner"
+    trick = _ruffed_trick(partner, trump)
+    hand = [C(Suit.HEARTS, "Q"), C(Suit.HEARTS, "K")]
+    legal = trick.legal_moves(hand)
+    card = choose_expert_follow_card(hand, legal, trick.plays, trump, {partner}, PlayTracker())
+    assert card.rank == "K", card
+
+
+def test_expert_follow_opponent_ruff_changes_nothing():
+    """Opponent side of the expert path - unchanged, for the rank-order reason."""
+    trump = Suit.SPADES
+    trick = _ruffed_trick("opponent", trump)
+    hand = [C(Suit.HEARTS, "Q"), C(Suit.HEARTS, "K")]
+    legal = trick.legal_moves(hand)
+    card = choose_expert_follow_card(hand, legal, trick.plays, trump, {"partner"}, PlayTracker())
+    assert card.rank == "Q", card
+
+
+def test_forced_beat_over_trump_still_fires_on_an_all_trump_legal_set():
+    """The third `forced_beat` in `pinochle_engine.py` - inside
+    `_expert_follow_card_honest`'s `all_trump` branch - is *correct* on raw
+    `RANK_VALUE` and was deliberately left alone by #173: there every legal card
+    is trump and so is the card being compared against, which is the same-suit
+    precondition `Card.beats` exists to enforce. Pinned so a later pass at the
+    two sites above does not sweep this one up with them."""
+    trump = Suit.SPADES
+    trick = Trick(trump)
+    trick.play("opener", C(Suit.HEARTS, "9"))
+    trick.play("opponent", C(trump, "9"))
+    hand = [C(trump, "Q"), C(trump, "K")]
+    legal = trick.legal_moves(hand)
+    assert len(legal) == 2, "void of Hearts, holding trump - both trumps must beat the 9"
+    card = choose_expert_follow_card(hand, legal, trick.plays, trump, {"partner"}, PlayTracker())
+    assert card.rank == "Q", "cheapest sufficient over-trump, not a fall-through to protect/feed"
+
+
+def test_the_worked_example_is_decided_before_the_comparison_matters():
+    """#155's worked example, which is the position that makes the bug look
+    reachable and is not: partner leads the King of Diamonds, an opponent ruffs
+    with the 9 of trump, this seat holds the Ace and the 9 of Diamonds.
+    `Trick.legal_moves` forces the set to the Ace alone. `choose_follow_card`
+    then returns on its single-legal-move line without evaluating `forced_beat`
+    at all; the expert path has no such line, reaches the comparison, and plays
+    the Ace either way because it is the only card there is. A one-card legal
+    set can never distinguish the two readings - it is the multi-card positions
+    above that expose the bug."""
+    trump = Suit.SPADES
+    partner = "partner"
+    trick = Trick(trump)
+    trick.play(partner, C(Suit.DIAMONDS, "K"))
+    trick.play("opponent", C(trump, "9"))
+    hand = [C(Suit.DIAMONDS, "A"), C(Suit.DIAMONDS, "9")]
+    legal = trick.legal_moves(hand)
+    assert [c.rank for c in legal] == ["A"], legal
+    assert choose_follow_card(hand, legal, trick.plays, trump, {partner}, PlayTracker()).rank == "A"
+    expert = choose_expert_follow_card(hand, legal, trick.plays, trump, {partner}, PlayTracker())
+    assert expert.rank == "A", expert
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What was wrong

Both Python follow paths gated their forced-beat tier on

```python
all(RANK_VALUE[c.rank] > RANK_VALUE[winner_card.rank] for c in legal_moves)
```

`RANK_VALUE` is rank-only and suit-blind, and `_current_winner` returns a **trump**
whenever one has been played. So a partner who had ruffed in with the 9 of trump —
the lowest `RANK_VALUE` there is — read as beatable by every Queen in hand. The tier
fired, and the seat played its cheapest card into a trick its own side had already
won, never reaching the feed-partner tier below it that #164/#168 had just finished
tuning.

The same bug #155 fixed in `web/src/engine/tracker.ts`. Python carried a faithful
port of a reference bug, so fixing the port left the original standing — the same
shape as #154 → #164.

## The two sites fixed

Both are the `all_lead_suit and lead_suit != trump` branch, and both now read
`c.beats(winner_card, trump)` — trump over non-trump, else rank within the suit.
`Card.beats` already existed (`pinochle_engine.py:48`) and is the equivalent of the
TypeScript `beats(other, trump)`, so nothing new was written; the comparison is no
longer open-coded a third and fourth time.

| line (new) | function | reached by |
| --- | --- | --- |
| 675 | `choose_follow_card` | Proficient and `GeneralStrategy` skills 1–3 |
| 1676 | `_expert_follow_card_honest` | `GeneralStrategy` skills 4–5, at the table |

Every legal card in that branch is of the lead suit, so `Card.beats` returns `False`
against any trump — correctly: no card of the lead suit can take a trick a trump is
winning.

## The site deliberately left alone

**`_expert_follow_card_honest`'s `all_trump` branch** (line 1702 after the change)
still compares raw `RANK_VALUE`, and should. There `legal_moves` are all trump *and*
`current_best_trump` is trump by construction, so both sides of the comparison are
already the same suit — which is exactly the precondition `Card.beats` exists to
enforce. The rank comparison is the right one and converting it would be a
regression.

The only edit in that branch is a comment saying so, because `grep forced_beat`
returns three hits and the third looks identical out of context. That is the whole
diff there — no logic changed.

**It is also inert, which is the belt to that braces.** That tier and the
protect-count-card fallback beneath it return the *same card for every possible legal
set*: the rank order (9 J Q K 10 A) puts every non-counter strictly below every
counter, so "lowest legal card" and "lowest non-counter" coincide whenever a
non-counter exists. Checked exhaustively over all **2509** legal-set shapes up to six
cards — **zero disagreements**. So the predicate's value cannot change what that
branch plays, which is a second independent reason not to touch it, and is also why
`test_forced_beat_over_trump_still_fires_on_an_all_trump_legal_set` asserts the
branch's *behaviour* rather than the predicate's value: no test could assert the
latter.

## Blast radius, and the tests pinning both directions

The fixed reading is **strictly weaker** than the old one, so the only positions that
change are those where a trump was winning and the old comparison fired anyway. Of
those, only the ones where **partner** holds the trump change the card actually
played: pinochle's rank order (9 J Q K 10 A) puts every non-counter strictly below
every counter, so on the opponent side the forced-beat tier and the dump-low tier
pick the same card.

Six new tests in `test_trick_play_strategy.py`, section 9:

| test | pins |
| --- | --- |
| `test_proficient_follow_partner_ruff_is_not_a_forced_beat` | partner ruffs → feed the King, not the Queen (line 675) |
| `test_proficient_follow_opponent_ruff_changes_nothing` | opponent ruffs → still the Queen, the null half |
| `test_expert_follow_partner_ruff_is_not_a_forced_beat` | same, line 1676 |
| `test_expert_follow_opponent_ruff_changes_nothing` | same null half, line 1676 |
| `test_forced_beat_over_trump_still_fires_on_an_all_trump_legal_set` | the untouched third site still fires |
| `test_the_worked_example_is_decided_before_the_comparison_matters` | #155's worked example is forced to one legal card |

Checked against the pre-fix engine: exactly the two partner-ruff tests fail
(`AssertionError: QH_1, assert 'Q' == 'K'`), the two opponent-side tests pass in both
directions, and so does the all-trump one. The suite that would have caught this had
it existed now does.

#155's worked example (partner leads K♦, opponent ruffs 9♠, this seat holds A♦ and
9♦) turns out **not** to distinguish the two readings here either: `Trick.legal_moves`
forces the set to `{A♦}`, `choose_follow_card` returns on its single-legal-move line,
and the expert path reaches the comparison but has only one card to return. Pinned,
because it is the position that makes the bug look reachable and isn't.

## Measurement

`ab_harness.py`, per #164's approach. The legacy arm is a `Player` / `GeneralStrategy`
subclass in a scratch file outside the repo, expressed as a wrapper — "if the old
predicate would have fired, return what the old code returned, else defer to the
shipped function" — which reproduces the pre-fix behaviour exactly, since this diff
changes one predicate in each function and nothing else. `pinochle_engine.py` carries
no policy dial, as #126, #153, #154 and #164 established.

**Controls first**, per #153's rule that a dial must report nothing when nothing
differs:

- The legacy arm against itself, 200 pairs, seed 173: **all 200 split**, every paired
  margin exactly `0.00`, `NO EVIDENCE`.
- Dial-is-read probe before any number was believed: the two arms dumped against
  fixed positions returned **K♥ vs Q♥** on the divergent one (partner ruffs the 9 of
  trump) and identical cards on two controls (opponent ruffs; no trump on the table)
  — on *both* follow paths.

### The line-675 arm — run

5000 paired deals / 10 000 games per seed, fixed vs the pre-fix comparison,
Proficient on both sides:

| seed | margin/deal | 95% CI | swept | sign-test p | games |
| --- | --- | --- | --- | --- | --- |
| 173 | **+1.32** | +0.55 to +2.13 | 7–1 | 0.070 | 5006–4994 |
| 27 | **+2.01** | +1.20 to +2.94 | 11–3 | 0.057 | 5008–4992 |

**The margin interval excludes zero on both seeds; the sign test reaches significance
on neither**, off eight and fourteen decisive deals in 5000. That is the reading
#154's methodology note says to report as margin and not as games-won, and it is the
same shape #155 measured in TypeScript for this exact fix (+1.81 and +1.77 per deal,
12–4 and 7–1). Not a null, but a small effect honestly reported as a small one.

It is small because the position is rare, which is measured rather than asserted —
instrumented over 300 paired deals of Proficient play:

| | share of follow decisions |
| --- | --- |
| old predicate fired at all | 11.0% |
| ...against a **trump** winner (i.e. wrongly) | 2.4% |
| ...**and the card actually changed** | 0.19% |

The divergence needs three things at once: partner (not an opponent) ruffed in, this
seat still holds the lead suit, and the legal set holds both a counter and a
non-counter.

### The line-1676 arm — NOT reported here

Skills 4–5 are the only seats that reach the second site at the table, and that arm is
the slow, noisy one #164 flagged: **1.07 s/game against Proficient's 20 ms**, so 5000
paired deals is ~3 CPU-hours per seed, and #164 measured it at ~6× Proficient's noise
(260 decisive pairs vs 42). Two 5000-pair skill-4 runs (seeds 173 and 27) were started
and are still in flight at the time of writing; **their numbers are not in this PR and
nothing here is stretched to cover them.** They will be posted to #173 as a comment
when they land, and if they do not land they will be reported as not run.

**Registered in advance: expect that arm to come back a null, and do not read the null
as evidence against the fix.** The same instrumentation run against skill 4, 250 paired
deals / 500 games:

| | Proficient (line 675) | skill 4 (line 1676) |
| --- | --- | --- |
| old predicate fired | 11.0% | 15.6% |
| ...against a trump winner | 2.4% | 1.41% |
| ...**and the card changed** | **0.19%** | **0.009%** (4 of 43 236) |
| changed decisions per game | ~0.16 | ~0.008 |

The divergent position is **twenty times rarer** at skill 4 than at Proficient, on an
arm that is already six times noisier. Those two facts together mean the skill-4 A/B
essentially cannot resolve an effect of this size — the same structural reason #164's
skill-4 arm was a null there, stated before the numbers are in rather than after. Why
the position is so much rarer at that tier is observed, not explained: expert leads,
passes and ruffing decisions differ enough that partner-ruffs-while-this-seat-still-
holds-the-lead-suit-with-a-mixed-legal-set barely arises.

What is *not* contingent on any of that: the second site is fixed, pinned by two tests
in both directions, and correct for the same reason the first one is. A measurement
would tell us what it is worth, not whether it is right.

## Checks

- `python -m pytest -q` → **304 passed** (298 before, 6 new)
- `python export_evaluator.py --check` → up to date
- `python export_parity_scenarios.py --check` → up to date

Both `--check` targets render from committed artifacts (`rollout_evaluator.json`,
`parity_scenarios.json`) rather than from live AI decisions, so an AI change is not
expected to make them stale — run anyway, per #164.

## Scope note

The TypeScript side is untouched: #155 fixed it there, and #158 is live in
`web/src/engine/tracker.ts` concurrently. This PR is Python-only.

`chooseForcedBeat`'s *selection* rule (non-counter first, then the lowest counter that
cannot be beaten, then the lowest counter) is **not** ported here. #173 scopes to the
detection, and tiers 1 and 3 pick the card `min(..., key=RANK_VALUE)` already picks for
the rank-order reason above, so porting it would be a no-op restructure that collides
with whatever a Python #158 does. Left for that issue.

Closes #173
