### PR TITLE
Partner-passed bid floor: reach the opener threshold, not clear it (#180)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -449,7 +449,8 @@ encode "strictly above `OPENER_THRESHOLD`" by someone thinking in ceiling points
 rather than in bids. `OPENER_THRESHOLD` and `DEFENSIVE_PUSH_FLOOR` really are
 points — thresholds a hand's valuation is compared against, where 321 is a
 perfectly ordinary number — and the floor sits one line away from them but is an
-actual bid placed on the table. It is now `PARTNER_PASSED_FLOOR = 330`.
+actual bid placed on the table. It became `PARTNER_PASSED_FLOOR = 330`, and
+#180 then took it to **320** — see "Reach, not clear" below.
 
 What it cost while it was wrong, over 20 000 headless auctions: **11 553 of
 40 200 bids placed — 28.7% — were not multiples of 10**, and 18.3% of deals
@@ -460,14 +461,15 @@ it reseeds `currentBid`: from 321 the ladder runs 331, 341, 351, and
 the human "Minimum: 331" — a number the +/− buttons, which step in tens, cannot
 produce. Typing 340 by hand works. Nothing says so.
 
-**Why 330 and not 320**, since both are legal and the code and its comment
-disagreed about which was meant. The rule (#93/#95) is that a seat whose partner
-has passed is buying the contract alone and must *clear* the opener threshold,
-not merely equal it — and `chooseBid` already says exactly that one tier up, in
-the other direction: it wants `ceiling > OPENER_THRESHOLD` when the partner has
-passed against `ceiling >= OPENER_THRESHOLD` when they have not. 320 would make
-the floor "at least 320" and leave that strict `>` arbitrary. So 330, on the
-rule, not on the arithmetic.
+**Why 330 and not 320** was #179's reading, since both are legal and the code
+and its comment disagreed about which was meant. The rule (#93/#95) is that a
+seat whose partner has passed is buying the contract alone and must *clear* the
+opener threshold, not merely equal it — and `chooseBid` said exactly that one
+tier up, in the other direction: it wanted `ceiling > OPENER_THRESHOLD` when the
+partner had passed against `ceiling >= OPENER_THRESHOLD` when they had not. 320
+would make the floor "at least 320" and leave that strict `>` arbitrary. So 330,
+on the rule, not on the arithmetic. #180 overturned that reading; the paragraphs
+below are the state at the time, kept because the numbers are still the record.
 
 Measured with a throwaway `partnerPassedFloor` field on `SkillParams` plus a
 temporary `cli.ts floor --baseline N` command, added in the shape the section
@@ -498,12 +500,13 @@ per deal is the price of the ladder being legal.
 
 That one is not small and it is not ambiguous: four seeds, four intervals
 excluding zero, ~10 points per deal — larger than #159's +7.61 and #154's +3.55,
-both of which shipped on their numbers. **320 plays better than 330.** It is
+both of which shipped on their numbers. **320 plays better than 330.** It was
 left unshipped deliberately, because it is a different question: #177 is a
 legality fix, both candidates are legal, and lowering the floor changes what
 #93/#95's rule *means* rather than correcting how it is spelled. Deciding that
 on a strength number alone would settle a design rule in passing under cover of
-a bug fix. It wants its own issue, and this table is the evidence for it.
+a bug fix. It wanted its own issue, and this table is the evidence that opened
+it (#180).
 
 Controls, run first as the section below requires: `selftest --policy distilled`
 split all 200 pairs with a paired margin of exactly 0, and so did the floor arm
@@ -511,6 +514,88 @@ against itself (`floor --baseline 330`), which is the same check for the new
 dial. The dial's ability to *see* a change is carried by the 320 rows rather than
 by a deliberately-bad arm — four intervals that clean is not what a field which
 is written but never read produces.
+
+### Reach, not clear (#180)
+
+Paul's call, 2026-08-02: **a seat whose partner has passed must reach the opener
+threshold, not clear it.** So `PARTNER_PASSED_FLOOR` is 320, and the `>` / `>=`
+asymmetry one tier up is gone — `chooseBid`'s static verdict now asks
+`ceiling >= OPENER_THRESHOLD` in both branches, because the only thing that
+asymmetry ever encoded was the "clear" intent that has now been retired.
+
+That second half is a **behaviour change the ~10-per-deal table above did not
+measure.** It lets a hand whose ceiling is exactly 320 open where it previously
+declined, and ceilings move in tens, so it is a whole rung of hands rather than a
+rounding edge. And `main` had moved: #178's auto-SET ends ~7% of contracts before
+the first lead and #158 shipped, both of which change which deals reach trick
+play. Everything below is a re-baseline, not a comparison against the older rows.
+
+**The two halves live on opposite sides of the `bidPolicy` gate**, which is the
+first thing this measurement found and the thing a reviewer should check by eye:
+
+- The **floor** is read unconditionally, so it moves every level whose bidding
+  reaches `chooseBid`'s Base Bid path — `medium` through `expert`. (`easy` short-
+  circuits into `meldOnlyBid` and never sees it.)
+- The **ceiling comparison** is only ever passed to `worthContract` as its
+  `staticVerdict`, and a `'distilled'` level discards that argument. So the
+  collapse is *inert* on `hard`, `proficient` and `expert`, and only `medium`
+  ("Apprentice") plays differently for it.
+
+So the three arms were run under both policies. Side A is current `main`
+(330 + `>`); 5000 paired deals / 10 000 games per row.
+
+**`'distilled'` — `hard`, `proficient`, `expert`, and the default seats:**
+
+| seed | (a) vs constant-only 320 | (b) vs the full change | (c) constant-only vs full |
+| --- | --- | --- | --- |
+| 1 | **−9.95** (−14.91 to −5.13) | **−9.95** (−14.91 to −5.13) | 0.00 (0.00 to 0.00) |
+| 2 | **−8.08** (−12.63 to −3.30) | **−8.08** (−12.63 to −3.30) | 0.00 (0.00 to 0.00) |
+| 3 | **−11.05** (−15.90 to −6.17) | **−11.05** (−15.90 to −6.17) | 0.00 (0.00 to 0.00) |
+
+(a) and (b) are not merely close, they are bit-identical, and (c) is exactly zero
+with every pair split and identical contract counts on both sides. That is the
+prediction from reading `worthContract` — confirmed as a number rather than
+asserted. All three (a)/(b) intervals exclude zero and land on the ~10 the old
+four-seed table gave, so the constant survived re-baselining onto #178/#158.
+
+**`'static'` — `medium`, the only level the collapse can reach:**
+
+| seed | (a) vs constant-only 320 | (b) vs the full change | (c) constant-only vs full |
+| --- | --- | --- | --- |
+| 1 | **−25.90** (−31.22 to −20.77) | **−30.63** (−36.70 to −24.94) | **−3.57** (−6.14 to −0.97) |
+| 2 | **−26.63** (−31.82 to −21.49) | **−32.22** (−37.89 to −26.49) | **−5.21** (−7.93 to −2.60) |
+| 3 | **−28.39** (−33.55 to −23.28) | **−31.99** (−37.62 to −26.39) | **−3.93** (−6.39 to −1.53) |
+
+**The collapse does not fight the constant; it adds to it.** (b) is larger than
+(a) on every seed, and (c) — the two changes head to head, which is the only row
+that isolates the comparison — excludes zero on all three, worth another 3.6 to
+5.2 points a deal in the same direction. Column (c) is reported rather than
+averaged into (b) precisely because the reverse result would have been the
+interesting one.
+
+Why `'static'` moves three times as far as `'distilled'`: the threshold rule is
+a blunter instrument, so it is more exposed to where the threshold sits.
+Make-rate moves with margin on every row (68.4% → 70.7% on static seed 1,
+70.5% → 71.4% on distilled seed 1), which is the check #126 exists to force —
+the cheaper floor is buying contracts it makes, not contracts it is set on.
+
+Controls, run first: the arm against itself split every pair at a paired margin
+of exactly **0.00** under both policies, with identical contract counts. That
+control is also what caught the one real trap in this rig. A bidding A/B has to
+carry its two arms on two skill levels, and #157 keys `TRUMP_MEMORY_CAPACITY` on
+the *level* rather than on `SkillParams` — `hard` remembers 6 trump, `expert` 10
+— so the first self-test came back one decisive pair and −1 per deal instead of
+0.00. #158 measured that same gap at ~6 points a deal. The rig pins both arms to
+one capacity for the run; without that, every number above would have had a
+trick-play difference folded into it.
+
+The throwaway rig was a `PartnerPassedRule` field on `SkillParams` naming the
+*whole* rule (`clear` / `floor-only` / `reach`) rather than #179's floor number,
+a `bidFloorAbPolicies` factory, a capacity equaliser and a `cli.ts floor --a X
+--b Y --policy P` command — all deleted before committing, the same call #126,
+#153, #154 and #159 made. Naming the rule rather than the number is what makes
+column (c) exist at all: an arm carrying only the constant cannot measure the
+comparison, and would have shipped the collapse unmeasured.
 
 ### "Cannot be beaten", and the first place skill decides a card (#158)
 

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -552,17 +552,53 @@ describe('every bid chooseBid can return is legal (#177)', () => {
     expect(offGrid.slice(0, 10)).toEqual([])
   }, 30_000)
 
-  it('takes the partner-passed floor to 330, the first legal bid clearing OPENER_THRESHOLD', () => {
-    // The decision the fix encodes, asserted directly rather than only through
-    // the sweep: 330 is not an arbitrary rounding of 321, it is "above 320" —
-    // the same strictness `chooseBid`'s static verdict applies to the ceiling
-    // when the partner has passed.
-    expect(PARTNER_PASSED_FLOOR).toBe(330)
+  it('takes the partner-passed floor to OPENER_THRESHOLD itself (#180)', () => {
+    // **What this used to assert, and why it changed.** #179 pinned
+    // `PARTNER_PASSED_FLOOR` to 330 with a `- OPENER_THRESHOLD === 10` guard
+    // whose stated purpose was "guards against a later 'simplify' that sets the
+    // floor to OPENER_THRESHOLD itself". #180 is that change — made as a
+    // decision rather than as a simplification. Paul's call is that a seat
+    // bidding alone must *reach* the opener threshold, not clear it, and 320
+    // measured 8-11 points per deal ahead of 330 on the shipped levels
+    // (`web/README.md`). The guard is inverted rather than deleted, so a later
+    // drift back to 330 fails here just as loudly.
+    expect(PARTNER_PASSED_FLOOR).toBe(320)
+    expect(PARTNER_PASSED_FLOOR).toBe(OPENER_THRESHOLD)
+    // Unchanged, and the part #177 was actually about: the floor is a bid, not
+    // a ceiling, so it has to be one the ladder and the +/- buttons can reach.
+    // 321 fails this; 320 and 330 both pass, which is why the choice between
+    // them was a design question and not a correctness one.
     expect(PARTNER_PASSED_FLOOR % 10).toBe(0)
-    expect(PARTNER_PASSED_FLOOR).toBeGreaterThan(OPENER_THRESHOLD)
-    // 320 would also be a legal bid; it is rejected because it only *equals*
-    // the threshold. Guards against a later "simplify" that sets the floor to
-    // OPENER_THRESHOLD itself.
-    expect(PARTNER_PASSED_FLOOR - OPENER_THRESHOLD).toBe(10)
+    expect(PARTNER_PASSED_FLOOR).toBeGreaterThanOrEqual(OPENING_BID)
+  })
+
+  it('opens a partner-passed seat on a ceiling of exactly OPENER_THRESHOLD (#180)', () => {
+    // The half of #180 the constant swap does not cover, and the half the
+    // ~10-per-deal table did not measure: collapsing
+    // `partnerPassed ? ceiling > OPENER_THRESHOLD : ceiling >= ...` to one
+    // `>=` lets a hand whose ceiling is *exactly* 320 open where it used to
+    // decline. Ceilings move in tens, so that is a whole rung of hands, not a
+    // rounding edge.
+    //
+    // Pinned to `medium`, the one shipped level still on `bidPolicy: 'static'`
+    // — a `'distilled'` level discards the static verdict entirely, so this
+    // branch is only reachable there (see `worthContract`). Asserting the
+    // ceiling first so a drift in the valuation constants fails as itself
+    // rather than as a bidding regression.
+    const ceiling320Hand = [...RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1)), new Card(Suit.Spades, 'A', 1)]
+    const { trump, total } = bestBaseBid(ceiling320Hand, 0, 0)
+    expect(trump).toBe(Suit.Hearts)
+    expect(total).toBe(OPENER_THRESHOLD) // Run 150 + two Aces 40 + baseline adj 130
+
+    // 4th bidder (dealer), partner (seat 2) has passed, nobody has bid.
+    const context: AuctionContext = {
+      everBid: false,
+      passesSoFar: 3,
+      bidHistory: [],
+      dealer: 0,
+      scores: { 0: 0, 1: 0 },
+      passedPlayers: [2],
+    }
+    expect(chooseBid(0, ceiling320Hand, OPENING_BID - 10, 10, context, 'medium')).toBe(PARTNER_PASSED_FLOOR)
   })
 })

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -80,26 +80,33 @@ export const DEFENSIVE_PUSH_FLOOR = 200
  * the right *intent* and an impossible *bid*. Once any seat bid 321 the whole
  * ladder went off-grid (331, 341, ...) and `BiddingControls` — which gates its
  * Bid button on `amount % 10 === 0` — displayed a minimum the human could not
- * reach with the +/- buttons.
+ * reach with the +/- buttons. That is why this constant exists at all, and it
+ * is the part of it that is not negotiable: whatever value sits here has to be
+ * a legal bid.
  *
- * Why 330 and not 320. The rule this encodes is that a hand bidding alone must
- * *clear* the opener threshold, not merely equal it: with no partner left to
- * speak, the seat is buying the contract outright, so it should be worth more
- * than the hand that would open with help still to come. `chooseBid`'s static
- * verdict one tier up already says so in the other direction — it asks for
- * `ceiling > OPENER_THRESHOLD` when the partner has passed against
- * `ceiling >= OPENER_THRESHOLD` when they have not. 320 would make the floor
- * "at least 320", which collapses that distinction and makes the strict `>` on
- * the ceiling arbitrary. The next legal bid above 320 is 330.
+ * *Which* legal bid was a design question, and #180 settled it — **reach the
+ * opener threshold, do not clear it.** #179 shipped 330 on the other reading:
+ * a seat whose partner has passed is buying the contract outright, so it should
+ * be worth more than the hand that would open with help still to come, and the
+ * strict `>` that `chooseBid`'s static verdict applied to the ceiling one tier
+ * up was that same intent spelled a second way. Paul's call (2026-08-02) is
+ * that bidding alone is a reason to *demand* the threshold, not a reason to
+ * demand ten points past it — so the floor is the threshold's own value, and
+ * the asymmetry that existed only to encode "clear" goes with it: the static
+ * verdict now asks `ceiling >= OPENER_THRESHOLD` whether or not the partner has
+ * passed.
  *
- * That settles what the rule *means*. It does not settle which value plays
- * better, and those turned out to differ: 320 measures ~10 points per deal
- * ahead of 330 over 5000 paired deals, replicated on four seeds (`web/README.md`,
- * "The partner-passed bid floor"). #177 is a legality fix and both candidates
- * are legal, so that is left as an open strategy question rather than settled
- * in passing by a bug fix.
+ * Still spelled as its own constant rather than as `OPENER_THRESHOLD`, because
+ * the two are different kinds of number that presently coincide — that one is a
+ * ceiling a valuation is compared against, this one is a bid placed on the
+ * table. #177 is what conflating them costs.
+ *
+ * The measurement is what raised the question, and it survived re-baselining
+ * onto #178 and #158: 320 plays 8-11 points per deal ahead of 330 on the
+ * `'distilled'` levels and 26-32 on `'static'`, over 5000 paired deals on each
+ * of three seeds (`web/README.md`, "The partner-passed bid floor").
  */
-export const PARTNER_PASSED_FLOOR = 330
+export const PARTNER_PASSED_FLOOR = 320
 
 function handCount(hand: readonly Card[], suit: Suit, rank: Rank): number {
   return hand.reduce((count, c) => count + (c.suit === suit && c.rank === rank ? 1 : 0), 0)
@@ -387,8 +394,9 @@ export interface AuctionContext {
   /** Cumulative game score per team, going into this round. */
   readonly scores: Record<TeamId, number>
   /** Players who have passed so far this auction. Used to detect when a
-   * partner has passed so the remaining bidder knows to raise the floor to
-   * 320. */
+   * partner has passed so the remaining bidder knows to raise its floor to
+   * `PARTNER_PASSED_FLOOR`. (This comment said 320 while the code said 321 —
+   * the #177 disagreement. Naming the constant is what stops it recurring.) */
   readonly passedPlayers: readonly PlayerIndex[]
 }
 
@@ -475,10 +483,10 @@ export function chooseBid(
 
   // When partner has already passed they cannot come back in (#93), so a bid
   // here is one this hand must carry alone — which means committing to
-  // PARTNER_PASSED_FLOOR (330), the first legal bid clearing OPENER_THRESHOLD.
-  // That raises the *bid floor*, not the hand's ceiling: the ceiling still
-  // reflects what the cards are actually worth, so a hopeless hand declines
-  // rather than being talked into a 330 it cannot make.
+  // PARTNER_PASSED_FLOOR (320), the opener threshold itself (#180: reach it,
+  // do not clear it). That raises the *bid floor*, not the hand's ceiling: the
+  // ceiling still reflects what the cards are actually worth, so a hopeless
+  // hand declines rather than being talked into a 320 it cannot make.
   const minBidAfterPartnerPass = Math.max(PARTNER_PASSED_FLOOR, currentBid + minIncrement)
 
   // "Is this hand worth committing to a contract at `level`?" — the single
@@ -516,15 +524,15 @@ export function chooseBid(
       return OPENING_BID
     }
 
-    // With partner passed the bid must clear OPENER_THRESHOLD (so, 330), so the
-    // static rule wants the ceiling strictly above the opener threshold rather
-    // than merely level with it. (Ceilings move in tens, so the two differ only
-    // at exactly 320.)
+    // One comparison, whether or not the partner has passed (#180). This read
+    // `partnerPassed ? ceiling > OPENER_THRESHOLD : ceiling >= OPENER_THRESHOLD`
+    // — the second place "a lone bidder must *clear* the threshold" was written
+    // down, the first being PARTNER_PASSED_FLOOR itself. With that intent
+    // retired the two branches say the same thing, so they are one. The level
+    // being committed to still differs: a partner-passed seat opens at the
+    // floor rather than at OPENING_BID.
     const openingLevel = partnerPassed ? minBidAfterPartnerPass : OPENING_BID
-    const opens = worthContract(
-      openingLevel,
-      partnerPassed ? ceiling > OPENER_THRESHOLD : ceiling >= OPENER_THRESHOLD,
-    )
+    const opens = worthContract(openingLevel, ceiling >= OPENER_THRESHOLD)
 
     // 3rd bidder opens cheap.
     if (context.passesSoFar === 2) {
@@ -581,8 +589,8 @@ export function chooseBid(
     return pushLevel
   }
 
-  // When partner passed, the bid must clear OPENER_THRESHOLD regardless of
-  // ceiling — so PARTNER_PASSED_FLOOR (330), not a bid one point over 320.
+  // When partner passed, the bid must reach OPENER_THRESHOLD regardless of
+  // ceiling — so PARTNER_PASSED_FLOOR (320), not the next rung of the ladder.
   if (partnerPassed && nextBid < PARTNER_PASSED_FLOOR) {
     return competitiveCeiling >= PARTNER_PASSED_FLOOR ? PARTNER_PASSED_FLOOR : null
   }


### PR DESCRIPTION
Closes #180

**Paul's call, 2026-08-02: a seat whose partner has passed must *reach* the
opener threshold, not clear it.** So `PARTNER_PASSED_FLOOR` is 320, and the
`>` / `>=` split one tier up goes with it.

## The two changes

1. `PARTNER_PASSED_FLOOR` 330 → 320.
2. `partnerPassed ? ceiling > OPENER_THRESHOLD : ceiling >= OPENER_THRESHOLD`
   → `ceiling >= OPENER_THRESHOLD`. That ternary existed *only* to encode
   clear-not-reach — it was the same rule written down a second time. With the
   intent retired the two branches say the same thing, so it collapses rather
   than being left as a dead ternary that reads like a live distinction.

What does **not** change is why the constant exists at all. #177 was `320 + 1`
— "strictly above `OPENER_THRESHOLD`" written by someone thinking in ceiling
points rather than in bids — and 321 took the whole ladder off the grid (331,
341, 351) and showed the human a "Minimum: 331" the +/− buttons cannot produce.
Both 320 and 330 are legal, which is exactly why choosing between them was a
design question and not a correctness one.

## Measurement

(2) is a second behaviour change and the old ~10/deal table did not cover it:
it lets a hand whose ceiling is *exactly* 320 open where it previously
declined, and ceilings move in tens. `main` had also moved — #178's auto-SET
ends ~7% of contracts before the first lead, #158 shipped — so everything below
is a **re-baseline**, not a comparison against #179's rows.

### The two halves live on opposite sides of the `bidPolicy` gate

This is the first thing the measurement turned up and the thing to check by eye:

- The **floor** is read unconditionally, so it moves `medium` through `expert`.
  (`easy` short-circuits into `meldOnlyBid` and never reaches this code.)
- The **ceiling comparison** is only ever passed to `worthContract` as its
  `staticVerdict`, and a `'distilled'` level discards that argument outright. So
  the collapse is **inert on `hard`, `proficient` and `expert`**, and only
  `medium` ("Apprentice") plays differently for it.

So all three arms were run under both policies. Side A is current `main`
(330 + `>`). 5000 paired deals / 10 000 games per row, seeds 1–3.

### `'distilled'` — `hard`, `proficient`, `expert`, and the default seats

| seed | (a) vs constant-only 320 | (b) vs the full change | (c) constant-only vs full |
| --- | --- | --- | --- |
| 1 | **−9.95** (−14.91 to −5.13) | **−9.95** (−14.91 to −5.13) | 0.00 (0.00 to 0.00) |
| 2 | **−8.08** (−12.63 to −3.30) | **−8.08** (−12.63 to −3.30) | 0.00 (0.00 to 0.00) |
| 3 | **−11.05** (−15.90 to −6.17) | **−11.05** (−15.90 to −6.17) | 0.00 (0.00 to 0.00) |

(a) and (b) are not merely close, they are **bit-identical**, and (c) is exactly
zero — every pair split, identical contract counts on both sides. That is the
prediction from reading `worthContract`, confirmed as a number rather than
asserted from the code. All six (a)/(b) intervals exclude zero and land on the
~10 the old four-seed table gave, so the constant survived re-baselining.

### `'static'` — `medium`, the only shipped level the collapse can reach

| seed | (a) vs constant-only 320 | (b) vs the full change | (c) constant-only vs full |
| --- | --- | --- | --- |
| 1 | **−25.90** (−31.22 to −20.77) | **−30.63** (−36.70 to −24.94) | **−3.57** (−6.14 to −0.97) |
| 2 | **−26.63** (−31.82 to −21.49) | **−32.22** (−37.89 to −26.49) | **−5.21** (−7.93 to −2.60) |
| 3 | **−28.39** (−33.55 to −23.28) | **−31.99** (−37.62 to −26.39) | **−3.93** (−6.39 to −1.53) |

**The `>=` collapse does not fight the constant — it adds to it.** (b) beats (a)
on every seed, and (c), the head-to-head that isolates the comparison, excludes
zero on all three at a further 3.6–5.2 points a deal in the same direction.
Column (c) is reported rather than averaged into (b) precisely because the
reverse result is the one that would have mattered.

Why `'static'` moves roughly three times as far as `'distilled'`: the threshold
rule is a blunter instrument and so is more exposed to where the threshold sits.
Make-rate moves *with* margin on every row (68.41% → 70.65% on static seed 1,
70.47% → 71.39% on distilled seed 1), which is the check #126 exists to force —
the cheaper floor is buying contracts it makes, not contracts it is set on.

### Controls, and the trap one of them caught

The arm against itself split every pair at a paired margin of exactly **0.00**
under both policies, with identical contract counts.

That control also earned its keep. A bidding A/B has to carry its two arms on
two skill levels, and #157 keys `TRUMP_MEMORY_CAPACITY` on the **level** rather
than on `SkillParams` — `hard` remembers 6 trump, `expert` 10. The first
self-test came back one decisive pair and −1 per deal instead of 0.00 for
exactly that reason, and #158 measured that same gap at ~6 points a deal. The
rig pins both arms to one capacity for the duration of a run; without it every
number above would have had a trick-play difference folded into it.

### The rig, and why it named the rule rather than the number

A throwaway `PartnerPassedRule` field on `SkillParams` selecting the *whole*
rule (`clear` / `floor-only` / `reach`), a `bidFloorAbPolicies` factory, the
capacity equaliser, and a `cli.ts floor --a X --b Y --policy P` command — **all
deleted before committing**, the same call #126, #153, #154 and #159 made.

#179's rig carried a floor *number*. That would have measured (a) and shipped
(b), because the comparison is not a number — an arm carrying only the constant
cannot produce column (c) at all.

## Tests

- **#177's multiple-of-10 property test over `chooseBid` is untouched and still
  passes.** 320 is a legal multiple of 10, so it should, and it does — that
  invariant is the part of #177 that was never up for debate.
- `biddingSim.test.ts`'s end-to-end off-grid sweep: untouched, passing.
- The test that pinned 330 specifically is **inverted, not deleted**, and
  carries what it used to assert. It had a
  `PARTNER_PASSED_FLOOR - OPENER_THRESHOLD === 10` guard whose stated purpose
  was "guards against a later 'simplify' that sets the floor to
  `OPENER_THRESHOLD` itself" — this PR *is* that change, made as a decision
  rather than as a simplification, so the guard is inverted so a drift back to
  330 fails just as loudly.
- **New:** `opens a partner-passed seat on a ceiling of exactly
  OPENER_THRESHOLD (#180)` pins the collapse itself, on `medium` since that is
  the only level it reaches. It **fails on the old comparison** (returns `null`)
  and passes on the new one — checked by restoring the ternary before
  committing.

## Checks

`npx tsc -b` clean · `npm test` 407 passed, 39 files · `npm run build` clean
(260.62 kB, unchanged) · `oxlint` — the three pre-existing `exhaustive-deps`
warnings on `main`, nothing new · `python -m pytest -q` 298 passed.

`web/` only; `pinochle_engine.py` is untouched, and has no equivalent of this
constant (TypeScript-only, not a port slip — same as #177).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
