### PR TITLE
Pin the 3-card pass against the skill dial (#196)

### DIFF
--- a/web/src/components/AuctionFlow.test.tsx
+++ b/web/src/components/AuctionFlow.test.tsx
@@ -1,11 +1,14 @@
 import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { Card, FORCED_BID, Suit } from '../engine/card'
+import { Card, Deck, FORCED_BID, Suit } from '../engine/card'
+import { partnerOf } from '../engine/round'
+import { PASS_COUNT, choosePassCards } from '../engine/passing'
 import type { PlayerIndex } from '../engine/trick'
 import { AI_BID_DELAY_MS, AuctionFlow } from './AuctionFlow'
 import type { AuctionState } from './auctionReducer'
 import { auctionReducer, initAuctionState, passedPlayersOf } from './auctionReducer'
 import type { AuctionResult } from './auctionTypes'
+import { DEFAULT_OPTIONS, type GameOptions, type SkillLevel } from '../persistence/options'
 
 const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'You', 1: 'West', 2: 'Partner', 3: 'East' }
 const SCORES = { 0: 0, 1: 0 }
@@ -357,5 +360,118 @@ describe('AuctionFlow (component)', { timeout: 20_000 }, () => {
     // text query matches both and cannot tell "seat 2 opened" from "the high bid
     // is 300" — which is the whole point of the assertion (#191).
     expect(screen.getByLabelText('Partner: bid 300')).not.toBeNull()
+  })
+
+  /**
+   * The pass is three cards at every skill level, end to end (#196).
+   *
+   * Paul's dad reported that changing the AI skill let him pass **4** cards.
+   * `passing.test.ts` fixes the count in the engine; this fixes it where he
+   * actually saw it — the wiring from `GameOptions` through `AuctionFlow` into
+   * the selector's `count` prop, and the selector's own refusal of a fourth.
+   *
+   * `PassSelector.test.tsx` already proves the component honours whatever
+   * `count` it is handed, and that is exactly the gap: a component that
+   * faithfully enforces the wrong number passes its own suite. The number has to
+   * be checked where it is chosen.
+   */
+  it.each(['easy', 'medium', 'hard', 'proficient', 'expert'] as const)(
+    'asks the human for exactly 3 cards, and refuses a 4th, at skill %s',
+    (skill) => {
+      vi.useFakeTimers()
+      const hands = buildTestHands()
+
+      render(
+        <AuctionFlow
+          initialHands={hands}
+          seatNames={SEAT_NAMES}
+          humanPlayer={0}
+          dealer={3}
+          scoresByTeam={SCORES}
+          options={{ ...DEFAULT_OPTIONS, opponentSkill: skill, teammateSkill: skill } as GameOptions}
+          onComplete={vi.fn()}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Bid' }))
+      act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+      act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+      act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+      fireEvent.click(screen.getByText('Hearts'))
+      act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
+
+      const heading = screen.getByRole('heading', { name: /Choose \d+ cards to pass/ })
+      expect(heading.textContent).toContain('Choose 3 cards to pass')
+
+      const panel = within(heading.closest('div') as HTMLElement)
+      const selectable = panel.getAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'))
+      expect(selectable.length).toBeGreaterThan(3)
+
+      // Three land; the fourth is refused and Confirm only ever opens on three.
+      for (const card of selectable.slice(0, 3)) fireEvent.click(card)
+      expect(panel.getByRole('button', { name: 'Confirm pass' })).not.toHaveProperty('disabled', true)
+      fireEvent.click(selectable[3])
+      expect(selectable.filter((b) => b.getAttribute('aria-pressed') === 'true')).toHaveLength(3)
+      expect(heading.textContent).toContain('(3/3 selected)')
+    },
+  )
+})
+
+/**
+ * The exchange conserves cards (#196).
+ *
+ * The count invariants in `passing.test.ts` say each side *hands over* three;
+ * they say nothing about what the reducer does with them. A pass that removed a
+ * card by value rather than by identity, or appended before removing, would
+ * leave a seat holding 11 or 13 and satisfy every test above — and "my hand has
+ * the wrong number of cards" is precisely the shape of the original report.
+ *
+ * So this runs the real exchange over real deals at every skill and asserts the
+ * two properties that make it a *pass* rather than a rewrite: every seat still
+ * holds twelve, and the 48 distinct cards of the deck are all still somewhere.
+ */
+describe('the pass exchange conserves the deck (#196)', () => {
+  const SKILLS: readonly SkillLevel[] = ['easy', 'medium', 'hard', 'proficient', 'expert']
+  const TRUMPS = [Suit.Spades, Suit.Diamonds, Suit.Clubs, Suit.Hearts] as const
+
+  it('leaves every seat on 12 cards and all 48 cards in play', () => {
+    const bad: string[] = []
+
+    for (let deal = 0; deal < 40; deal++) {
+      const deck = new Deck()
+      deck.shuffle()
+      const hands = deck.deal()
+      const bidder = (deal % 4) as PlayerIndex
+      const partner = partnerOf(bidder)
+      const trump = TRUMPS[deal % 4]
+      const skill = SKILLS[deal % SKILLS.length]
+
+      let state: AuctionState = {
+        ...initAuctionState(hands, 0, SEAT_NAMES, SCORES),
+        bidWinner: bidder,
+        bid: 300,
+        trumpSuit: trump,
+        phase: 'passing',
+      }
+
+      state = auctionReducer(state, {
+        type: 'PASS_CARDS',
+        from: bidder,
+        cards: choosePassCards(hands[bidder], PASS_COUNT, trump, true, skill),
+      })
+      state = auctionReducer(state, {
+        type: 'PASS_CARDS',
+        from: partner,
+        cards: choosePassCards(hands[partner], PASS_COUNT, trump, false, skill),
+      })
+
+      const where = `${skill}/${trump}/bidder ${bidder}`
+      const sizes = state.hands.map((h) => h.length)
+      if (sizes.some((n) => n !== 12)) bad.push(`${where}: hand sizes ${sizes.join(',')}`)
+      const everyCard = new Set(state.hands.flat().map((c) => c.toString()))
+      if (everyCard.size !== 48) bad.push(`${where}: ${everyCard.size} of 48 cards survived`)
+    }
+
+    expect(bad.slice(0, 10)).toEqual([])
   })
 })

--- a/web/src/engine/passing.test.ts
+++ b/web/src/engine/passing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { Card, Suit } from './card'
-import { bidderPassSelection, choosePassCards, partnerPassSelection } from './passing'
+import type { SkillLevel } from '../persistence/options'
+import { Card, Deck, Suit } from './card'
+import { PASS_COUNT, bidderPassSelection, choosePassCards, partnerPassSelection } from './passing'
 
 describe('partnerPassSelection', () => {
   it('D/S category: sends QS and JD to the bidder first', () => {
@@ -145,5 +146,72 @@ describe('choosePassCards', () => {
 
     expect(choosePassCards(hand, 3, Suit.Hearts, true)).toEqual([onlyCard])
     expect(choosePassCards(hand, 3, Suit.Hearts, false)).toEqual([onlyCard])
+  })
+})
+
+/**
+ * The 3-card pass, pinned against the skill dial (#196).
+ *
+ * Paul's dad reported that changing the AI skill level let him pass **4** cards
+ * instead of 3. It was not reproducible — he was on a stale deployed build whose
+ * one-row hand overflowed and clipped, which is the likelier thing he saw — but
+ * "not reproducible" is a weaker guarantee than the rules deserve, and the
+ * report named a dial that nothing should connect to the pass at all.
+ *
+ * So this fixes the count as a property rather than trusting that no future
+ * skill row grows a `passCount` field. Every combination that a real game can
+ * produce — five levels x both roles x four trumps, over real dealt hands —
+ * must return exactly three distinct cards that the hand actually held.
+ *
+ * `pinochle_rules.md` is the authority: the pass is three cards, always. The
+ * existing "returns exactly `count`" tests above take `count` as a parameter and
+ * so cannot catch a caller passing the wrong one; these fix the number itself.
+ */
+describe('the 3-card pass is invariant across skill levels (#196)', () => {
+  const SKILLS: readonly SkillLevel[] = ['easy', 'medium', 'hard', 'proficient', 'expert']
+  const TRUMPS = [Suit.Spades, Suit.Diamonds, Suit.Clubs, Suit.Hearts] as const
+
+  it('is three cards, and no skill level is wired to change it', () => {
+    expect(PASS_COUNT).toBe(3)
+  })
+
+  it('gives exactly 3 distinct cards from the hand, at every skill, role and trump', () => {
+    // Reported as a list rather than asserted per-iteration: a single failing
+    // combination is far more useful than the first one, since the whole
+    // question is *which* dial position misbehaves.
+    const bad: string[] = []
+
+    for (let deal = 0; deal < 60; deal++) {
+      const deck = new Deck()
+      deck.shuffle()
+      const hands = deck.deal()
+
+      for (const skill of SKILLS) {
+        for (const isBidder of [true, false]) {
+          for (const trump of TRUMPS) {
+            for (const hand of hands) {
+              const chosen = choosePassCards(hand, PASS_COUNT, trump, isBidder, skill)
+              const where = `${skill}/${isBidder ? 'bidder' : 'partner'}/${trump}`
+              if (chosen.length !== 3) bad.push(`${where}: passed ${chosen.length} cards`)
+              if (new Set(chosen).size !== chosen.length) bad.push(`${where}: duplicated a card`)
+              if (chosen.some((c) => !hand.includes(c))) bad.push(`${where}: passed a card not in hand`)
+            }
+          }
+        }
+      }
+    }
+
+    expect(bad.slice(0, 10)).toEqual([])
+  })
+
+  it('agrees on the count across every skill level for one identical hand', () => {
+    const deck = new Deck()
+    deck.shuffle()
+    const [hand] = deck.deal()
+
+    for (const isBidder of [true, false]) {
+      const counts = SKILLS.map((skill) => choosePassCards(hand, PASS_COUNT, Suit.Spades, isBidder, skill).length)
+      expect(new Set(counts)).toEqual(new Set([3]))
+    }
   })
 })


### PR DESCRIPTION
Closes #196. Tests only — no behaviour change, so no deploy needed.

Dad's item 4. Not reproducible when investigated, and the likelier cause was the
stale deployed build; adding the guard anyway on Paul's call.

## The gap, independent of what he saw

Every existing pass test takes `count` as a **parameter** — `partnerPassSelection(hand, trump, 'DS', 2)`,
`choosePassCards(hand, 3, ...)`. That proves the functions honour whatever number
they are handed, which is exactly the wrong question here. `PassSelector` has the
same shape: it already has tests for "keeps Confirm disabled until exactly
`count`" and "does not allow selecting more than `count`", and a component
faithfully enforcing a **wrong** `count` passes both.

The number was checked nowhere it is actually chosen.

## What was added

Three separate properties, each across all five skill levels:

| where | property |
|---|---|
| `passing.test.ts` | `choosePassCards` gives exactly 3 distinct cards, all really in the hand, for every skill x role x trump over real dealt hands — and all five levels agree on the count for one identical hand |
| `AuctionFlow.test.tsx` | the human is asked for exactly 3 **end to end**, and a 4th click is refused — this covers the wiring from `GameOptions` through `AuctionFlow` into the selector's `count` prop, which is where a skill-dependent count would have to live |
| `AuctionFlow.test.tsx` | the exchange **conserves the deck**: every seat still holds 12 and all 48 distinct cards survive |

The third is not redundant with the first two. A pass that removed a card by
value rather than by identity, or appended before removing, would leave a seat
holding 11 or 13 while every count assertion above stayed green — and "my hand
has the wrong number of cards" is precisely the shape of the original report.

## Verified non-vacuous

Forcing `PASS_COUNT = 4` fails **8** of the new assertions, including every
skill-level arm. The deck-conservation test correctly stays *green* under that
mutation — passing four each way still conserves — which is why it is a separate
property rather than folded into the others.

Failures are collected into a list and asserted at the end rather than thrown at
the first one: the question these answer is *which* dial position misbehaves, and
failing fast hides that.

## Tests

434 pass, up from 425. Runtime cost is negligible (`passing.test.ts` is 72ms for
the whole file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)