### PR TITLE
Auction calls on the circle (#191)

### DIFF
--- a/web/src/components/AuctionFlow.test.tsx
+++ b/web/src/components/AuctionFlow.test.tsx
@@ -352,6 +352,10 @@ describe('AuctionFlow (component)', { timeout: 20_000 }, () => {
 
     // Left of dealer (1) is seat 2 (Partner), and this hand is worth a contract.
     act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
-    expect(screen.getByText('300')).not.toBeNull()
+    // Asserted on the seat's call on the board, not on the bare text "300":
+    // the Scoreboard shows the same number as the standing contract, so a plain
+    // text query matches both and cannot tell "seat 2 opened" from "the high bid
+    // is 300" — which is the whole point of the assertion (#191).
+    expect(screen.getByLabelText('Partner: bid 300')).not.toBeNull()
   })
 })

--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -8,13 +8,12 @@ import type { SkillLevel } from '../persistence/options'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { auctionReducer, initAuctionState, passedPlayersOf } from './auctionReducer'
 import type { AuctionResult } from './auctionTypes'
-import { AuctionLog } from './AuctionLog'
 import { BiddingControls } from './BiddingControls'
 import { PassRevealDialog } from './PassRevealDialog'
 import { PassSelector } from './PassSelector'
 import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
-import type { SeatState, TableState } from './tableTypes'
+import type { SeatCall, SeatState, TableState } from './tableTypes'
 import { TrumpSelector } from './TrumpSelector'
 
 export const AI_BID_DELAY_MS = 600
@@ -131,20 +130,25 @@ export function AuctionFlow({
   }, [state, onComplete])
 
   const tableState: TableState = useMemo(() => {
+    // The order matters and is not arbitrary: a seat that has passed is out for
+    // the rest of the hand (#93), so 'pass' outranks everything, including still
+    // holding the high bid from before it passed. Below that, the standing high
+    // bid outranks whose turn it is, so the number stays on the board while the
+    // next seat is being asked rather than blinking out and back.
     const seatFor = (p: PlayerIndex): SeatState => {
       const active = state.bidding.active[p]
       const isBidWinner = p === state.bidding.bidWinner && state.bidding.currentBid > 0
-      let statusText: string | undefined
+      let call: SeatCall
       if (!active) {
-        statusText = 'Pass'
+        call = { kind: 'pass' }
       } else if (isBidWinner) {
-        statusText = `(${state.bidding.currentBid})`
+        call = { kind: 'bid', amount: state.bidding.currentBid }
       } else if (state.phase === 'bidding' && p === state.bidding.turn) {
-        // current turn — no status overlay needed
+        call = { kind: 'turn' }
       } else {
-        statusText = '(Waiting)'
+        call = { kind: 'waiting' }
       }
-      return { player: p, name: seatNames[p], hand: state.hands[p], statusText }
+      return { player: p, name: seatNames[p], hand: state.hands[p], call }
     }
     const seats: TableState['seats'] = [seatFor(0), seatFor(1), seatFor(2), seatFor(3)]
     return {
@@ -228,24 +232,17 @@ export function AuctionFlow({
     return null
   }, [state, humanPlayer, options.showBaseBidHint])
 
-  const logPanel = useMemo(() => {
-    const bidWinner = state.bidding.bidWinner
-    return (
-      <AuctionLog
-        entries={state.log}
-        currentBid={state.bid || state.bidding.currentBid}
-        bidWinnerName={bidWinner !== null ? state.seatNames[bidWinner] : undefined}
-        dealerName={state.seatNames[state.dealer]}
-      />
-    )
-  }, [state.log, state.bid, state.bidding.currentBid, state.bidding.bidWinner, state.seatNames, state.dealer])
-
-  return (
-    <Table
-      state={tableState}
-      overlay={overlay}
-      logPanel={logPanel}
-      onOpenMenu={onOpenMenu}
-    />
-  )
+  // No `logPanel` (#191). The auction used to run a corner feed — "Molly bid
+  // 320", "Amanda passed" — naming seats the board was already drawing, in a
+  // box that covered part of it. Every event it reported is now on the circle at
+  // the seat that caused it, so the feed was restating the board in words.
+  //
+  // What the panel's header carried and the circle does not: the dealer, and the
+  // high bid attributed by name. Both are still on screen — the dealer as the
+  // `D` badge in `Seat`, the contract as "Bid: 340 (Nerida)" in `Scoreboard`.
+  // What is genuinely gone is the *history*: who bid what earlier in the
+  // auction, as opposed to where it now stands. `state.log` is still built and
+  // still handed to `onComplete`, so restoring a view of it is a render, not a
+  // rebuild.
+  return <Table state={tableState} overlay={overlay} onOpenMenu={onOpenMenu} />
 }

--- a/web/src/components/Seat.tsx
+++ b/web/src/components/Seat.tsx
@@ -37,6 +37,12 @@ const POSITION_LAYOUT: Record<SeatPosition, string> = {
  * information a player needs to track how many tricks are left. The one
  * exception is `exposeCards` during the meld phase, where an AI's cards are
  * laid face-up because meld is public.
+ *
+ * A seat does **not** render its own auction call (#191). It used to, as one
+ * `text-xs text-white/60` line under the name, and that is the line Paul's dad
+ * could not read. `SeatState.call` is rendered by `TrickArea` instead, at the
+ * seat's own side of the circle — same information, at the size the rest of the
+ * board uses, and in the place the eye is already on during trick play.
  */
 export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable, exposeCards }: SeatProps) {
   return (
@@ -61,9 +67,6 @@ export function Seat({ seat, position, isHuman, isBidWinner, isDealer, playable,
           <span className="text-xs text-white/70">{seat.hand.length} cards</span>
         )}
       </div>
-      {seat.statusText && (
-        <div className="text-xs text-white/60">{seat.statusText}</div>
-      )}
       {isHuman ? (
         // Explicit rows, never `flex-wrap` (#187, and the #161 note it replaces).
         // The fanned-overlap look relies on `first:ml-0` to zero the leading

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -162,7 +162,19 @@ export function Table({ state, overlay, logPanel, onOpenMenu, trickNumber, expos
           </div>
         ))}
         <div className="col-start-2 row-start-2">
-          <TrickArea trick={trick} humanPlayer={humanPlayer} winningPlayer={trickWinner} trickNumber={trickNumber} />
+          {/* Calls are derived here rather than passed in, so a caller only has
+              to populate `SeatState.call` and the circle placement follows from
+              the seat it is already describing. Seats without a call (every
+              phase after the auction) contribute nothing. */}
+          <TrickArea
+            trick={trick}
+            humanPlayer={humanPlayer}
+            winningPlayer={trickWinner}
+            trickNumber={trickNumber}
+            calls={seats.flatMap((seat) =>
+              seat.call ? [{ player: seat.player, name: seat.name, call: seat.call }] : [],
+            )}
+          />
         </div>
       </div>
       {/* Fixed to the viewport, so the root's safe-area padding doesn't reach

--- a/web/src/components/TrickArea.test.tsx
+++ b/web/src/components/TrickArea.test.tsx
@@ -1,0 +1,104 @@
+import { render, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Card, Suit } from '../engine/card'
+import type { PlayerIndex } from '../engine/trick'
+import { TrickArea, type SeatCallAt } from './TrickArea'
+import { seatPosition } from './tableTypes'
+
+// Queries are scoped with `within(container)`, not taken from `screen` or from
+// `render()`'s own bound queries: this suite mounts many boards, the project does
+// not enable RTL's auto-cleanup, and the bound queries are bound to `baseElement`
+// (the whole body) rather than to the container — so both of the easier options
+// see every board mounted so far. Same reason PlayingCard.test.tsx reads
+// `container.firstElementChild` instead of `screen`.
+
+const NAMES: Record<PlayerIndex, string> = { 0: 'You', 1: 'West', 2: 'Partner', 3: 'East' }
+
+const PLAYERS: readonly PlayerIndex[] = [0, 1, 2, 3]
+
+const CELL: Record<string, string> = {
+  top: 'col-start-2 row-start-1',
+  left: 'col-start-1 row-start-2',
+  right: 'col-start-3 row-start-2',
+  bottom: 'col-start-2 row-start-3',
+}
+
+function callsFor(entries: Partial<Record<PlayerIndex, SeatCallAt['call']>>): SeatCallAt[] {
+  return PLAYERS.filter((p) => entries[p] !== undefined).map((p) => ({
+    player: p,
+    name: NAMES[p],
+    call: entries[p]!,
+  }))
+}
+
+describe('TrickArea auction calls (#191)', () => {
+  it('names every kind of call, so the board is readable without its layout', () => {
+    const { container } = render(
+      <TrickArea
+        trick={[]}
+        humanPlayer={0}
+        calls={callsFor({
+          0: { kind: 'turn' },
+          1: { kind: 'bid', amount: 320 },
+          2: { kind: 'pass' },
+          3: { kind: 'waiting' },
+        })}
+      />,
+    )
+
+    const board = within(container)
+    expect(board.getByLabelText('You: to bid')).not.toBeNull()
+    expect(board.getByLabelText('West: bid 320')).not.toBeNull()
+    expect(board.getByLabelText('Partner: passed')).not.toBeNull()
+    expect(board.getByLabelText('East: waiting')).not.toBeNull()
+  })
+
+  // The whole point of the change is *where* a call sits: "300" means nothing
+  // until you know whose 300 it is, and the only thing saying so is the cell.
+  // This pins a call to the same cell that seat's played card would land in, for
+  // a human at each of the four PlayerIndex values — the mapping Seat, Table and
+  // TrickArea all have to agree on for the board to make sense at all.
+  it('places a call in the same cell as that seat’s played card, for any human seat', () => {
+    for (const human of PLAYERS) {
+      for (const player of PLAYERS) {
+        const { container, unmount } = render(
+          <TrickArea trick={[]} humanPlayer={human} calls={callsFor({ [player]: { kind: 'pass' } })} />,
+        )
+        expect(within(container).getByLabelText(`${NAMES[player]}: passed`).className).toContain(
+          CELL[seatPosition(player, human)],
+        )
+        unmount()
+      }
+    }
+  })
+
+  it('renders the bid amount as visible text, not only as a label', () => {
+    const { container } = render(
+      <TrickArea trick={[]} humanPlayer={0} calls={callsFor({ 2: { kind: 'bid', amount: 340 } })} />,
+    )
+    expect(within(container).getByLabelText('Partner: bid 340').textContent).toBe('340')
+  })
+
+  it('shows nothing in the circle when no seat has a call', () => {
+    const { container } = render(<TrickArea trick={[]} humanPlayer={0} />)
+    expect(container.querySelectorAll('[role="img"]').length).toBe(0)
+  })
+
+  // Calls and cards share one 3x3 grid, so a phase that had both would stack
+  // them in the same cell. Nothing does today — `trick` is empty until the
+  // auction settles, and AuctionFlow is the only thing that sets calls — but the
+  // sharing is deliberate, and this records that trick play alone stays clean.
+  it('renders played cards with no calls once the auction is over', () => {
+    const { container } = render(
+      <TrickArea
+        trick={[{ player: 1, card: new Card(Suit.Hearts, 'A', 1) }]}
+        humanPlayer={0}
+        trickNumber={3}
+      />,
+    )
+    const board = within(container)
+    expect(board.getByLabelText('A of H')).not.toBeNull()
+    expect(board.queryByLabelText(/: (bid|passed|waiting|to bid)/)).toBeNull()
+    expect(board.getByText('Trick 3 of 12')).not.toBeNull()
+  })
+})

--- a/web/src/components/TrickArea.tsx
+++ b/web/src/components/TrickArea.tsx
@@ -1,6 +1,41 @@
 import type { PlayerIndex, TrickPlay } from '../engine/trick'
 import { PlayingCard } from './PlayingCard'
-import { seatPosition, type SeatPosition } from './tableTypes'
+import { seatPosition, type SeatCall, type SeatPosition } from './tableTypes'
+
+/** One seat's auction call, placed on the board the same way a played card is. */
+export interface SeatCallAt {
+  readonly player: PlayerIndex
+  readonly name: string
+  readonly call: SeatCall
+}
+
+/**
+ * The call as a phrase, for the accessible name.
+ *
+ * Rendered, a call is a bare "300" or "PASS" whose meaning comes entirely from
+ * *where on the circle it sits* — which is exactly the information that does not
+ * survive being read aloud.
+ *
+ * `name: call` rather than `formatAuctionLogEntry`'s "West bid 320" sentence,
+ * because the human's seat is literally named **"You"** and two of these four
+ * cases need a copula: "You is waiting" and "You is deciding". Reaching for
+ * "are" on one name is a special case waiting to break on the next one, and the
+ * mixed alternative ("You passed" but "Waiting: You") is worse to listen to. The
+ * colon form is grammatical for every seat name including that one, and reads as
+ * the label it is.
+ */
+function describeCall(name: string, call: SeatCall): string {
+  switch (call.kind) {
+    case 'bid':
+      return `${name}: bid ${call.amount}`
+    case 'pass':
+      return `${name}: passed`
+    case 'turn':
+      return `${name}: to bid`
+    case 'waiting':
+      return `${name}: waiting`
+  }
+}
 
 export interface TrickAreaProps {
   trick: readonly TrickPlay[]
@@ -12,6 +47,10 @@ export interface TrickAreaProps {
   /** Trick counter display: e.g. 1-based trick number so "Trick 3 of 12"
    * renders above the trick circle. Omitted outside trick-play. */
   trickNumber?: number
+  /** Auction (#191): each seat's call, placed at that seat's side of the circle
+   * exactly as `trick` places its cards. Omitted outside the auction, where
+   * `trick` occupies the same cells. */
+  calls?: readonly SeatCallAt[]
 }
 
 const POSITION_CLASS: Record<SeatPosition, string> = {
@@ -22,12 +61,48 @@ const POSITION_CLASS: Record<SeatPosition, string> = {
 }
 
 /**
- * Center-of-table area: the cards played so far in the current trick,
- * each placed on the side of the center matching its player's seat. Empty
- * until a seat has played, so a trick in progress shows 1-3 cards and a
- * completed-but-not-yet-cleared trick shows all 4.
+ * One seat's call, sized by what it is rather than uniformly (#191).
+ *
+ * A bid is the only one that carries a number, so it gets the weight: it is the
+ * thing a player is actually tracking, and at `text-3xl` a three-digit bid is
+ * ~55px inside a ~69px cell. Pass and waiting are deliberately quieter and in
+ * two different registers — a pass is a decision and stays legible in white, a
+ * wait is the absence of one and recedes to 45% — so the board can be read at a
+ * glance for "who is still in" without reading any words.
+ *
+ * Nothing here animates. The seat being asked shows a static ellipsis rather
+ * than a pulsing one: the auction already paces itself at `AI_BID_DELAY_MS`, and
+ * a second moving thing on a board that is otherwise still reads as a bug.
  */
-export function TrickArea({ trick, humanPlayer, winningPlayer, trickNumber }: TrickAreaProps) {
+function CallLabel({ call }: { call: SeatCall }) {
+  switch (call.kind) {
+    case 'bid':
+      return (
+        <span className="text-3xl leading-none font-extrabold text-amber-300 tabular-nums drop-shadow">
+          {call.amount}
+        </span>
+      )
+    case 'pass':
+      return <span className="text-xl leading-none font-bold tracking-wide text-white/80">PASS</span>
+    case 'turn':
+      return <span className="text-2xl leading-none font-bold text-amber-200/80">…</span>
+    case 'waiting':
+      return <span className="text-[10px] leading-none font-semibold tracking-[0.14em] text-white/45">WAITING</span>
+  }
+}
+
+/**
+ * Center-of-table area: during trick play, the cards played so far in the
+ * current trick; during the auction, each seat's call. Both are placed on the
+ * side of the center matching that player's seat, which is the point — the
+ * auction now reads the same way the play does (#191), instead of as a list in
+ * a corner box that named seats the board was already showing.
+ *
+ * The two never overlap in practice (`trick` is empty until the auction is
+ * settled), so they share the same 3x3 placement grid rather than each getting
+ * their own layout to keep in sync.
+ */
+export function TrickArea({ trick, humanPlayer, winningPlayer, trickNumber, calls }: TrickAreaProps) {
   return (
     <div className="flex flex-col items-center gap-1">
       {trickNumber !== undefined && (
@@ -56,17 +131,31 @@ export function TrickArea({ trick, humanPlayer, winningPlayer, trickNumber }: Tr
           at 85.7 and 304.3. Re-measure both if the card width, the column cap,
           or the board gutters change. */}
       <div className="grid aspect-square w-52 max-w-full grid-cols-3 grid-rows-3 items-center justify-items-center rounded-full bg-green-950/40">
-      {trick.map((play) => (
-        <div
-          key={play.player}
-          className={`rounded-lg ${POSITION_CLASS[seatPosition(play.player, humanPlayer)]} ${
-            play.player === winningPlayer ? 'ring-4 ring-amber-400' : ''
-          }`}
-        >
-          <PlayingCard suit={play.card.suit} rank={play.card.rank} />
-        </div>
-      ))}
-    </div>
+        {trick.map((play) => (
+          <div
+            key={play.player}
+            className={`rounded-lg ${POSITION_CLASS[seatPosition(play.player, humanPlayer)]} ${
+              play.player === winningPlayer ? 'ring-4 ring-amber-400' : ''
+            }`}
+          >
+            <PlayingCard suit={play.card.suit} rank={play.card.rank} />
+          </div>
+        ))}
+        {calls?.map(({ player, name, call }) => (
+          <div
+            key={`call-${player}`}
+            // `role="img"` with a sentence for a name, the same shape
+            // `PlayingCard` uses: the visible content is a fragment whose meaning
+            // is positional, so the node is labelled as a whole rather than read
+            // as loose text.
+            role="img"
+            aria-label={describeCall(name, call)}
+            className={`flex items-center justify-center text-center ${POSITION_CLASS[seatPosition(player, humanPlayer)]}`}
+          >
+            <CallLabel call={call} />
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/web/src/components/tableTypes.ts
+++ b/web/src/components/tableTypes.ts
@@ -8,6 +8,28 @@ import type { Card, Suit } from '../engine/card'
 import type { TeamId } from '../engine/round'
 import type { PlayerIndex, TrickPlay } from '../engine/trick'
 
+/**
+ * What a seat has said in the auction, as data rather than as a formatted
+ * string (#191).
+ *
+ * It used to be `statusText?: string` — "Pass", "(300)", "(Waiting)" — rendered
+ * as one dim line under the player's name. Paul's dad asked for the auction to
+ * read like trick play does: the call shown big, at the seat's own place on the
+ * board. A pre-formatted string cannot do that, because the three cases want
+ * genuinely different type: a bid is a number and should dominate, a pass is a
+ * word, and waiting is the absence of news and should recede. Keeping the kind
+ * lets `TrickArea` make that call at the point of rendering.
+ *
+ * `'turn'` is the seat currently being asked, which the old string had no case
+ * for at all — it rendered nothing, so the one seat you most want to watch was
+ * the one the board said least about.
+ */
+export type SeatCall =
+  | { readonly kind: 'bid'; readonly amount: number }
+  | { readonly kind: 'pass' }
+  | { readonly kind: 'waiting' }
+  | { readonly kind: 'turn' }
+
 /** One seat at the table. `hand` is the real per-player Card list; seats
  * other than `TableState['humanPlayer']` only ever render `hand.length`
  * (face-down fan / count), never the cards themselves, since a real
@@ -16,9 +38,9 @@ export interface SeatState {
   readonly player: PlayerIndex
   readonly name: string
   readonly hand: readonly Card[]
-  /** Auction-phase status shown under the player name:
-   * "Pass", "(300)", "(Waiting)" etc. */
-  readonly statusText?: string
+  /** Auction-phase call, rendered big in the trick circle by `TrickArea`.
+   * Omitted outside the auction. */
+  readonly call?: SeatCall
 }
 
 export interface TableState {

--- a/web/src/layout/layoutProbe.tsx
+++ b/web/src/layout/layoutProbe.tsx
@@ -49,7 +49,7 @@ import { MeldFlow } from '../components/MeldFlow'
 import { PassSelector } from '../components/PassSelector'
 import { RoundSummary } from '../components/RoundSummary'
 import { Table } from '../components/Table'
-import type { TableState } from '../components/tableTypes'
+import type { SeatCall, TableState } from '../components/tableTypes'
 import { TrickLog } from '../components/TrickLog'
 import type { TrickPlayLogEntry } from '../components/trickPlayTypes'
 
@@ -107,12 +107,12 @@ const AUCTION_LOG: readonly AuctionLogEntry[] = [
   { kind: 'card-pass', fromPlayer: 3, fromName: SEAT_NAMES[3], toPlayer: 1, toName: SEAT_NAMES[1], count: 3 },
 ]
 
-function baseSeats(hands: Hands, statusText?: (p: PlayerIndex) => string | undefined): TableState['seats'] {
+function baseSeats(hands: Hands, call?: (p: PlayerIndex) => SeatCall | undefined): TableState['seats'] {
   const seat = (p: PlayerIndex) => ({
     player: p,
     name: SEAT_NAMES[p],
     hand: hands[p] as readonly Card[],
-    statusText: statusText?.(p),
+    call: call?.(p),
   })
   return [seat(0), seat(1), seat(2), seat(3)]
 }
@@ -128,9 +128,16 @@ export const PHASES = ['auction', 'pass', 'meld', 'trick', 'summary', 'gameover'
 export type PhaseId = (typeof PHASES)[number]
 
 function auctionPhase() {
-  // AuctionFlow's bidding composition: table + BiddingControls overlay + log.
+  // AuctionFlow's bidding composition: table + BiddingControls overlay. No log
+  // panel since #191 — the calls are on the circle now, and the probe has to
+  // compose what the flow composes or it measures a board nobody sees.
   const state: TableState = {
-    seats: baseSeats(HANDS, (p) => (p === 3 ? 'Pass' : p === 1 ? '(310)' : p === 2 ? '(Waiting)' : undefined)),
+    seats: baseSeats(HANDS, (p) =>
+      p === 3 ? { kind: 'pass' }
+      : p === 1 ? { kind: 'bid', amount: 310 }
+      : p === 2 ? { kind: 'waiting' }
+      : { kind: 'turn' },
+    ),
     humanPlayer: HUMAN,
     trick: [],
     trumpSuit: null,
@@ -146,21 +153,15 @@ function auctionPhase() {
       overlay={
         <BiddingControls minBid={320} currentBid={310} suggestedCeiling={330} onBid={noop} onPass={noop} />
       }
-      logPanel={
-        <AuctionLog
-          entries={AUCTION_LOG.slice(0, 5)}
-          currentBid={310}
-          bidWinnerName={SEAT_NAMES[1]}
-          dealerName={SEAT_NAMES[3]}
-        />
-      }
       onOpenMenu={noop}
     />
   )
 }
 
 function passPhase() {
-  // AuctionFlow's passing composition: table + PassSelector overlay + log.
+  // AuctionFlow's passing composition: table + PassSelector overlay. Passing is
+  // past the auction, so no seat carries a call and the circle is empty — same
+  // as the flow.
   const state: TableState = {
     seats: baseSeats(HANDS),
     humanPlayer: HUMAN,
@@ -176,7 +177,6 @@ function passPhase() {
     <Table
       state={state}
       overlay={<PassSelector hand={HANDS[HUMAN]} count={3} trumpSuit={TRUMP} onConfirm={noop} />}
-      logPanel={<AuctionLog entries={AUCTION_LOG} currentBid={BID} bidWinnerName={SEAT_NAMES[1]} dealerName={SEAT_NAMES[3]} />}
       onOpenMenu={noop}
     />
   )


### PR DESCRIPTION
Closes #191. Item 3 of dad's feedback.

## What changed

The auction used to say the same thing twice — a corner `AuctionLog` panel, and a
`text-xs text-white/60` line under each seat's name — and neither was placed
where you are already looking during trick play. Both are gone. Each seat's call
now renders in `TrickArea`, in the same cell that seat's played card lands in.

`SeatState.statusText?: string` became `SeatState.call?: SeatCall`, a
discriminated union of `bid` / `pass` / `waiting` / `turn`. That is the point of
the change rather than a tidy-up: a pre-formatted string can only be one size,
and these four cases want different weight, not different words.

| call | rendering |
|---|---|
| bid | `text-3xl` amber, tabular — the number dominates |
| pass | `text-xl` white/80 — a decision, still legible |
| waiting | `10px` white/45, tracked — the absence of one, recedes |
| turn | `…` amber/80 — **new**; the old string rendered nothing for the seat being asked |

So the board can be read for "who is still in" without reading any words.

## Accessibility

A call is visibly a bare `300`, and all of its meaning is *which cell it is in* —
which is exactly what does not survive being read aloud. Each call is a
`role="img"` with a name like `West: bid 320`, the same shape `PlayingCard` uses.

The colon form is deliberate rather than `formatAuctionLogEntry`'s "West bid 320"
sentence: the human's seat is literally named **"You"**, and two of the four
cases need a copula — "You is waiting". No single sentence form is grammatical
for every seat name; the label form is.

## Verified in the running app at 390x844

Four calls at the four cells, correct text and placement, board still exactly
844px with no scrolling in either direction and the corner panel gone.

`layoutProbe`'s auction and pass phases lost their log panels too — the probe has
to compose what the flow composes or it measures a board nobody sees.

## Not in this PR

`TrickPlayFlow` still renders `AuctionLog` after the auction, showing the bid
history. That is arguably the same "bidding box", but it is the only place the
per-seat bids remain visible once the circle is holding cards, and dropping it
loses information rather than duplicating it. One line to remove if you want it
gone — say the word.

## Tests

426 pass, five of them new. The placement test is the load-bearing one: it pins a
call to the same cell as that seat's played card for all 16 human/player
combinations, which is the mapping `Seat`, `Table` and `TrickArea` all have to
agree on for the board to mean anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)