### PR TITLE
Open the auction at 250 instead of 300 (#200)

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -31,8 +31,16 @@ RANK_VALUE = {rank: i for i, rank in enumerate(RANKS)}
 
 GAME_WIN_SCORE = 1000
 GAME_LOSE_SCORE = -1000
-OPENING_BID = 300
-FORCED_BID = 250  # what the dealer is stuck with if everyone passes without ever bidding
+# Lowest rung the auction can open at. 250 since #200 (was 300): a house
+# preference, not a rules discovery. Only the opening rung moved - the minimum
+# raise (10), OPENER_THRESHOLD (320, the hand a bidder needs to open at all)
+# and PARTNER_PASSED_FLOOR (320) are unchanged, so the AI opens on the same set
+# of hands as before and simply commits to 250 rather than 300 when it does.
+OPENING_BID = 250
+# What the dealer is stuck with if everyone passes without ever bidding. Equal
+# to OPENING_BID since #200, so passing the auction out no longer discounts
+# anything - the dealer lands on the rung the first seat could have opened at.
+FORCED_BID = 250
 
 
 class Card:

--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -44,13 +44,16 @@ from standard card-game rank order.
 
 ## Phase 1: Bidding
 
-- Opening bid: **300**. Minimum raise: **10**.
+- Opening bid: **250** (300 before #200). Minimum raise: **10**.
 - Starting with the player left of the dealer, bidding rotates clockwise.
 - On your turn: bid `current_bid + 10` (or more), or pass.
 - Once you pass, you're out of the rotation for the rest of the auction.
 - Bidding ends when 3 players have passed. The 4th is the **ContractWinner**.
 - Edge case: if all 4 players pass without ever bidding, the dealer is
-  forced to take the contract at a reduced **forced bid of 250**.
+  forced to take the contract at a **forced bid of 250**. Since the opening
+  bid came down to 250 (#200) this is no longer a reduction — passing the
+  auction out lands the dealer on the same rung the first seat could have
+  opened at.
 
 ## Phase 2: Trump & Passing
 

--- a/web/src/components/AuctionFlow.test.tsx
+++ b/web/src/components/AuctionFlow.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { Card, Deck, FORCED_BID, Suit } from '../engine/card'
+import { Card, Deck, FORCED_BID, OPENING_BID, Suit } from '../engine/card'
 import { partnerOf } from '../engine/round'
 import { PASS_COUNT, choosePassCards } from '../engine/passing'
 import type { PlayerIndex } from '../engine/trick'
@@ -279,7 +279,9 @@ describe('AuctionFlow (component)', { timeout: 20_000 }, () => {
     expect(onComplete).toHaveBeenCalledOnce()
     const result = onComplete.mock.calls[0][0] as AuctionResult
     expect(result.bidWinner).toBe(0)
-    expect(result.bid).toBe(300)
+    // The human took the contract at the opening rung, whatever that currently
+    // is — 250 since #200. A literal here pinned the rung, not the behaviour.
+    expect(result.bid).toBe(OPENING_BID)
     expect(result.trumpSuit).toBe(Suit.Hearts)
     // The 3 cards the human chose to pass are gone from their final hand.
     expect(result.hands[0].some((c) => c.suit === Suit.Clubs && c.rank === 'A')).toBe(false)
@@ -355,11 +357,11 @@ describe('AuctionFlow (component)', { timeout: 20_000 }, () => {
 
     // Left of dealer (1) is seat 2 (Partner), and this hand is worth a contract.
     act(() => vi.advanceTimersByTime(AI_BID_DELAY_MS))
-    // Asserted on the seat's call on the board, not on the bare text "300":
+    // Asserted on the seat's call on the board, not on the bare opening number:
     // the Scoreboard shows the same number as the standing contract, so a plain
-    // text query matches both and cannot tell "seat 2 opened" from "the high bid
-    // is 300" — which is the whole point of the assertion (#191).
-    expect(screen.getByLabelText('Partner: bid 300')).not.toBeNull()
+    // text query matches both and cannot tell "seat 2 opened" from "the high
+    // bid is the opener" — which is the whole point of the assertion (#191).
+    expect(screen.getByLabelText(`Partner: bid ${OPENING_BID}`)).not.toBeNull()
   })
 
   /**

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -372,14 +372,20 @@ describe('chooseBid', () => {
       expect(chooseBid(0, strongHand, 300, 10, context)).toBe(310)
     })
 
-    it('defensively pushes against an opening bid of 300 unless the hand is truly hopeless', () => {
+    it('defensively pushes against an opening bid unless the hand is truly hopeless', () => {
+      // Written against OPENING_BID rather than the literal it used to pin:
+      // the rule is "the opponent opened at the minimum", and #200 moved that
+      // minimum from 300 to 250. Held at 300 this test kept feeding a level
+      // that is no longer an opener, so `currentBid <= OPENING_BID` went false
+      // and the push it exists to check stopped firing at all.
+      const opener = { player: 1 as PlayerIndex, amount: OPENING_BID }
       // runOnlyHand has ceiling 300 (Run 150 + Ace 20 + baseline adj 130) >= DEFENSIVE_PUSH_FLOOR (200)
-      const context = baseContext({ everBid: true, bidHistory: [{ player: 1, amount: 300 }] })
-      expect(chooseBid(0, runOnlyHand, 300, 10, context)).toBe(310)
+      const context = baseContext({ everBid: true, bidHistory: [opener] })
+      expect(chooseBid(0, runOnlyHand, OPENING_BID, 10, context)).toBe(OPENING_BID + 10)
 
       // weakHand has ceiling 130 (no meld, no aces) < DEFENSIVE_PUSH_FLOOR (200) — truly hopeless
-      const hopelessContext = baseContext({ everBid: true, bidHistory: [{ player: 1, amount: 300 }] })
-      expect(chooseBid(0, weakHand, 300, 10, hopelessContext)).toBeNull()
+      const hopelessContext = baseContext({ everBid: true, bidHistory: [opener] })
+      expect(chooseBid(0, weakHand, OPENING_BID, 10, hopelessContext)).toBeNull()
     })
 
     it('relaxes the ceiling to at least 330 once my partner has bid', () => {

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -64,11 +64,13 @@ export const MAX_BID_MELD_THRESHOLD = 300
 
 // Minimum Base Bid to justify opening at all.
 export const OPENER_THRESHOLD = 320
-// Minimum ceiling to justify a defensive push against an opening bid of 300.
-// Hands at or above this floor should almost always raise a 300 opener,
-// since even moderate hands can contribute toward making 300 with partner's
-// help, and pushing deprives the opponent of a cheap contract. "Truly
-// hopeless" hands (no meld, no aces — ceiling ~130) fall below this floor.
+// Minimum ceiling to justify a defensive push against an opening bid (250
+// since #200, 300 before). Hands at or above this floor should almost always
+// raise an opener, since even moderate hands can contribute toward making it
+// with partner's help, and pushing deprives the opponent of a cheap contract.
+// "Truly hopeless" hands (no meld, no aces — ceiling ~130) fall below this
+// floor. It is a hand-strength threshold, not a bid level, so it did not move
+// with the opener.
 export const DEFENSIVE_PUSH_FLOOR = 200
 
 /**
@@ -576,12 +578,12 @@ export function chooseBid(
 
   const nextBid = currentBid + minIncrement
 
-  // Defensive push (#78): when opponent opened at the minimum (300), respond
-  // unless the hand is truly hopeless. The static rule is a ceiling floor
-  // (DEFENSIVE_PUSH_FLOOR) on the reasoning that 300 is the absolute floor and
-  // is almost always raised — even a moderate hand can contribute toward making
-  // 300 with partner's help, and pushing deprives the opponent of a cheap
-  // contract. The distilled rule asks the evaluator about the level actually
+  // Defensive push (#78): when opponent opened at the minimum (OPENING_BID —
+  // 250 since #200), respond unless the hand is truly hopeless. The static
+  // rule is a ceiling floor (DEFENSIVE_PUSH_FLOOR) on the reasoning that the
+  // opening rung is the absolute floor and is almost always raised — even a
+  // moderate hand can contribute toward making it with partner's help, and
+  // pushing deprives the opponent of a cheap contract. The distilled rule asks the evaluator about the level actually
   // being pushed to; declining here is not the end of the auction, it just
   // falls through to the ordinary raise ladder below.
   const pushLevel = partnerPassed ? Math.max(nextBid, PARTNER_PASSED_FLOOR) : nextBid

--- a/web/src/engine/card.ts
+++ b/web/src/engine/card.ts
@@ -33,8 +33,17 @@ export const COPIES_PER_CARD: readonly CopyId[] = [1, 2]
 
 export const GAME_WIN_SCORE = 1000
 export const GAME_LOSE_SCORE = -1000
-export const OPENING_BID = 300
+// Lowest rung the auction can open at. **250 since #200** (was 300): a house
+// preference, not a rules discovery. Only the opening rung moved — the minimum
+// raise (10), OPENER_THRESHOLD (320, the hand an AI needs to open at all) and
+// PARTNER_PASSED_FLOOR (320) are unchanged, so the AI opens on the same set of
+// hands as before and simply commits to 250 rather than 300 when it does.
+export const OPENING_BID = 250
 // What the dealer is stuck with if everyone passes without ever bidding.
+// Equal to OPENING_BID since #200, so passing the auction out no longer
+// discounts anything — the dealer lands on the rung the first seat could have
+// opened at. Kept as its own constant because the two mean different things
+// and only one of them is a house preference.
 // Coincidentally equal to round.ts's MAX_TRICK_POINTS and entirely unrelated
 // to it — one is an auction floor, the other the trick points in a deck. Do
 // not use either in place of the other (#178).

--- a/web/src/engine/evaluator.test.ts
+++ b/web/src/engine/evaluator.test.ts
@@ -4,7 +4,7 @@
 // hooked up, that the two models stay apart, and that the evaluator responds to
 // the bid level, which is the whole reason it replaces a fixed threshold.
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { type AuctionContext, chooseBid } from './bidding'
 import { Card, OPENING_BID, type Rank, Suit } from './card'
 import { evaluateBid, evaluateFold, modelLogit, shouldBid } from './evaluator'
@@ -223,8 +223,26 @@ describe('the skill dial selects the bid policy (#114, opened by #115)', () => {
   it('leaves easy on the meld-only path, which the evaluator never enters', () => {
     // Skill 1 short-circuits before any Base Bid valuation happens, so its
     // bidding is unchanged by #114 and MELD_ONLY_TRICK_ESTIMATE stays live.
-    // A lone trump Run scores 150 meld + 60 flat + noise in [-30, 30], never
-    // reaching the 300 opening bid.
-    expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'easy')).toBeNull()
+    // This hand melds 190 under Hearts (Run 150 + Royal Marriage 40), so the
+    // meld-only ceiling is 190 + 60 flat + noise in [-30, 30] = [220, 280].
+    //
+    // The noise has to be pinned. Against the old 300 opener the whole range
+    // fell short and a bare `toBeNull()` was deterministic; #200's 250 opener
+    // sits *inside* it, so the same assertion became a coin flip that passed
+    // roughly half the time. Pinning it is also a sharper check than the old
+    // one: at minimum noise `easy` declines a hand the evaluator opens, which
+    // is the divergence this test is named for, and at maximum noise the
+    // decision follows meld + flat arithmetic rather than the model.
+    const random = vi.spyOn(Math, 'random')
+    try {
+      random.mockReturnValue(0) // noise -30 -> ceiling 220, under the opener
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'easy')).toBeNull()
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
+
+      random.mockReturnValue(1) // noise +30 -> ceiling 280, over it
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'easy')).toBe(OPENING_BID)
+    } finally {
+      random.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
Closes #200.

`OPENING_BID` 300 -> 250 in `pinochle_engine.py`, `web/src/engine/card.ts` and `pinochle_rules.md`. House preference, per Paul: his dad expects to see the auction start at 250, "even if it will generally go up above".

## What did *not* move

Per "keep all minimums the same and rules of bidding the same":

| | |
|---|---|
| minimum raise | 10 |
| `OPENER_THRESHOLD` | 320 — the hand strength a bidder needs before opening at all |
| `PARTNER_PASSED_FLOOR` | 320 |
| `DEFENSIVE_PUSH_FLOOR` | 200 (a hand-strength threshold, not a bid level) |
| `MAX_BID_DEFAULT` / meld uncap | 400 / >300 |

So the AI opens on the same *set of hands* as before — that gate is `OPENER_THRESHOLD` — and simply commits to 250 rather than 300 when it does.

## Two consequences, written down rather than discovered later

- **`FORCED_BID` was already 250**, so passing the auction out is no longer a discount: the dealer lands on the rung the first seat could have opened at. Noted in the rules doc and both constant blocks.
- **The defensive push keys on `currentBid <= OPENING_BID`**, so it follows the opener down to 250 instead of firing a rung later.

## Three tests pinned 300 as a literal

Each was rewritten against `OPENING_BID`, which is the more useful assertion in every case:

- **bidding** — "defensively pushes against an opening bid of 300" was feeding a level that is no longer an opener, so `currentBid <= OPENING_BID` went false and the push the test exists to check stopped firing.
- **AuctionFlow** — the human's contract and seat 2's opening call are *the opening rung*, not the number 300.
- **evaluator** — `easy` melds **190** on that hand (Run 150 + Royal Marriage 40, measured, not assumed), so its meld-only ceiling is 190 + 60 flat + noise = **[220, 280]**. The old 300 opener sat above that whole range, which is what made a bare `toBeNull()` deterministic; 250 sits *inside* it and the test became a ~50/50 coin flip. `Math.random` is pinned now, and the assertion is sharper for it: at minimum noise `easy` declines a hand `hard` opens — the divergence the test is named for.

## Verification

- **453 web tests** (suite run 3x, for the noise-dependent paths) and **304 Python tests** pass. `oxlint` unchanged at its 3 pre-existing warnings; `tsc -b && vite build` clean.
- Driven in the browser: the human's bid panel reads **"Minimum: 250"**, and letting the AI take it over ends the auction at **"Bid: 250 (Jennifer)"**.

## One thing to know, not a blocker

The distilled evaluator (`evaluatorModel.ts`) was fitted on a dataset generated with a 300 opener, so 250 is a bid level it never saw in training. It is a linear model in the bid level, so it extrapolates smoothly rather than doing anything strange — a cheaper contract simply reads as more takeable. It is the same staleness class as #185, one more reason that issue's provenance stamp is worth having, and nothing here needs to wait on it.

**Not deployed** — merging does not ship here.