### PR TITLE
Hand-by-hand game ledger on the scoring screens (#198)

### DIFF
--- a/web/src/components/GameFlow.tsx
+++ b/web/src/components/GameFlow.tsx
@@ -209,13 +209,20 @@ export function GameFlow({ initialState, options = DEFAULT_OPTIONS, onOpenMenu }
   }
 
   if (state.phase === 'round-summary' && state.roundSummary) {
-    return <RoundSummary data={state.roundSummary} onContinue={() => dispatch({ type: 'CONTINUE_ROUND' })} />
+    return (
+      <RoundSummary
+        data={state.roundSummary}
+        ledger={state.handLedger}
+        onContinue={() => dispatch({ type: 'CONTINUE_ROUND' })}
+      />
+    )
   }
 
   if (state.phase === 'game-over' && state.gameOverData) {
     return (
       <GameOverScreen
         data={state.gameOverData}
+        ledger={state.handLedger}
         onNewGame={() => {
           // Local autosave (#54): the finished game's save would otherwise
           // briefly linger on disk (the autosave effect above skips writes

--- a/web/src/components/GameOverScreen.test.tsx
+++ b/web/src/components/GameOverScreen.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { GameOverData } from './scoreTypes'
+import { Suit } from '../engine/card'
+import type { GameOverData, HandLedgerEntry } from './scoreTypes'
 import { GameOverScreen } from './GameOverScreen'
 
 // See RoundSummary.test.tsx: no global `afterEach` is wired up for
@@ -14,6 +15,30 @@ const data: GameOverData = {
   teamNames: { 0: 'Team A', 1: 'Team B' },
 }
 
+/** A two-hand game: team 0 goes set, then wins it back. */
+const ledger: HandLedgerEntry[] = [
+  {
+    hand: 1,
+    bidWinnerTeam: 0,
+    bid: 340,
+    trumpSuit: Suit.Diamonds,
+    wentSet: true,
+    conceded: false,
+    roundScoreByTeam: { 0: -340, 1: 200 },
+    cumulativeScoresByTeam: { 0: -340, 1: 200 },
+  },
+  {
+    hand: 2,
+    bidWinnerTeam: 0,
+    bid: 300,
+    trumpSuit: Suit.Clubs,
+    wentSet: false,
+    conceded: false,
+    roundScoreByTeam: { 0: 1380, 1: 560 },
+    cumulativeScoresByTeam: { 0: 1040, 1: 760 },
+  },
+]
+
 describe('GameOverScreen', () => {
   it('announces the winning team', () => {
     render(<GameOverScreen data={data} onNewGame={() => {}} />)
@@ -24,6 +49,22 @@ describe('GameOverScreen', () => {
     render(<GameOverScreen data={data} onNewGame={() => {}} />)
     expect(screen.getByText('1040')).not.toBeNull()
     expect(screen.getByText('760')).not.toBeNull()
+  })
+
+  it('shows the whole match hand by hand when given a ledger (#198)', () => {
+    render(<GameOverScreen data={data} ledger={ledger} onNewGame={() => {}} />)
+    expect(screen.getByText('Game ledger')).not.toBeNull()
+    // Header row + one row per hand.
+    expect(screen.getAllByRole('row')).toHaveLength(3)
+    // Twice on hand 1: the delta, and the running total it produced from 0.
+    expect(screen.getAllByText('-340')).toHaveLength(2)
+    expect(screen.getByText('(set)')).not.toBeNull()
+    expect(screen.getByText('+1380')).not.toBeNull()
+  })
+
+  it('renders without a ledger for callers that do not have one', () => {
+    render(<GameOverScreen data={data} onNewGame={() => {}} />)
+    expect(screen.queryByText('Game ledger')).toBeNull()
   })
 
   it('calls onNewGame when the start-new-game button is clicked', () => {

--- a/web/src/components/GameOverScreen.tsx
+++ b/web/src/components/GameOverScreen.tsx
@@ -1,8 +1,13 @@
 import type { TeamId } from '../engine/round'
-import type { GameOverData } from './scoreTypes'
+import { HandLedger } from './HandLedger'
+import type { GameOverData, HandLedgerEntry } from './scoreTypes'
 
 export interface GameOverScreenProps {
   data: GameOverData
+  /** Every hand of the finished game (#198), rendered as a scrolling
+   * ledger under the final scores — the whole match at a glance rather
+   * than just the two totals it ended on. Omit to render without one. */
+  ledger?: readonly HandLedgerEntry[]
   onNewGame: () => void
 }
 
@@ -15,12 +20,14 @@ const TEAM_IDS: readonly TeamId[] = [0, 1]
  * the caller (a future game-orchestrator issue) owns actually resetting
  * game state when `onNewGame` fires.
  */
-export function GameOverScreen({ data, onNewGame }: GameOverScreenProps) {
+export function GameOverScreen({ data, ledger, onNewGame }: GameOverScreenProps) {
   const { winningTeam, finalScoresByTeam, teamNames } = data
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/70 p-4">
-      <div className="w-full max-w-sm rounded-lg bg-white p-6 text-center text-neutral-900 shadow-xl">
+      {/* max-h-full + scroll (#198): see RoundSummary — a long ledger must not
+          push "Start new game" off a short phone. */}
+      <div className="max-h-full w-full max-w-sm overflow-y-auto rounded-lg bg-white p-6 text-center text-neutral-900 shadow-xl">
         <h2 className="text-2xl font-bold">{teamNames[winningTeam]} wins!</h2>
 
         <dl className="mt-4 flex justify-center gap-8 text-sm">
@@ -33,6 +40,8 @@ export function GameOverScreen({ data, onNewGame }: GameOverScreenProps) {
             </div>
           ))}
         </dl>
+
+        {ledger && <HandLedger entries={ledger} teamNames={teamNames} />}
 
         <button
           type="button"

--- a/web/src/components/HandLedger.test.tsx
+++ b/web/src/components/HandLedger.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Suit } from '../engine/card'
+import { HandLedger } from './HandLedger'
+import type { HandLedgerEntry } from './scoreTypes'
+
+// See RoundSummary.test.tsx: no global `afterEach` is wired up for
+// @testing-library/react's automatic cleanup, so each render() here would
+// otherwise persist into the next test's DOM.
+afterEach(cleanup)
+
+const TEAM_NAMES = { 0: 'Team A', 1: 'Team B' } as const
+
+/** A three-hand game that goes up, down, up for team 0 — the shape the
+ * ledger exists to show. */
+const entries: readonly HandLedgerEntry[] = [
+  {
+    hand: 1,
+    bidWinnerTeam: 0,
+    bid: 250,
+    trumpSuit: Suit.Spades,
+    wentSet: false,
+    conceded: false,
+    roundScoreByTeam: { 0: 260, 1: 90 },
+    cumulativeScoresByTeam: { 0: 260, 1: 90 },
+  },
+  {
+    hand: 2,
+    bidWinnerTeam: 0,
+    bid: 340,
+    trumpSuit: Suit.Hearts,
+    wentSet: true,
+    conceded: false,
+    roundScoreByTeam: { 0: -340, 1: 150 },
+    cumulativeScoresByTeam: { 0: -80, 1: 240 },
+  },
+  {
+    hand: 3,
+    bidWinnerTeam: 1,
+    bid: 320,
+    trumpSuit: Suit.Clubs,
+    wentSet: false,
+    conceded: false,
+    roundScoreByTeam: { 0: 110, 1: 330 },
+    cumulativeScoresByTeam: { 0: 30, 1: 570 },
+  },
+]
+
+describe('HandLedger', () => {
+  it('renders one row per completed hand', () => {
+    render(<HandLedger entries={entries} teamNames={TEAM_NAMES} />)
+    // 3 hands + the header row.
+    expect(screen.getAllByRole('row')).toHaveLength(4)
+  })
+
+  it('shows each team per-hand delta with its sign', () => {
+    render(<HandLedger entries={entries} teamNames={TEAM_NAMES} />)
+    expect(screen.getByText('+260')).not.toBeNull()
+    expect(screen.getByText('-340')).not.toBeNull()
+    expect(screen.getByText('+330')).not.toBeNull()
+  })
+
+  it('shows the running total after each hand', () => {
+    render(<HandLedger entries={entries} teamNames={TEAM_NAMES} />)
+    expect(screen.getByText('-80')).not.toBeNull()
+    expect(screen.getByText('570')).not.toBeNull()
+  })
+
+  it('shows the bid and trump in the bidding team column only', () => {
+    render(<HandLedger entries={[entries[0]]} teamNames={TEAM_NAMES} />)
+    const cells = screen.getAllByRole('cell')
+    expect(cells[0].textContent).toContain('250')
+    expect(cells[0].textContent).toContain('♠')
+    expect(cells[1].textContent).not.toContain('250')
+  })
+
+  it('labels a hand the bidding team went set on', () => {
+    render(<HandLedger entries={[entries[1]]} teamNames={TEAM_NAMES} />)
+    expect(screen.getByText('(set)')).not.toBeNull()
+  })
+
+  it('labels a folded hand differently from a played-out set', () => {
+    const folded: HandLedgerEntry = { ...entries[1], conceded: true }
+    render(<HandLedger entries={[folded]} teamNames={TEAM_NAMES} />)
+    expect(screen.getByText('(folded)')).not.toBeNull()
+    expect(screen.queryByText('(set)')).toBeNull()
+  })
+
+  it('renders nothing before the first hand completes', () => {
+    const { container } = render(<HandLedger entries={[]} teamNames={TEAM_NAMES} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('caps its height and scrolls rather than growing with the game', () => {
+    render(<HandLedger entries={entries} teamNames={TEAM_NAMES} />)
+    const scroller = screen.getByRole('table').parentElement
+    expect(scroller?.className).toContain('overflow-y-auto')
+    expect(scroller?.className).toContain('max-h-')
+  })
+})

--- a/web/src/components/HandLedger.tsx
+++ b/web/src/components/HandLedger.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef } from 'react'
+import type { TeamId } from '../engine/round'
+import type { HandLedgerEntry } from './scoreTypes'
+import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
+
+export interface HandLedgerProps {
+  entries: readonly HandLedgerEntry[]
+  teamNames: Record<TeamId, string>
+}
+
+const TEAM_IDS: readonly TeamId[] = [0, 1]
+
+/** `+260` / `-340` — the sign is the whole point of this table, so a
+ * positive delta carries an explicit `+` rather than a bare number. */
+function formatDelta(points: number): string {
+  return points > 0 ? `+${points}` : String(points)
+}
+
+/**
+ * Hand-by-hand game ledger (#198), shown under the round-summary and
+ * game-over screens: one row per completed hand with who bid what, each
+ * team's delta for that hand, and their running total afterward. The two
+ * screens above it only ever show one round's numbers and the current
+ * totals — this is the answer to "we played 6 hands, up, down, up, up,
+ * down, up", which neither of them could give.
+ *
+ * Scrolls rather than growing: a game to 1000 usually takes 4-8 hands but
+ * has no bound, and both screens are fixed overlays on a phone. The body
+ * is capped and auto-scrolled to the bottom so the hand just played — the
+ * one the surrounding screen is about — is what's on screen when it opens,
+ * with the earlier hands a scroll up.
+ *
+ * Renders nothing before the first hand completes, so a caller can pass its
+ * ledger unconditionally.
+ */
+export function HandLedger({ entries, teamNames }: HandLedgerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  // Pin to the latest hand (see above). Depends on the count, not the
+  // array identity, so a re-render with an equivalent-but-new array doesn't
+  // yank a player's scroll position back down while they're reading up.
+  const handCount = entries.length
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [handCount])
+
+  if (handCount === 0) return null
+
+  return (
+    <div className="mt-4 text-left">
+      <h3 className="text-sm font-semibold text-neutral-900">Game ledger</h3>
+      {/* max-h-48 fits about 6 hands — a typical game to 1000 — without
+          scrolling, so the scroll only appears once a game runs long. */}
+      <div ref={scrollRef} className="mt-1 max-h-48 overflow-y-auto rounded border border-neutral-200">
+        <table className="w-full text-xs">
+          <caption className="sr-only">
+            Every hand played this game: the bid, each team&apos;s points for the hand, and their running total.
+          </caption>
+          <thead>
+            {/* Sticky inside the scroll box above — with 8 hands on screen
+                the team names would otherwise scroll away from the columns
+                they label. */}
+            <tr className="sticky top-0 bg-neutral-100 text-left text-neutral-500">
+              <th scope="col" className="px-2 py-1 font-medium">
+                #
+              </th>
+              {TEAM_IDS.map((team) => (
+                <th key={team} scope="col" className="px-2 py-1 font-medium text-neutral-900">
+                  {teamNames[team]}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => (
+              <tr key={entry.hand} className="border-t border-neutral-200">
+                <th scope="row" className="px-2 py-1 text-left font-normal text-neutral-500">
+                  {entry.hand}
+                </th>
+                {TEAM_IDS.map((team) => {
+                  const delta = entry.roundScoreByTeam[team]
+                  return (
+                    <td key={team} className="px-2 py-1 whitespace-nowrap">
+                      {/* The bid rides in the bidding team's own column, so
+                          who bid is readable without a separate column and
+                          a name to abbreviate (team names run long — see
+                          teamNames.ts's pool). */}
+                      {team === entry.bidWinnerTeam && (
+                        <span className="mr-1 text-neutral-500">
+                          {entry.bid}
+                          <span className={RED_SUITS.includes(entry.trumpSuit) ? 'text-red-600' : 'text-neutral-900'}>
+                            {SUIT_GLYPH[entry.trumpSuit]}
+                          </span>
+                        </span>
+                      )}
+                      {/* Space, not just the margin above: without it the bid
+                          and the delta run together as one word for a screen
+                          reader ("250♠+280"). */}
+                      {team === entry.bidWinnerTeam && ' '}
+                      <span className={delta < 0 ? 'font-semibold text-red-700' : 'font-semibold text-green-700'}>
+                        {formatDelta(delta)}
+                      </span>{' '}
+                      <span className="text-neutral-600">{entry.cumulativeScoresByTeam[team]}</span>
+                      {team === entry.bidWinnerTeam && entry.wentSet && (
+                        <span className="text-red-700"> {entry.conceded ? '(folded)' : '(set)'}</span>
+                      )}
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/RoundSummary.test.tsx
+++ b/web/src/components/RoundSummary.test.tsx
@@ -1,6 +1,7 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { RoundSummaryData } from './scoreTypes'
+import { Suit } from '../engine/card'
+import type { HandLedgerEntry, RoundSummaryData } from './scoreTypes'
 import { RoundSummary } from './RoundSummary'
 
 // No global `afterEach` is wired up for @testing-library/react's automatic
@@ -28,6 +29,29 @@ const wentSetData: RoundSummaryData = {
   teamNames: { 0: 'Team A', 1: 'Team B' },
 }
 
+const ledger: HandLedgerEntry[] = [
+  {
+    hand: 1,
+    bidWinnerTeam: 0,
+    bid: 250,
+    trumpSuit: Suit.Spades,
+    wentSet: false,
+    conceded: false,
+    roundScoreByTeam: { 0: 420, 1: 380 },
+    cumulativeScoresByTeam: { 0: 420, 1: 380 },
+  },
+  {
+    hand: 2,
+    bidWinnerTeam: 0,
+    bid: 180,
+    trumpSuit: Suit.Hearts,
+    wentSet: false,
+    conceded: false,
+    roundScoreByTeam: { 0: 190, 1: 144 },
+    cumulativeScoresByTeam: { 0: 610, 1: 524 },
+  },
+]
+
 describe('RoundSummary', () => {
   it('renders meld, trick, round, and running scores for both teams', () => {
     render(<RoundSummary data={madeContractData} />)
@@ -53,6 +77,23 @@ describe('RoundSummary', () => {
   it('omits the continue button when onContinue is not supplied', () => {
     render(<RoundSummary data={madeContractData} />)
     expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('shows every hand played so far when given a ledger (#198)', () => {
+    render(<RoundSummary data={madeContractData} ledger={ledger} />)
+    expect(screen.getByText('Game ledger')).not.toBeNull()
+    // Scoped to the ledger's own table — this screen renders a second one
+    // above it for the round just played.
+    const table = screen.getByRole('table', { name: /Every hand played/ })
+    // Header row + one row per hand.
+    expect(within(table).getAllByRole('row')).toHaveLength(3)
+    expect(within(table).getByText('+420')).not.toBeNull()
+    expect(within(table).getByText('+190')).not.toBeNull()
+  })
+
+  it('renders without a ledger for callers that do not have one', () => {
+    render(<RoundSummary data={madeContractData} />)
+    expect(screen.queryByText('Game ledger')).toBeNull()
   })
 
   it('calls onContinue when the continue button is clicked', () => {

--- a/web/src/components/RoundSummary.tsx
+++ b/web/src/components/RoundSummary.tsx
@@ -1,8 +1,14 @@
 import type { TeamId } from '../engine/round'
-import type { RoundSummaryData } from './scoreTypes'
+import { HandLedger } from './HandLedger'
+import type { HandLedgerEntry, RoundSummaryData } from './scoreTypes'
 
 export interface RoundSummaryProps {
   data: RoundSummaryData
+  /** Every hand played this game so far, including the one this screen is
+   * summarizing (#198) — rendered as a scrolling ledger under the round's
+   * own numbers. A separate prop rather than part of `RoundSummaryData`
+   * (see scoreTypes.ts's HandLedgerEntry); omit to render without one. */
+  ledger?: readonly HandLedgerEntry[]
   /** Called when the player dismisses the summary to continue. Optional
    * since this screen doesn't own round-advance logic (that's the
    * trick-play/bid UI, separate issues) — omit to render without a
@@ -20,7 +26,7 @@ const TEAM_IDS: readonly TeamId[] = [0, 1]
  * round-loop/game-orchestrator issue) decides when to show it and what
  * `onContinue` does.
  */
-export function RoundSummary({ data, onContinue }: RoundSummaryProps) {
+export function RoundSummary({ data, ledger, onContinue }: RoundSummaryProps) {
   const { meldPointsByTeam, trickPointsByTeam, roundScoreByTeam, bidWinnerTeam, bid, cumulativeScoresByTeam, teamNames } =
     data
   // scoreRound() only ever produces a negative net score for the bidding
@@ -29,7 +35,9 @@ export function RoundSummary({ data, onContinue }: RoundSummaryProps) {
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/60 p-4">
-      <div className="w-full max-w-sm rounded-lg bg-white p-6 text-neutral-900 shadow-xl">
+      {/* max-h-full + scroll (#198): the ledger grows with the game, and on a
+          short phone a long one would otherwise push Continue off-screen. */}
+      <div className="max-h-full w-full max-w-sm overflow-y-auto rounded-lg bg-white p-6 text-neutral-900 shadow-xl">
         <h2 className="text-lg font-semibold">Round summary</h2>
         <p className="mt-1 text-sm text-neutral-600">
           {teamNames[bidWinnerTeam]} bid {bid} and{' '}
@@ -82,6 +90,8 @@ export function RoundSummary({ data, onContinue }: RoundSummaryProps) {
             </tr>
           </tbody>
         </table>
+
+        {ledger && <HandLedger entries={ledger} teamNames={teamNames} />}
 
         {onContinue && (
           <button

--- a/web/src/components/gameFlowReducer.test.ts
+++ b/web/src/components/gameFlowReducer.test.ts
@@ -4,10 +4,23 @@ import type { Hands } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
 import type { AuctionResult } from './auctionTypes'
 import { gameFlowReducer, initGameFlowState, type GameFlowState } from './gameFlowReducer'
+import type { HandLedgerEntry } from './scoreTypes'
 import type { TrickPlayResult } from './trickPlayTypes'
 
 function emptyHands(): Hands {
   return [[], [], [], []]
+}
+
+/** One already-played hand, for the ledger tests (#198). */
+const ledgerEntry: HandLedgerEntry = {
+  hand: 1,
+  bidWinnerTeam: 0,
+  bid: 300,
+  trumpSuit: Suit.Hearts,
+  wentSet: false,
+  conceded: false,
+  roundScoreByTeam: { 0: 320, 1: 90 },
+  cumulativeScoresByTeam: { 0: 320, 1: 90 },
 }
 
 describe('initGameFlowState', () => {
@@ -173,6 +186,55 @@ describe('gameFlowReducer', () => {
       const trickResult: TrickPlayResult = { trickPointsByTeam: { 0: 0, 1: 0 }, trickWinners: [] }
       expect(gameFlowReducer(state, { type: 'TRICK_COMPLETE', result: trickResult })).toBe(state)
     })
+
+    it('appends the hand to the game ledger, numbered and carrying the bid (#198)', () => {
+      const state = stateAfterAuction()
+      const trickResult: TrickPlayResult = { trickPointsByTeam: { 0: 100, 1: 150 }, trickWinners: [] }
+      const next = gameFlowReducer(state, { type: 'TRICK_COMPLETE', result: trickResult })
+
+      expect(next.handLedger).toHaveLength(1)
+      expect(next.handLedger[0]).toEqual({
+        hand: 1,
+        bidWinnerTeam: 0,
+        bid: 300,
+        trumpSuit: Suit.Hearts,
+        // 190 meld + 100 tricks = 290 < 300 -> set (see the first test above).
+        wentSet: true,
+        conceded: false,
+        roundScoreByTeam: { 0: -300, 1: 150 },
+        cumulativeScoresByTeam: { 0: -300, 1: 150 },
+      })
+    })
+
+    it('numbers each hand after the last and keeps the earlier ones (#198)', () => {
+      const first = gameFlowReducer(stateAfterAuction(), {
+        type: 'TRICK_COMPLETE',
+        result: { trickPointsByTeam: { 0: 100, 1: 150 }, trickWinners: [] },
+      })
+      // Second hand, played from the scores and ledger the first one left.
+      const second = gameFlowReducer(
+        { ...stateAfterAuction({}, first.scoresByTeam), handLedger: first.handLedger },
+        { type: 'TRICK_COMPLETE', result: { trickPointsByTeam: { 0: 200, 1: 50 }, trickWinners: [] } },
+      )
+
+      expect(second.handLedger.map((e) => e.hand)).toEqual([1, 2])
+      expect(second.handLedger[0].roundScoreByTeam).toEqual({ 0: -300, 1: 150 })
+      // 190 meld + 200 tricks = 390 >= 300 -> made, and the running totals
+      // pick up where hand 1 left off.
+      expect(second.handLedger[1].wentSet).toBe(false)
+      expect(second.handLedger[1].roundScoreByTeam).toEqual({ 0: 390, 1: 50 })
+      expect(second.handLedger[1].cumulativeScoresByTeam).toEqual({ 0: 90, 1: 200 })
+    })
+
+    it('marks a folded hand as conceded in the ledger (#198)', () => {
+      const state = stateAfterAuction()
+      const next = gameFlowReducer(state, {
+        type: 'TRICK_COMPLETE',
+        result: { trickPointsByTeam: { 0: 0, 1: 0 }, trickWinners: [], conceded: true },
+      })
+      expect(next.handLedger[0].conceded).toBe(true)
+      expect(next.handLedger[0].wentSet).toBe(true)
+    })
   })
 
   describe('CONTINUE_ROUND', () => {
@@ -224,6 +286,13 @@ describe('gameFlowReducer', () => {
       const state = initGameFlowState(3)
       expect(gameFlowReducer(state, { type: 'CONTINUE_ROUND' })).toBe(state)
     })
+
+    it('carries the game ledger into the next round (#198)', () => {
+      const state = { ...stateAfterRoundSummary({ 0: 100, 1: 100 }), handLedger: [ledgerEntry] }
+      const next = gameFlowReducer(state, { type: 'CONTINUE_ROUND' })
+      expect(next.phase).toBe('dealing')
+      expect(next.handLedger).toEqual([ledgerEntry])
+    })
   })
 
   describe('NEW_GAME', () => {
@@ -243,6 +312,11 @@ describe('gameFlowReducer', () => {
       expect(next.dealer).toBe(3)
       expect(next.scoresByTeam).toEqual({ 0: 0, 1: 0 })
       expect(next.gameOverData).toBeNull()
+    })
+
+    it('clears the game ledger so a new game starts from an empty one (#198)', () => {
+      const state: GameFlowState = { ...initGameFlowState(1), phase: 'game-over', handLedger: [ledgerEntry] }
+      expect(gameFlowReducer(state, { type: 'NEW_GAME', dealer: 3 }).handLedger).toEqual([])
     })
 
     it('redraws seat and team names for the new game (#73)', () => {

--- a/web/src/components/gameFlowReducer.ts
+++ b/web/src/components/gameFlowReducer.ts
@@ -22,7 +22,7 @@ import { scoreRound, teamOf, type Hands, type TeamId } from '../engine/round'
 import { sampleTeamNames } from '../engine/teamNames'
 import type { PlayerIndex } from '../engine/trick'
 import type { AuctionResult } from './auctionTypes'
-import type { GameOverData, RoundSummaryData } from './scoreTypes'
+import type { GameOverData, HandLedgerEntry, RoundSummaryData } from './scoreTypes'
 import type { TrickPlayState } from './trickPlayReducer'
 import type { TrickPlayResult } from './trickPlayTypes'
 
@@ -50,6 +50,13 @@ export interface GameFlowState {
    * trick-play scoring. null until the meld phase completes. */
   readonly meldPointsByTeam: Record<TeamId, number> | null
   readonly roundSummary: RoundSummaryData | null
+  /** Hand-by-hand history of the game so far (#198), oldest first — one
+   * entry appended per completed round, cleared by NEW_GAME. The
+   * round-summary and game-over screens render it as a scrolling ledger;
+   * nothing in the game loop reads it back, so it is display-only state
+   * (which is why it lives here, alongside the scores it summarizes,
+   * rather than being reconstructed from a round log that doesn't exist). */
+  readonly handLedger: readonly HandLedgerEntry[]
   readonly gameOverData: GameOverData | null
   /** Local autosave (#54): a snapshot of TrickPlayFlow's internal state,
    * taken after each completed trick (never mid-trick/mid-AI-delay — see
@@ -131,6 +138,7 @@ export function initGameFlowState(dealer: PlayerIndex): GameFlowState {
     auctionResult: null,
     meldPointsByTeam: null,
     roundSummary: null,
+    handLedger: [],
     gameOverData: null,
     trickPlayCheckpoint: null,
     seatNames: randomSeatNames(),
@@ -221,10 +229,25 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         cumulativeScoresByTeam,
         teamNames: state.teamNames,
       }
+      // Game ledger (#198): one row per completed hand. scoreRound only
+      // ever returns a negative score for the bidding team falling short of
+      // their bid, so that sign is what "went set" means here — the same
+      // test RoundSummary.tsx makes.
+      const ledgerEntry: HandLedgerEntry = {
+        hand: state.handLedger.length + 1,
+        bidWinnerTeam,
+        bid,
+        trumpSuit: state.auctionResult.trumpSuit,
+        wentSet: roundScoreByTeam[bidWinnerTeam] < 0,
+        conceded: action.result.conceded === true,
+        roundScoreByTeam,
+        cumulativeScoresByTeam,
+      }
       return {
         ...state,
         phase: 'round-summary',
         roundSummary,
+        handLedger: [...state.handLedger, ledgerEntry],
         scoresByTeam: cumulativeScoresByTeam,
         trickPlayCheckpoint: null,
       }
@@ -257,6 +280,7 @@ export function gameFlowReducer(state: GameFlowState, action: GameFlowAction): G
         auctionResult: null,
         meldPointsByTeam: null,
         roundSummary: null,
+        handLedger: [],
         gameOverData: null,
         trickPlayCheckpoint: null,
         seatNames: randomSeatNames(),

--- a/web/src/components/scoreTypes.ts
+++ b/web/src/components/scoreTypes.ts
@@ -5,6 +5,7 @@
 // supply these shapes — the components themselves don't change. Mirrors
 // the approach tableTypes.ts took for the table layout scaffold (#33).
 
+import type { Suit } from '../engine/card'
 import type { TeamId } from '../engine/round'
 
 /** Fallback team display names (#73) for callers that don't have live
@@ -40,6 +41,38 @@ export interface RoundSummaryData {
    * GameFlowState.teamNames — replaces the old static "Team A"/"Team B"
    * labels. */
   readonly teamNames: Record<TeamId, string>
+}
+
+/**
+ * One completed hand as it appears in the game ledger (#198) — the
+ * hand-by-hand history both the round-summary and game-over screens show
+ * beneath their own numbers, so a player can see the shape of the game
+ * ("up, down, up, up, down") rather than only the two running totals.
+ *
+ * Deliberately *not* folded into `RoundSummaryData`: that shape is one
+ * round's detail and is persisted inside `GameFlowState.roundSummary`, so
+ * carrying the whole ledger in it would store the history once per round.
+ * The ledger is its own array on `GameFlowState` and reaches the screens as
+ * a separate prop.
+ */
+export interface HandLedgerEntry {
+  /** 1-based hand number, in the order they were played. */
+  readonly hand: number
+  readonly bidWinnerTeam: TeamId
+  readonly bid: number
+  readonly trumpSuit: Suit
+  /** True when the bidding team failed their contract — i.e. their entry in
+   * `roundScoreByTeam` is `-bid`. Stored rather than re-derived from the
+   * sign, since a defending team's score is never negative and a bidding
+   * team's `-bid` is the only way one appears. */
+  readonly wentSet: boolean
+  /** True when the bidding team folded (conceded) rather than playing the
+   * hand out — a set, but one the ledger labels differently. */
+  readonly conceded: boolean
+  /** scoreRound()'s output for this hand: the per-team delta. */
+  readonly roundScoreByTeam: Record<TeamId, number>
+  /** Running totals after this hand's delta was applied. */
+  readonly cumulativeScoresByTeam: Record<TeamId, number>
 }
 
 /** Everything the win/loss screen needs once `checkGameOutcome` (game.ts)

--- a/web/src/persistence/gameSave.test.ts
+++ b/web/src/persistence/gameSave.test.ts
@@ -120,6 +120,37 @@ describe('game save persistence', () => {
     expect(hasSavedGame()).toBe(false)
   })
 
+  it('round-trips the game ledger (#198)', () => {
+    const state: GameFlowState = {
+      ...initGameFlowState(3),
+      phase: 'round-summary',
+      handLedger: [
+        {
+          hand: 1,
+          bidWinnerTeam: 0,
+          bid: 300,
+          trumpSuit: Suit.Hearts,
+          wentSet: false,
+          conceded: false,
+          roundScoreByTeam: { 0: 320, 1: 90 },
+          cumulativeScoresByTeam: { 0: 320, 1: 90 },
+        },
+      ],
+    }
+    saveGame(state)
+    expect(loadGame()!.handLedger).toEqual(state.handLedger)
+  })
+
+  it('resumes a save written before the ledger existed with an empty one (#198)', () => {
+    // The save format's version wasn't bumped for the ledger, so a save
+    // already on a player's device parses but has no handLedger — it has to
+    // come back as [] rather than undefined, which the reducer would crash
+    // appending to at the end of the next hand.
+    const { handLedger: _omitted, ...preLedgerState } = initGameFlowState(3)
+    window.localStorage.setItem('pinochle:save:v1', JSON.stringify({ version: 1, state: preLedgerState }))
+    expect(loadGame()!.handLedger).toEqual([])
+  })
+
   it('treats corrupt JSON as no save', () => {
     window.localStorage.setItem('pinochle:save:v1', '{not json')
     expect(loadGame()).toBeNull()

--- a/web/src/persistence/gameSave.ts
+++ b/web/src/persistence/gameSave.ts
@@ -127,6 +127,12 @@ function reviveAuctionResult(result: AuctionResult): AuctionResult {
 function reviveGameFlowState(state: GameFlowState): GameFlowState {
   return {
     ...state,
+    // Game ledger (#198) postdates this save format, and the version wasn't
+    // bumped for it: a save written before it exists parses fine and would
+    // otherwise resume with `handLedger: undefined`, crashing the reducer's
+    // append on the first completed hand. An in-progress game predating the
+    // ledger simply resumes with an empty one rather than being discarded.
+    handLedger: state.handLedger ?? [],
     hands: reviveHands(state.hands),
     auctionResult: state.auctionResult ? reviveAuctionResult(state.auctionResult) : null,
     trickPlayCheckpoint: state.trickPlayCheckpoint ? reviveTrickPlayState(state.trickPlayCheckpoint) : null,


### PR DESCRIPTION
Closes #198.

## What

Both scoring screens now show every hand of the game underneath their own numbers:

```
Game ledger
#   Ironclad Vanguard      The Card Sharks
1   250♠ +280 280          +120 120
2   340♥ -340 -60 (set)    +210 330
3   +90 30                 320♦ +360 690
4   300♣ +310 340          +80 770
5   +60 400                360♠ -360 410 (folded)
6   320♥ +190 590          +144 554
```

Per hand: the bid and trump, each team's delta for that hand, and their running total afterward. The up/down shape Paul asked for reads straight off the sign column.

## How

- `GameFlowState.handLedger` — one `HandLedgerEntry` appended on `TRICK_COMPLETE`, cleared by `NEW_GAME`, carried across `CONTINUE_ROUND`. Display-only: nothing in the game loop reads it back.
- Kept out of `RoundSummaryData`, which is one round's detail and is persisted inside `GameFlowState.roundSummary` — folding the ledger into it would store the whole history once per round. It reaches both screens as a separate optional prop instead.
- The bid rides in the bidding team's own column rather than getting a column of its own; team names come from a pool where "Wyrmscale Brotherhood" is a normal draw, so there is nothing short to abbreviate them to.

## Scrolling

Paul's ask was "if the game goes long make it scroll", so it only scrolls when it has to: `max-h-48` fits about six hands — a typical game to 1000 — and taller ledgers scroll inside their own box, auto-pinned to the bottom so the hand just played is on screen with the earlier ones a scroll up. The header row is sticky, since with eight hands showing the team names would otherwise scroll away from the columns they label.

Both overlay cards also gained `max-h-full` + scroll: without it a long ledger pushes Continue / Start new game off the bottom of a short phone.

## Save compatibility

`SAVE_VERSION` is deliberately **not** bumped. A save written before this parses fine and would resume with `handLedger: undefined`, which the reducer crashes appending to at the end of the next hand — so `reviveGameFlowState` defaults it to `[]`. An in-progress game predating the ledger resumes with an empty one instead of being discarded. Pinned by a test that strips the field from a v1 payload.

## Verification

- **453 tests pass** (41 files), `oxlint` clean of new warnings, `tsc -b && vite build` clean.
- New coverage: `HandLedger.test.tsx` (rows, signs, running totals, bid-in-bidder-column, set vs folded, empty ledger, the scroll cap), plus ledger cases in the reducer, both screens, and the save round-trip.
- **Driven in the browser** at 375x812 and 375x500 with 6- and 10-hand ledgers: no horizontal overflow, `scrollTop` pinned to the last row, and the action button reachable after scrolling on the short viewport.

**Not deployed** — merging does not ship here.