### PR TITLE
Meld cards 1.5x bigger — 28 -> 42px (#202)

### DIFF
--- a/web/src/components/MeldFlow.test.tsx
+++ b/web/src/components/MeldFlow.test.tsx
@@ -93,8 +93,11 @@ describe('MeldFlow', { timeout: 20_000 }, () => {
     const cards = screen.getAllByRole('img').filter((el) => el.closest('section[aria-label$="meld"]'))
     expect(cards.length).toBeGreaterThan(0)
     for (const card of cards) {
-      // `sm`, per PlayingCard's CARD_SIZES — 28px since #161's sizing pass.
-      expect(card.className).toContain('w-7')
+      // `sm`, per PlayingCard's CARD_SIZES — 28px in #161's sizing pass, 42
+      // since #202 grew it 1.5x for readability. Still the compact size, and
+      // still the only place `sm` is used anywhere in the app, which is what
+      // keeps a meld-panel resize off the table behind it.
+      expect(card.className).toContain('w-10.5')
       expect(card.className).not.toContain('w-16')
     }
   })

--- a/web/src/components/PlayingCard.test.tsx
+++ b/web/src/components/PlayingCard.test.tsx
@@ -50,7 +50,7 @@ describe('PlayingCard', { timeout: 20_000 }, () => {
     const { container: md } = render(<PlayingCard suit={Suit.Spades} rank="A" size="md" />)
     const { container: lg } = render(<PlayingCard suit={Suit.Spades} rank="A" />)
 
-    expect(widthsFor(sm.firstElementChild!)).toEqual(['w-7'])
+    expect(widthsFor(sm.firstElementChild!)).toEqual(['w-10.5'])
     expect(widthsFor(md.firstElementChild!)).toEqual(['w-12'])
     expect(widthsFor(lg.firstElementChild!)).toEqual(['w-20'])
   })
@@ -61,7 +61,8 @@ describe('PlayingCard', { timeout: 20_000 }, () => {
   // ratio rather than the pixel value keeps it true if the widths move again.
   it('keeps the index inside the strip the fan leaves visible', () => {
     const px = (cls: string, re: RegExp) => Number(cls.match(re)![1])
-    const WIDTH_PX = { sm: 28, md: 48, lg: 80 } as const
+    // sm is 42 since #202 (`w-10.5` — Tailwind v4's spacing scale takes halves).
+    const WIDTH_PX = { sm: 42, md: 48, lg: 80 } as const
 
     for (const size of ['sm', 'md', 'lg'] as const) {
       const { container } = render(<PlayingCard suit={Suit.Spades} rank="A" size={size} />)
@@ -87,9 +88,9 @@ describe('PlayingCard', { timeout: 20_000 }, () => {
   it('keeps a caller className from introducing a competing width', () => {
     const { container } = render(<PlayingCard suit={Suit.Spades} rank="A" size="sm" className="-ml-2" />)
     const cls = container.firstElementChild!.className
-    expect(cls).toContain('w-7')
+    expect(cls).toContain('w-10.5')
     expect(cls).toContain('-ml-2')
-    expect(cls.match(/(^|\s)w-\S+/g)!.map((s) => s.trim())).toEqual(['w-7'])
+    expect(cls.match(/(^|\s)w-\S+/g)!.map((s) => s.trim())).toEqual(['w-10.5'])
   })
 
   it('renders every suit and rank without throwing', () => {

--- a/web/src/components/PlayingCard.tsx
+++ b/web/src/components/PlayingCard.tsx
@@ -17,9 +17,19 @@ import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
  * the card shrank under them.
  *
  * Widths: `lg` went 80 -> 64 in #161 to fit a 12-card hand on a phone, and back
- * to **80** here now that #187's two rows only have to fit six. `aspect-5/7` is
- * what turns each width into a card, so the heights follow (lg 112, md 67,
- * sm 39) and the ratio is unchanged.
+ * to **80** here now that #187's two rows only have to fit six. `sm` went
+ * 28 -> **42** in #202 — exactly 1.5x, the size Paul asked for after his dad
+ * found the meld cards hard to read. `aspect-5/7` is what turns each width into
+ * a card, so the heights follow (lg 112, md 67, sm 59) and the ratio is
+ * unchanged.
+ *
+ * **Why 42 and not more.** `sm` is only ever used inside MeldFlow's panel, whose
+ * columns are ~147px on a 375px phone. Cards wrap at 3 per row from 40px all the
+ * way to 47px, so anything in that band costs the same rows; 48px is where it
+ * drops to 2 and a five-card Run needs three rows. Measured on a real 19-card
+ * meld at 375x812: the panel stands 509px tall at 28, 668 at 42, and reaches its
+ * own `max-h-[85vh]` cap (690) at 48, where the list starts scrolling. 42 keeps
+ * the biggest card that still leaves an ordinary hand un-scrolled.
  *
  * Everything else in a row is that row's width times a fixed fraction, which is
  * how the face stays the same face at every size:
@@ -33,7 +43,7 @@ import { RED_SUITS, SUIT_GLYPH } from './suitGlyphs'
  */
 const CARD_SIZES = {
   /** Compact, for dense read-only displays like meld declaration. */
-  sm: { width: 'w-7', rankSize: 'text-[11px]', suitSize: 'text-[15px]', markSize: 'text-[29px]', stripe: 'w-1', indexLeft: 'left-[6px]' },
+  sm: { width: 'w-10.5', rankSize: 'text-[17px]', suitSize: 'text-[23px]', markSize: 'text-[44px]', stripe: 'w-1', indexLeft: 'left-[7px]' },
   /** An AI seat's exposed hand during meld. */
   md: { width: 'w-12', rankSize: 'text-[19px]', suitSize: 'text-[26px]', markSize: 'text-[50px]', stripe: 'w-1', indexLeft: 'left-[7px]' },
   /** Full size — the human's hand, trick area, pass selector, pass reveal. */


### PR DESCRIPTION
Closes #202.

`PlayingCard`'s `sm` goes from `w-7` (28×39) to `w-10.5` (42×59) — **exactly 1.5×**, the size Paul asked for — with the matched set scaled with it per the table's own documented ratios: rank .40w (11→17), suit .55w (15→23), watermark 1.05w (29→44), index offset 6→7. The stripe stays 4px, its documented floor.

**Rendered comparison at real pixel sizes:** <https://claude.ai/code/artifact/ef80f2cc-7b84-4403-8f76-e0447af956eb>

## Nothing behind the panel moves

`sm` is used in exactly one place in the whole app — `MeldFlow`'s meld groups. `md` (an AI seat's exposed hand) and `lg` (the human's hand, trick area, pass selector, pass reveal) are untouched, which is what keeps this off the board. That is load-bearing: per #187 the board is already exactly 844px tall on a 390×844 phone, and anything that grows the human's seat costs twice its own height. `MeldFlow.test.tsx` pins the meld groups to `sm`, so the coupling can't silently widen.

## Sized by measurement, not by eye

Measured live at 375×812 against a real dealt hand — 19 meld cards, 8 groups, largest a five-card Run.

The meld column is **147.5px** there, and the card width only matters where it changes the wrap:

| Card width | fits per row |
|---|---|
| up to 35px | 4 |
| 36–47px | 3 |
| 48px and up | 2 |

Inside the 36–47 band bigger is free — same rows, same panel shape. 48 is a cliff: a five-card Run goes from two rows to three.

Panel height against its own `max-h-[85vh]` cap (690px on this viewport):

| Card width | | Panel height |
|---|---|---|
| 28px | today | 509 |
| 40px | 1.43× | 651 |
| **42px** | **1.50×** | **668** — 22px of headroom |
| 44px | 1.57× | 685 — 5px, which one extra meld row erases |
| 48px | 1.71× | 690, at the cap — list starts scrolling |

42 is the size asked for *and* the one that leaves an ordinary hand un-scrolled. A bigger-meld hand still reaches the cap and scrolls, which is the intended fallback and already how the panel behaves.

## Verification

- **453 tests pass**, `oxlint` unchanged at its 3 pre-existing warnings, `tsc -b && vite build` clean.
- Four tests pinned `w-7` as a literal (`PlayingCard` ×3, `MeldFlow` ×1) and now pin `w-10.5`; the index-inside-the-strip guard is a ratio, so it needed only its width constant updated (23/42 = .55, well under the .6875 limit).
- In the running app at 375×812: cards measure **42 × 58.8**, panel **668**, meld list not scrolling, no horizontal overflow, index box still inside the card.

One note: on a 320px-wide phone (iPhone SE 1st gen) the column is ~120px and 42px cards drop to 2 per row. Everything from the 5s era and later is 375+.

**Not deployed** — merging does not ship here.