### PR TITLE
Jumbo-index card face at 80px (#189)

### DIFF
--- a/web/src/components/PlayingCard.test.tsx
+++ b/web/src/components/PlayingCard.test.tsx
@@ -34,11 +34,15 @@ describe('PlayingCard', { timeout: 20_000 }, () => {
   // cards silently rendered full size. Width now comes from `size` alone, so
   // exactly one width utility is ever emitted.
   //
-  // The values are #161's ~20% reduction (lg 80 -> 64, md 60 -> 48, sm 36 ->
-  // 28), which is what makes a 12-card hand fit a phone. They are pinned here
-  // rather than left to inspection because the fan overlaps in Seat.tsx are
-  // tuned against these exact widths — changing one without the other either
-  // overflows the viewport again or buries the corner indices.
+  // `lg` is back at 80 after #161 took it to 64: that reduction existed to fit
+  // twelve cards in one row, and #187's two rows only have to fit six. They are
+  // pinned here rather than left to inspection because the fan overlaps in
+  // Seat.tsx are tuned against these exact widths — changing one without the
+  // other either overflows the viewport or buries the index.
+  //
+  // Matched against the root only. The face now has inner elements that carry
+  // their own width (the edge stripe), and #94's rule is about the *card's*
+  // width having no competitor, not about the string `w-` appearing once.
   it('emits exactly one width utility, chosen by size', () => {
     const widthsFor = (el: Element) => (el.className.match(/(^|\s)w-\S+/g) ?? []).map((s) => s.trim())
 
@@ -48,7 +52,24 @@ describe('PlayingCard', { timeout: 20_000 }, () => {
 
     expect(widthsFor(sm.firstElementChild!)).toEqual(['w-7'])
     expect(widthsFor(md.firstElementChild!)).toEqual(['w-12'])
-    expect(widthsFor(lg.firstElementChild!)).toEqual(['w-16'])
+    expect(widthsFor(lg.firstElementChild!)).toEqual(['w-20'])
+  })
+
+  // The fan in Seat.tsx covers all but a 0.6875w strip of every card except the
+  // last, so a face whose index outgrows that strip is a face you cannot read in
+  // a hand — which is the whole complaint this design answers. Guarding the
+  // ratio rather than the pixel value keeps it true if the widths move again.
+  it('keeps the index inside the strip the fan leaves visible', () => {
+    const px = (cls: string, re: RegExp) => Number(cls.match(re)![1])
+    const WIDTH_PX = { sm: 28, md: 48, lg: 80 } as const
+
+    for (const size of ['sm', 'md', 'lg'] as const) {
+      const { container } = render(<PlayingCard suit={Suit.Spades} rank="A" size={size} />)
+      const index = container.querySelector('.font-extrabold')!
+      const suitSpan = index.lastElementChild!
+      const suitPx = px(suitSpan.className, /text-\[(\d+)px\]/)
+      expect(suitPx / WIDTH_PX[size]).toBeLessThan(0.6875)
+    }
   })
 
   // A card is a width plus a ratio — nothing sets a height — so `aspect-5/7`

--- a/web/src/components/PlayingCard.tsx
+++ b/web/src/components/PlayingCard.tsx
@@ -2,8 +2,8 @@ import { type Rank, type Suit } from '../engine/card'
 import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
 
 /**
- * Card sizes, as matched sets of width + corner/centre type scale + the
- * positions of both corner indices.
+ * Card sizes, as matched sets of width + every type size and offset that has to
+ * scale with it.
  *
  * Size is a prop rather than something a caller passes through `className`
  * because Tailwind resolves conflicting utilities by their order in the
@@ -16,18 +16,28 @@ import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
  * corner's offsets used to be hardcoded in the JSX, so they stayed put while
  * the card shrank under them.
  *
- * Widths came down ~20% for #161 (lg 80 -> 64, md 60 -> 48, sm 36 -> 28): at
- * the old sizes a 12-card hand measured 564px against a 390px phone viewport.
- * `aspect-5/7` is what turns each width into a card, so the heights follow
- * (lg 112 -> 90, md 84 -> 67, sm 50 -> 39) and the ratio is unchanged.
+ * Widths: `lg` went 80 -> 64 in #161 to fit a 12-card hand on a phone, and back
+ * to **80** here now that #187's two rows only have to fit six. `aspect-5/7` is
+ * what turns each width into a card, so the heights follow (lg 112, md 67,
+ * sm 39) and the ratio is unchanged.
+ *
+ * Everything else in a row is that row's width times a fixed fraction, which is
+ * how the face stays the same face at every size:
+ *
+ *   rank 0.40w · suit 0.55w · watermark 1.05w · stripe max(4, 0.075w)
+ *
+ * The suit fraction is the one Paul picked from a rendered comparison at 0.34 /
+ * 0.45 / 0.55 / 0.68. **0.68 is the hard ceiling and 0.55 is deliberately under
+ * it**: `Seat.tsx` fans the hand at a 0.6875w reveal, so an index wider than
+ * that is the part of the card the next card covers.
  */
 const CARD_SIZES = {
   /** Compact, for dense read-only displays like meld declaration. */
-  sm: { width: 'w-7', corner: 'text-[0.5rem]', cornerPos: 'top-0 left-0.5', cornerPosAlt: 'right-0.5 bottom-0', centre: 'text-base' },
-  /** The fanned hand in a seat. */
-  md: { width: 'w-12', corner: 'text-xs', cornerPos: 'top-0.5 left-1', cornerPosAlt: 'right-1 bottom-0.5', centre: 'text-xl' },
-  /** Full size — trick area, pass selector, pass reveal. */
-  lg: { width: 'w-16', corner: 'text-xs', cornerPos: 'top-0.5 left-1', cornerPosAlt: 'right-1 bottom-0.5', centre: 'text-2xl' },
+  sm: { width: 'w-7', rankSize: 'text-[11px]', suitSize: 'text-[15px]', markSize: 'text-[29px]', stripe: 'w-1', indexLeft: 'left-[6px]' },
+  /** An AI seat's exposed hand during meld. */
+  md: { width: 'w-12', rankSize: 'text-[19px]', suitSize: 'text-[26px]', markSize: 'text-[50px]', stripe: 'w-1', indexLeft: 'left-[7px]' },
+  /** Full size — the human's hand, trick area, pass selector, pass reveal. */
+  lg: { width: 'w-20', rankSize: 'text-[32px]', suitSize: 'text-[44px]', markSize: 'text-[84px]', stripe: 'w-1.5', indexLeft: 'left-[11px]' },
 } as const
 
 export type PlayingCardSize = keyof typeof CARD_SIZES
@@ -46,9 +56,27 @@ export interface PlayingCardProps {
  * fixed off-white regardless of app theme (dark/light) — real cards don't
  * change color with the room lights, and it keeps contrast high against
  * either a light or dark table background by construction.
+ *
+ * **Jumbo index, not a pip field.** The face is one oversized rank-over-suit
+ * index in the top-left, a faint suit watermark filling the rest, and a
+ * suit-coloured stripe down the left edge. That shape is chosen for one
+ * specific reading condition rather than for looks: `Seat.tsx` fans the hand
+ * with a negative margin, so for eleven of twelve cards **the only part on
+ * screen is a ~0.69w strip of the left edge**. The previous face put a single
+ * centred glyph there and a 0.22w index in the corner, which meant a fanned
+ * hand was a row of near-identical white rectangles and the rank was the
+ * smallest thing on the card. Everything here is placed inside that strip.
+ *
+ * The stripe is the part that survives even a heavier overlap, since it sits at
+ * x=0. It is `bg-current`, so it inherits the same two-colour suit mapping as
+ * the index rather than restating it.
+ *
+ * `overflow-hidden` is load-bearing twice over: it clips the stripe to the
+ * rounded corners, and it crops the watermark, which is deliberately larger
+ * than the card and offset past two edges.
  */
 export function PlayingCard({ suit, rank, faceDown, size = 'lg', className = '' }: PlayingCardProps) {
-  const { width, corner, cornerPos, cornerPosAlt, centre } = CARD_SIZES[size]
+  const { width, rankSize, suitSize, markSize, stripe, indexLeft } = CARD_SIZES[size]
 
   if (faceDown) {
     return (
@@ -62,26 +90,21 @@ export function PlayingCard({ suit, rank, faceDown, size = 'lg', className = '' 
 
   const glyph = SUIT_GLYPH[suit]
   const colorClass = RED_SUITS.includes(suit) ? 'text-red-600' : 'text-neutral-900'
-  // The compact size has no room for the second, rotated corner index.
-  const showRotatedCorner = size !== 'sm'
 
   return (
     <div
       role="img"
       aria-label={`${rank} of ${suit}`}
-      className={`relative aspect-5/7 ${width} rounded-lg border border-neutral-300 bg-neutral-50 shadow-sm select-none ${colorClass} ${className}`}
+      className={`relative aspect-5/7 ${width} overflow-hidden rounded-lg border border-neutral-300 bg-neutral-50 shadow-sm select-none ${colorClass} ${className}`}
     >
-      <div className={`absolute ${cornerPos} flex flex-col items-center ${corner} leading-none font-semibold`}>
-        <span>{rank}</span>
-        <span>{glyph}</span>
+      <div className={`absolute inset-y-0 left-0 ${stripe} bg-current`} />
+      <div className={`absolute -right-[6%] -bottom-[8%] ${markSize} leading-none opacity-15`} aria-hidden="true">
+        {glyph}
       </div>
-      {showRotatedCorner && (
-        <div className={`absolute ${cornerPosAlt} flex rotate-180 flex-col items-center ${corner} leading-none font-semibold`}>
-          <span>{rank}</span>
-          <span>{glyph}</span>
-        </div>
-      )}
-      <div className={`flex h-full w-full items-center justify-center ${centre}`}>{glyph}</div>
+      <div className={`absolute top-[4%] ${indexLeft} flex flex-col items-center leading-[0.95] font-extrabold`}>
+        <span className={rankSize}>{rank}</span>
+        <span className={suitSize}>{glyph}</span>
+      </div>
     </div>
   )
 }

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -73,14 +73,25 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
         // left of the row above it. Giving each row its own flex container is
         // what makes `first:` mean "first of this row" and the two line up.
         //
-        // Pitch is `card + gap + margin = 64 + 4 - 24 = 44px`, so six cards span
-        // `5 * 44 + 64 = 284px` — inside the ~304px a 320px viewport leaves after
-        // the board's padding, and comfortably inside a 390px phone. The reveal
-        // goes from 24px (a corner index) to 44px (most of the card).
+        // Pitch is `card + gap + margin = 80 + 4 - 32 = 52px`, so six cards span
+        // `5 * 52 + 80 = 340px`. The reveal is 52px, most of an 80px card, and
+        // comfortably more than the 30px the jumbo index actually occupies.
         //
-        // The overlap is paired with the card width: change `w-16` on
-        // `PlayingCard` without changing `-ml-6` here and this either re-overflows
-        // or buries the indices again.
+        // This is the 80px arm of Paul's size call, taken against a rendered
+        // comparison: 64px spans 284 and clears a 320px phone too, 92px only fits
+        // at three rows of four. At 80 a 320px viewport (~304px usable) **does**
+        // overflow and the row scrolls — that is the accepted cost, and it is why
+        // `overflow-x-auto` below is now load-bearing rather than a backstop.
+        //
+        // -32 rather than the -28 that keeps the reveal proportional to #161's
+        // ratio: at -28 the row measured 360px against the 359px a 375px iPhone
+        // leaves, i.e. it scrolled by one pixel. -32 buys 19px of headroom for a
+        // reveal nobody can tell apart.
+        //
+        // The overlap is paired with the card width: change `w-20` on
+        // `PlayingCard` without changing `-ml-8` here and this either re-overflows
+        // or buries the index again. `PlayingCard`'s own suit-size ceiling is
+        // derived from this pitch — see the note there.
         //
         // `w-full` is what makes `overflow-x-auto` mean anything — it resolves
         // against the seat's stretched width (Table.tsx) so a row is as wide as
@@ -93,7 +104,7 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
                 const cardFace = <PlayingCard suit={card.suit} rank={card.rank} />
                 if (!playable) {
                   return (
-                    <div key={card.toString()} className="-ml-6 first:ml-0">
+                    <div key={card.toString()} className="-ml-8 first:ml-0">
                       {cardFace}
                     </div>
                   )
@@ -106,7 +117,7 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
                     disabled={!isLegal}
                     onClick={() => playable.onPlay(card)}
                     aria-label={`Play ${card.rank} of ${card.suit}`}
-                    className={`-ml-6 first:ml-0 rounded-lg transition-transform ${
+                    className={`-ml-8 first:ml-0 rounded-lg transition-transform ${
                       isLegal
                         ? 'cursor-pointer ring-2 ring-amber-400 hover:-translate-y-2'
                         : 'cursor-not-allowed opacity-40'
@@ -123,7 +134,7 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
         <div className="flex w-full justify-center gap-1 overflow-x-auto">
           {/* Same 24px reveal as the human fan above, against a 48px `md` card. */}
           {sortHandForDisplay(seat.hand).map((card, i) => (
-            <div key={i} className="-ml-7 first:ml-0">
+            <div key={i} className="-ml-8 first:ml-0">
               <PlayingCard suit={card.suit} rank={card.rank} size="md" />
             </div>
           ))}

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -120,6 +120,11 @@ export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, expos
           exceed the viewport down to ~240px. Gutters halved from 4 to 2
           (16px -> 8px): 32px of the 390 was board margin.
 
+          13rem stayed put when the cards went 64 -> 80px, so it is no longer
+          "three cards across" the way #161 sized it. That is measured, not an
+          oversight — see `TrickArea` for why the circle deliberately did not
+          grow with the cards, and for the 5px overhang it buys.
+
           Rows are `1fr auto 1fr`, not `auto 1fr auto` (#187). Sizing the outer
           rows to their content and giving the slack to the middle centred the
           circle *within the middle row*, and that row is only centred on the
@@ -130,7 +135,15 @@ export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, expos
           gap further. Giving the middle row to the circle and splitting the
           remainder equally makes the circle's centre the board's centre by
           construction. `1fr` (min-content floor), not `minmax(0,1fr)`: the
-          outer rows must never shrink below the hand they hold. */}
+          outer rows must never shrink below the hand they hold.
+
+          The cost of that mirroring scales with the hand, and the 80px card
+          spends what was left: the bottom seat is 252px, so the top row is 252px
+          too even though it holds a name, and the board measures **exactly 844**
+          on a 390x844 phone. It fits, with nothing to spare. A shorter phone
+          scrolls — 375x812 is 14px over — and anything that grows the bottom
+          seat or the circle costs twice its own height here. Re-measure this
+          number before changing either. */}
       <div className="grid flex-1 grid-cols-[minmax(0,1fr)_minmax(0,13rem)_minmax(0,1fr)] grid-rows-[1fr_auto_1fr] items-center justify-items-center gap-2 p-2">
         {seats.map((seat) => (
           <div

--- a/web/src/components/TrickArea.tsx
+++ b/web/src/components/TrickArea.tsx
@@ -35,13 +35,26 @@ export function TrickArea({ trick, humanPlayer, winningPlayer, trickNumber }: Tr
       )}
       {/* 13rem (208px) rather than the old 18rem (288px), which was 74% of a
           390px phone viewport on its own and left ~100px for the two side
-          seats put together (#161). 208 is three 64px cards across, which is
-          all the 3x3 placement grid inside ever needs. The old
-          `min-h-[12rem]` is gone with it: it existed to stop `max-w-full`
-          collapsing the circle on a narrow screen, but it did that by letting
-          the box go taller than it is wide — at 208 the aspect ratio holds the
-          height on its own, and a floor above the width would only re-introduce
-          a non-circular circle. */}
+          seats put together (#161). The old `min-h-[12rem]` is gone with it: it
+          existed to stop `max-w-full` collapsing the circle on a narrow screen,
+          but it did that by letting the box go taller than it is wide — at 208
+          the aspect ratio holds the height on its own, and a floor above the
+          width would only re-introduce a non-circular circle.
+
+          208 was three 64px cards across. The cards are 80px now, so three of
+          them are 240 and each of the four played cards, centred in a 69px
+          column, hangs 5px past the circle. **That is deliberate, and 15rem was
+          measured and rejected.** The board is `1fr auto 1fr` rows (#187), so
+          the top row mirrors the bottom seat's height; with a two-row 80px hand
+          that already spends 844px of a 390x844 phone exactly, and widening the
+          circle to 240 pushed the board to 858 and started it scrolling
+          vertically. A 5px overhang on a felt circle is a cosmetic rounding; a
+          hand you have to scroll to see is the bug #187 just fixed.
+
+          The overhang is bounded and does not collide: at 390px the side seat
+          columns end at 83 and start at 307, and the outermost card edges land
+          at 85.7 and 304.3. Re-measure both if the card width, the column cap,
+          or the board gutters change. */}
       <div className="grid aspect-square w-52 max-w-full grid-cols-3 grid-rows-3 items-center justify-items-center rounded-full bg-green-950/40">
       {trick.map((play) => (
         <div


### PR DESCRIPTION
Closes #189.

Dad's items 1 and 2. Item 3 (bidding status on the circle) and item 4 (the
reported 4-card pass) are not in here — see the issue for where item 4 landed.

## What changed

The card face is now one oversized rank-over-suit index in the top-left, a faint
suit watermark cropped past two edges, and a suit-coloured stripe down the left
edge. Cards went 64 -> 80px.

The reasoning is in the code, but the short version: the complaint is about the
face **in a fanned hand**, where the only visible part of eleven of twelve cards
is a strip of the left edge. Everything on the new face lives inside that strip.
The stripe sits at x=0, so it is the one element that survives any overlap.

## Numbers, all measured at 390x844 in the running app

| | before | after |
|---|---|---|
| card | 64x90 | 80x112 |
| fan pitch / reveal | 44px | 52px |
| row of six | 284px | 340px (374 available) |
| index width | ~14px | 34.6px |
| board height | 796px | **844px — exactly the viewport** |

No horizontal or vertical scrolling at 390x844. A 375x812 phone is 14px over;
that is the cost of the 80px card and it is called out in `Table.tsx`.

## Two things that were tried and rejected, with the measurement

- **Overlap -28px** (keeps #161's reveal ratio): row of six measures 360 against
  the 359 a 375px iPhone leaves. Scrolls by one pixel. -32 buys 19px of headroom
  for a reveal nobody can tell apart.
- **Trick circle 208 -> 240px**, so three 80px cards fit it exactly. The board's
  `1fr auto 1fr` rows (#187) mirror the bottom seat's height, so the extra 32px
  costs 32 twice: the board went 844 -> 858 and started scrolling vertically.
  Kept at 208, where the played cards hang 5px past the circle and clear the side
  seat columns by 2.7px on each side.

## Tests

421 pass. `PlayingCard.test.tsx` gains a guard that the index stays inside the
0.6875w strip the fan leaves, at every size — the constraint that actually
governs this design, rather than the pixel values that express it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)