### PR TITLE
Phone layout: two-row hand, menu inside the scoreboard, circle centred on the board (#187)

### DIFF
--- a/web/src/components/Scoreboard.test.tsx
+++ b/web/src/components/Scoreboard.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Suit } from '../engine/card'
+import { Scoreboard } from './Scoreboard'
+
+afterEach(cleanup)
+
+const SCORES = { 0: 120, 1: 90 }
+const TEAM_NAMES = { 0: 'Meld Squad', 1: 'Quantum Drifters' }
+
+function renderStrip(props: Partial<Parameters<typeof Scoreboard>[0]> = {}) {
+  return render(
+    <Scoreboard
+      scoresByTeam={SCORES}
+      teamNames={TEAM_NAMES}
+      currentBid={320}
+      trumpSuit={Suit.Spades}
+      {...props}
+    />,
+  )
+}
+
+describe('Scoreboard', () => {
+  it('shows the scores, the standing bid and trump', () => {
+    renderStrip()
+    expect(screen.getByText('Meld Squad:')).not.toBeNull()
+    expect(screen.getByText('320')).not.toBeNull()
+    expect(screen.getByText('♠')).not.toBeNull()
+  })
+
+  // #187: the menu button used to be an `absolute top-2 left-2 z-10` sibling in
+  // Table, painted over this strip's first line — on a phone "☰ Menu" sat across
+  // "Trump: —". Rendering it as the strip's leading item is what makes the
+  // collision impossible rather than merely unlikely, so the ownership is the
+  // thing worth pinning.
+  it('renders the menu button as its own leading item when onOpenMenu is given', () => {
+    const onOpenMenu = vi.fn()
+    const { container } = renderStrip({ onOpenMenu })
+    const strip = container.firstElementChild
+    const button = screen.getByRole('button', { name: 'Open menu' })
+    expect(button.parentElement).toBe(strip)
+    expect(strip?.firstElementChild).toBe(button)
+    expect(button.className).not.toContain('absolute')
+  })
+
+  it('fires onOpenMenu when the button is pressed', () => {
+    const onOpenMenu = vi.fn()
+    renderStrip({ onOpenMenu })
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+    expect(onOpenMenu).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders no menu button at all when onOpenMenu is omitted', () => {
+    renderStrip()
+    expect(screen.queryByRole('button', { name: 'Open menu' })).toBeNull()
+  })
+})

--- a/web/src/components/Scoreboard.tsx
+++ b/web/src/components/Scoreboard.tsx
@@ -14,12 +14,19 @@ export interface ScoreboardProps {
   trumpSuit: Suit | null
   /** Meld points of the bidding team, shown after meld declaration. */
   meldPoints?: number
+  /** Opens the mid-game menu (#54). Rendered as the strip's leading item rather
+   * than floated over the table (#187): as an `absolute top-2 left-2` button it
+   * was drawn on top of this strip's first line — "☰ Menu" sat across
+   * "Trump: —" on a phone. Reserving space for it instead would have pushed the
+   * centred strip off-centre by half the button; putting it *in* the flow costs
+   * nothing and cannot collide. Omitted entirely when not provided. */
+  onOpenMenu?: () => void
 }
 
 /** Top strip: cumulative team scores, the standing bid, and trump. Stays
  * mounted throughout bidding/passing/trick-play so those flows (separate
  * issues) can render alongside it without needing their own scoreboard. */
-export function Scoreboard({ scoresByTeam, teamNames, currentBid, bidWinnerName, trumpSuit, meldPoints }: ScoreboardProps) {
+export function Scoreboard({ scoresByTeam, teamNames, currentBid, bidWinnerName, trumpSuit, meldPoints, onOpenMenu }: ScoreboardProps) {
   const trumpColor = trumpSuit && RED_SUITS.includes(trumpSuit) ? 'text-red-400' : 'text-white'
 
   return (
@@ -28,6 +35,16 @@ export function Scoreboard({ scoresByTeam, teamNames, currentBid, bidWinnerName,
     // leaving a bare band of table felt above it. Gutters are tightened from
     // gap-x-6/px-4 so the five items pack into fewer wrapped lines on a phone.
     <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-0.5 bg-green-950 pt-[calc(0.375rem_+_var(--safe-top))] pr-[calc(0.5rem_+_var(--safe-right))] pb-1.5 pl-[calc(0.5rem_+_var(--safe-left))] text-sm text-white shadow-md">
+      {onOpenMenu && (
+        <button
+          type="button"
+          onClick={onOpenMenu}
+          aria-label="Open menu"
+          className="rounded bg-black/40 px-2 py-0.5 text-xs font-semibold text-white hover:bg-black/60"
+        >
+          ☰ Menu
+        </button>
+      )}
       <span>
         Trump:{' '}
         <span className={`text-lg font-semibold ${trumpColor}`}>

--- a/web/src/components/Seat.test.tsx
+++ b/web/src/components/Seat.test.tsx
@@ -1,6 +1,7 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
-import { Card, Suit } from '../engine/card'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Card, sortHandForDisplay, Suit } from '../engine/card'
+import { splitHandIntoRows } from './handRows'
 import { Seat } from './Seat'
 import type { SeatState } from './tableTypes'
 
@@ -44,5 +45,125 @@ describe('Seat', () => {
     expect(screen.getByLabelText('K of H')).not.toBeNull()
     expect(screen.getByLabelText('Q of H')).not.toBeNull()
     expect(screen.queryAllByLabelText('face-down card')).toHaveLength(0)
+  })
+})
+
+// #187: one row of 12 overflowed below ~350px, and an overflowing
+// `justify-center` row centres inside its own scroll box — so the fan was
+// clipped at the right with its leading cards unreachable. Two rows halve the
+// width that has to fit.
+describe('splitHandIntoRows', () => {
+  const hand = (n: number) => Array.from({ length: n }, (_, i) => i)
+
+  it('splits a full 12-card hand evenly', () => {
+    expect(splitHandIntoRows(hand(12))).toEqual([[0, 1, 2, 3, 4, 5], [6, 7, 8, 9, 10, 11]])
+  })
+
+  it('puts the extra card on the top row for an odd hand', () => {
+    // Grows upward, so an odd hand does not leave a short trailing row under a
+    // full one — and the bottom row is never the wider of the two.
+    expect(splitHandIntoRows(hand(11))).toEqual([[0, 1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    expect(splitHandIntoRows(hand(7))).toEqual([[0, 1, 2, 3], [4, 5, 6]])
+  })
+
+  it('keeps a short hand on a single row', () => {
+    // The last tricks play out at 1-2 cards; two rows of one card each would
+    // read as a layout fault rather than a hand.
+    expect(splitHandIntoRows(hand(6))).toEqual([[0, 1, 2, 3, 4, 5]])
+    expect(splitHandIntoRows(hand(1))).toEqual([[0]])
+    expect(splitHandIntoRows(hand(0))).toEqual([[]])
+  })
+
+  it('never leaves a row wider than the single-row limit', () => {
+    // The property that actually protects the layout: whatever the hand size,
+    // no row exceeds what fits a 320px viewport.
+    for (let n = 0; n <= 24; n += 1) {
+      for (const row of splitHandIntoRows(hand(n))) {
+        expect(row.length).toBeLessThanOrEqual(Math.max(6, Math.ceil(n / 2)))
+        if (n <= 12) expect(row.length).toBeLessThanOrEqual(6)
+      }
+    }
+  })
+
+  it('preserves the sorted order across the split', () => {
+    expect(splitHandIntoRows(hand(12)).flat()).toEqual(hand(12))
+  })
+})
+
+describe('Seat hand layout (#187)', () => {
+  const RANKS = ['A', '10', 'K', 'Q', 'J', '9'] as const
+
+  /** n distinct cards — `key={card.toString()}` collides on a duplicate, and a
+   *  hand of repeats would silently test one card rendered n times. */
+  function humanHand(n: number): SeatState {
+    return {
+      player: 0,
+      name: 'You',
+      hand: Array.from(
+        { length: n },
+        (_, i) => new Card(i < 6 ? Suit.Spades : Suit.Hearts, RANKS[i % RANKS.length], 1),
+      ),
+    }
+  }
+
+  it('lays a 12-card hand out in two rows', () => {
+    const { container } = render(
+      <Seat seat={humanHand(12)} position="bottom" isHuman isBidWinner={false} isDealer={false} />,
+    )
+    const rows = container.querySelectorAll('div.overflow-x-auto')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].children).toHaveLength(6)
+    expect(rows[1].children).toHaveLength(6)
+  })
+
+  it('gives every row its own leading card with the overlap zeroed', () => {
+    // The reason this is two containers rather than one `flex-wrap` row:
+    // `first:ml-0` only matches the first child of its own parent, so under
+    // wrapping a visual second row kept the negative margin and hung left.
+    const { container } = render(
+      <Seat seat={humanHand(12)} position="bottom" isHuman isBidWinner={false} isDealer={false} />,
+    )
+    for (const row of container.querySelectorAll('div.overflow-x-auto')) {
+      expect(row.firstElementChild?.className).toContain('first:ml-0')
+    }
+  })
+
+  it('keeps the cards playable across both rows during trick play', () => {
+    // The split runs inside the branch that renders cards as buttons, so a row
+    // boundary must not cost the second row its click handlers or its legality
+    // styling — that would make half a hand unplayable rather than just hidden.
+    const seat = humanHand(12)
+    // Legality has to be expressed in *display* order: the component sorts
+    // before it splits, so the raw hand order says nothing about which row a
+    // card lands in.
+    const legalCards = [...splitHandIntoRows(sortHandForDisplay(seat.hand))[1]]
+    const onPlay = vi.fn()
+    const { container } = render(
+      <Seat
+        seat={seat}
+        position="bottom"
+        isHuman
+        isBidWinner={false}
+        isDealer={false}
+        playable={{ legalCards, onPlay }}
+      />,
+    )
+    const rows = container.querySelectorAll('div.overflow-x-auto')
+    expect(rows).toHaveLength(2)
+    expect(container.querySelectorAll('button')).toHaveLength(12)
+    // Legality is decided per card, not per row: the enabled ones here all live
+    // in the second row.
+    expect([...rows[0].querySelectorAll('button')].every((b) => (b as HTMLButtonElement).disabled)).toBe(true)
+    const enabled = [...rows[1].querySelectorAll('button')].filter((b) => !(b as HTMLButtonElement).disabled)
+    expect(enabled).toHaveLength(6)
+    fireEvent.click(enabled[0])
+    expect(onPlay).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a two-card hand on one row', () => {
+    const { container } = render(
+      <Seat seat={humanHand(2)} position="bottom" isHuman isBidWinner={false} isDealer={false} />,
+    )
+    expect(container.querySelectorAll('div.overflow-x-auto')).toHaveLength(1)
   })
 })

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -1,5 +1,6 @@
 import type { Card } from '../engine/card'
 import { sortHandForDisplay } from '../engine/card'
+import { splitHandIntoRows } from './handRows'
 import { PlayingCard } from './PlayingCard'
 import type { SeatPosition, SeatState } from './tableTypes'
 
@@ -64,47 +65,59 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
         <div className="text-xs text-white/60">{seat.statusText}</div>
       )}
       {isHuman ? (
-        // A single row, not `flex-wrap`: the fanned-overlap look below relies
-        // on `first:ml-0` to zero out the leading card's negative margin, which
-        // only identifies the true first card in the DOM — with wrapping on, a
-        // second row's leading card still carried the big negative margin and
-        // rendered shifted/misaligned relative to the row above it. One row
-        // that scrolls horizontally instead keeps every row's cards flush.
-        // -ml-11 against a 64px card leaves 24px of every card showing, which
-        // is enough for the corner index and puts all 12 in 328px — inside a
-        // 360px phone (#161). The overlap is paired with the card width, so
-        // changing one without the other either re-overflows or hides the
-        // indices. `w-full` is what makes `overflow-x-auto` mean anything: it
-        // resolves against the seat's stretched width (Table.tsx), so the row
-        // is as wide as the column and scrolls, instead of sizing to the fan.
-        <div className="flex w-full justify-center gap-1 overflow-x-auto">
-          {sortHandForDisplay(seat.hand).map((card) => {
-            const cardFace = <PlayingCard suit={card.suit} rank={card.rank} />
-            if (!playable) {
-              return (
-                <div key={card.toString()} className="-ml-11 first:ml-0">
-                  {cardFace}
-                </div>
-              )
-            }
-            const isLegal = playable.legalCards.includes(card)
-            return (
-              <button
-                key={card.toString()}
-                type="button"
-                disabled={!isLegal}
-                onClick={() => playable.onPlay(card)}
-                aria-label={`Play ${card.rank} of ${card.suit}`}
-                className={`-ml-11 first:ml-0 rounded-lg transition-transform ${
-                  isLegal
-                    ? 'cursor-pointer ring-2 ring-amber-400 hover:-translate-y-2'
-                    : 'cursor-not-allowed opacity-40'
-                }`}
-              >
-                {cardFace}
-              </button>
-            )
-          })}
+        // Explicit rows, never `flex-wrap` (#187, and the #161 note it replaces).
+        // The fanned-overlap look relies on `first:ml-0` to zero the leading
+        // card's negative margin, and `first:` only matches the first child of
+        // its own container — under `flex-wrap` a visual second row is still mid-
+        // list in the DOM, so its leading card kept the negative margin and hung
+        // left of the row above it. Giving each row its own flex container is
+        // what makes `first:` mean "first of this row" and the two line up.
+        //
+        // Pitch is `card + gap + margin = 64 + 4 - 24 = 44px`, so six cards span
+        // `5 * 44 + 64 = 284px` — inside the ~304px a 320px viewport leaves after
+        // the board's padding, and comfortably inside a 390px phone. The reveal
+        // goes from 24px (a corner index) to 44px (most of the card).
+        //
+        // The overlap is paired with the card width: change `w-16` on
+        // `PlayingCard` without changing `-ml-6` here and this either re-overflows
+        // or buries the indices again.
+        //
+        // `w-full` is what makes `overflow-x-auto` mean anything — it resolves
+        // against the seat's stretched width (Table.tsx) so a row is as wide as
+        // the column and scrolls, instead of sizing itself to its cards. It is a
+        // backstop now rather than the mechanism: at 320px and up nothing scrolls.
+        <div className="flex w-full flex-col items-center gap-1">
+          {splitHandIntoRows(sortHandForDisplay(seat.hand)).map((row, rowIndex) => (
+            <div key={rowIndex} className="flex w-full justify-center gap-1 overflow-x-auto">
+              {row.map((card) => {
+                const cardFace = <PlayingCard suit={card.suit} rank={card.rank} />
+                if (!playable) {
+                  return (
+                    <div key={card.toString()} className="-ml-6 first:ml-0">
+                      {cardFace}
+                    </div>
+                  )
+                }
+                const isLegal = playable.legalCards.includes(card)
+                return (
+                  <button
+                    key={card.toString()}
+                    type="button"
+                    disabled={!isLegal}
+                    onClick={() => playable.onPlay(card)}
+                    aria-label={`Play ${card.rank} of ${card.suit}`}
+                    className={`-ml-6 first:ml-0 rounded-lg transition-transform ${
+                      isLegal
+                        ? 'cursor-pointer ring-2 ring-amber-400 hover:-translate-y-2'
+                        : 'cursor-not-allowed opacity-40'
+                    }`}
+                  >
+                    {cardFace}
+                  </button>
+                )
+              })}
+            </div>
+          ))}
         </div>
       ) : exposeCards ? (
         <div className="flex w-full justify-center gap-1 overflow-x-auto">

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -96,19 +96,11 @@ export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, expos
     // top inset is handled by the Scoreboard, whose own background then fills
     // the strip behind the status bar instead of leaving a bare gap.
     <div className="relative flex min-h-svh flex-col bg-green-900 pr-[var(--safe-right)] pb-[var(--safe-bottom)] pl-[var(--safe-left)] text-white">
-      {onOpenMenu && (
-        <button
-          type="button"
-          onClick={onOpenMenu}
-          aria-label="Open menu"
-          // Absolute offsets resolve against the padding box, i.e. the very
-          // top-left corner, so this needs the inset added in explicitly or it
-          // sits under the notch.
-          className="absolute top-[calc(0.5rem_+_var(--safe-top))] left-[calc(0.5rem_+_var(--safe-left))] z-10 rounded bg-black/40 px-2 py-1 text-xs font-semibold text-white hover:bg-black/60"
-        >
-          ☰ Menu
-        </button>
-      )}
+      {/* The menu button lives inside the Scoreboard now (#187). Floated here as
+          `absolute top-2 left-2 z-10` it was painted over the strip's first line
+          — "☰ Menu" across "Trump: —" on a phone — and the strip had no way to
+          know it was there. In the strip's own flow it cannot collide, and it
+          inherits the safe-area insets the strip already carries. */}
       <Scoreboard
         scoresByTeam={scoresByTeam}
         teamNames={teamNames}
@@ -116,6 +108,7 @@ export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, expos
         bidWinnerName={bidWinnerSeat?.name}
         trumpSuit={trumpSuit}
         meldPoints={meldPoints}
+        onOpenMenu={onOpenMenu}
       />
       {/* Columns are capped, not proportional (#161). `1fr 2fr 1fr` let the
           centre column be sized by its contents, so the trick circle set a
@@ -124,10 +117,21 @@ export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, expos
           the circle's width and lets it shrink below that on a narrow screen,
           and `minmax(0, 1fr)` lets the side seats fall to zero rather than
           widening the board — together they make the grid physically unable to
-          exceed the viewport down to ~240px. Rows stay content-sized top and
-          bottom with the circle taking the slack. Gutters halved from 4 to 2
-          (16px -> 8px): 32px of the 390 was board margin. */}
-      <div className="grid flex-1 grid-cols-[minmax(0,1fr)_minmax(0,13rem)_minmax(0,1fr)] grid-rows-[auto_1fr_auto] items-center justify-items-center gap-2 p-2">
+          exceed the viewport down to ~240px. Gutters halved from 4 to 2
+          (16px -> 8px): 32px of the 390 was board margin.
+
+          Rows are `1fr auto 1fr`, not `auto 1fr auto` (#187). Sizing the outer
+          rows to their content and giving the slack to the middle centred the
+          circle *within the middle row*, and that row is only centred on the
+          board when the top and bottom seats are the same height — which they
+          never are, since the bottom seat carries the human's hand and the top
+          seat carries a name. At 390x844 that put the circle 37px above centre
+          (row centre 416, board centre 453), and the two-row hand widened the
+          gap further. Giving the middle row to the circle and splitting the
+          remainder equally makes the circle's centre the board's centre by
+          construction. `1fr` (min-content floor), not `minmax(0,1fr)`: the
+          outer rows must never shrink below the hand they hold. */}
+      <div className="grid flex-1 grid-cols-[minmax(0,1fr)_minmax(0,13rem)_minmax(0,1fr)] grid-rows-[1fr_auto_1fr] items-center justify-items-center gap-2 p-2">
         {seats.map((seat) => (
           <div
             key={seat.player}

--- a/web/src/components/handRows.ts
+++ b/web/src/components/handRows.ts
@@ -1,0 +1,39 @@
+/** Above this many cards the hand needs a second row to fit a narrow phone. Six
+ *  64px cards at the 44px pitch span 284px, inside the ~304px a 320px viewport
+ *  leaves once the board's padding is off. */
+const MAX_SINGLE_ROW = 6
+
+/**
+ * Splits the human's hand into the rows it is dealt across (#187).
+ *
+ * One row of 12 put the fan at `11 * 24 + 64 = 328px`, which fits a 390px phone
+ * with 46px to spare and a 360px phone with none — below about 350px it
+ * overflowed, and because that row is `justify-center` *and* `overflow-x-auto` an
+ * overflowing fan centres inside its own scroll box: cards clipped off the right,
+ * the leading ones unreachable at `scrollLeft: 0`, and nothing on screen saying
+ * the rest exists. That is "you can only see half your hand".
+ *
+ * Two rows halve the width that has to fit, which buys back enough room to widen
+ * the reveal from 24px — a corner index and little else — to most of the card.
+ *
+ * Split by **count, not by suit**. Paul suggested pairing suits (spades/diamonds,
+ * hearts/clubs) and the intent behind it is right, but suit counts are not
+ * balanced: nine spades and three hearts is an ordinary hand, and that split would
+ * put nine cards in one row and rebuild the overflow this exists to remove.
+ * `sortHandForDisplay` already groups by suit, so an even split keeps suits
+ * contiguous in practice while staying bounded in the worst case.
+ *
+ * The larger half goes on top, so an odd hand grows upward rather than leaving a
+ * short trailing row under a full one. A hand at or under `MAX_SINGLE_ROW` stays
+ * on one row rather than rendering two rows of one card each as the last tricks
+ * play out.
+ *
+ * Lives in its own module rather than in `Seat.tsx` so that file exports only its
+ * component (oxlint's `react(only-export-components)` — a mixed module breaks
+ * fast refresh).
+ */
+export function splitHandIntoRows<T>(cards: readonly T[]): readonly (readonly T[])[] {
+  if (cards.length <= MAX_SINGLE_ROW) return [cards]
+  const top = Math.ceil(cards.length / 2)
+  return [cards.slice(0, top), cards.slice(top)]
+}


### PR DESCRIPTION
Closes #187.

Reported from a phone mid-auction: "you can only see 1/2 of your hand and the circle
is off centre... shift the circle to the centre, and maybe stack the cards to make
them fit." Three independent faults, all measured before and after.

## 1. The hand: one row of 12 -> two rows of six

The fan was `11 x 24 + 64 = 328px` at a 24px pitch. That fits a 390px phone with
46px to spare, a 360px phone with **zero**, and overflows below ~350px. And because
the row is `justify-center` *and* `overflow-x-auto`, an overflowing fan centres
inside its own scroll box: clipped at the right, the leading cards unreachable at
`scrollLeft: 0`, and no visible affordance that the rest of the hand exists.

`splitHandIntoRows` (new, `handRows.ts`) halves the width that has to fit, which
buys back enough room to widen the pitch to 44px — six cards span 284px, inside the
~304px a 320px viewport leaves. **The reveal goes from 24px, a corner index and
little else, to 44px — most of the card.**

**Split by count, not by suit.** Paul suggested pairing suits (spades/diamonds,
hearts/clubs) and the intent is right, but suit counts are not balanced: nine spades
and three hearts is an ordinary hand, and that split would put nine cards in one row
and rebuild the exact overflow this removes. `sortHandForDisplay` already groups by
suit, so an even split keeps suits contiguous in practice while staying bounded in
the worst case. The larger half goes on top so an odd hand grows upward, and a hand
of six or fewer stays on one row rather than rendering two rows of one card as the
last tricks play out.

**Each row is its own flex container, never `flex-wrap`.** `first:ml-0` only matches
the first child of its own parent, so under wrapping a visual second row kept its
negative margin and hung left of the row above — that is why #161 settled on a single
row, and it is the part a future change is most likely to undo by "simplifying" this
back to one wrapping container.

## 2. The menu button was drawn on top of the scoreboard

`absolute top-2 left-2 z-10` in `Table`, over a strip that starts at `x: 0` — at 390
the button occupied `8..70 x 8..32`, directly across "Trump: —". That is the
collision in the screenshot.

It is now the strip's leading flow item. It cannot collide, and it inherits the
safe-area insets the strip already carries. Reserving space instead would have pushed
the centred strip off-centre by half a button's width.

## 3. The circle was centred on its grid row, not on the board

Horizontally it was already exact. Vertically it was not:

| | before | after |
|---|---|---|
| grid centre | 453 | 453 |
| circle centre | **416** | **453** |

Rows were `auto 1fr auto`, so the circle was centred within the middle row — which is
the board's centre only when the top and bottom seats are the same height. They never
are: one holds a name, the other holds a hand. `1fr auto 1fr` gives the middle row to
the circle and splits the remainder equally, making circle centre = board centre by
construction. Worth fixing here rather than separately: the two-row hand makes the
bottom row taller, so it would have got **worse**.

`1fr` and not `minmax(0,1fr)` — the outer rows must never shrink below the hand.

## Measured after, at four widths

| viewport | page overflow | row overflow | circle centred (h/v) | menu overlap |
|---|---|---|---|---|
| 320x700 | none | none | yes / yes | none |
| 360x800 | none | none | yes / yes | none |
| 390x844 | none | none | yes / yes | none |
| 430x932 | none | none | yes / yes | none |

Checked in a real browser against the running app, during the auction with the bid
overlay open (the overlay is `fixed inset-0` and does not reflow the table, so both
states were confirmed).

## Tests

**420 pass** (407 before, +13). `tsc -b` clean, `vite build` clean, `oxlint` back to
the three `exhaustive-deps` warnings already on `main` — `splitHandIntoRows` lives in
its own module so `Seat.tsx` keeps exporting only its component.

New coverage: the split itself (even, odd, short-hand, order-preservation, and a
property that no row exceeds the single-row limit); two rows rendered for 12 cards;
each row owning its own zeroed leading card; cards staying playable and
individually legality-styled across both rows; and `Scoreboard` owning the menu
button, firing it, and omitting it when no handler is passed.

The trick-play test matters most of the three component ones — the split runs inside
the branch that renders cards as buttons, and a row boundary that cost the second row
its handlers would make half a hand unplayable rather than merely hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

