### PR TITLE
Measure the opening-bid level (#204): the walk loses, dial ships off

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -824,6 +824,75 @@ contracts against cascade's 24.9% from the same bids on the same deals. A dial
 that can separate those by 202 points and separate a policy from itself by
 exactly 0 is one a null result from can be believed.
 
+### What the opener puts on the table (`openingPolicy`, #204)
+
+Paul, playing the deployed PWA, reported that too many hands settle under 300
+when almost all of them should land between 320 and 350. Measured over 4000
+AI-vs-AI auctions on `hard`, he was right and the distribution is stranger than
+the complaint: **41.1% settle at 250 and 51.7% at 320–350, with 0% anywhere in
+between.** Nothing in this engine ever settles at 260–310, because
+`PARTNER_PASSED_FLOOR` and the `Math.max(ceiling, 330)` in `chooseBid`'s
+competitive branch mean that once a raise ladder starts at all it clears 320. So
+"under 300" is exactly and only "the contract was never contested".
+
+Two causes, and only one of them is about aggression. 13.6% of deals are passed
+out and the dealer eats `FORCED_BID`. The other 27.4% are the one worth naming:
+**the opener never puts a number above the opening rung on the table.**
+`chooseBid` asks two separable questions — *should* I open, and *at what level* —
+and has only ever acted on the first, answering the second with `OPENING_BID`.
+A seat holding a 400-ceiling hand opens at 250 and, if the other three pass, buys
+the contract for 250. On those deals the winner's ceiling ran median 310, p75
+370, and 44.5% of them were worth 320 or more.
+
+`openingPolicy: 'walk'` is the fix, and it does not survive measurement.
+
+The dial is deliberately narrow. It is consulted only after `worthContract` has
+already returned true, so both arms open on an identical set of deals and pass on
+an identical set — `bidding.test.ts` asserts that directly. The only thing that
+differs is the price, which is what makes the result readable: a loss here means
+naming a higher number buys contracts that get set, and cannot be confounded
+with a change in how often the AI bids at all.
+
+`opening`, 5000 pairs x 3 seeds, both arms `distilled`/`model`/`cascade`:
+
+| seed | walk swept | fixed swept | split | margin/deal | 95% CI |
+|---|---|---|---|---|---|
+| 1 | 265 | 484 | 4251 | **-52** | -59 to -44 |
+| 2 | 264 | 509 | 4227 | **-56** | -65 to -48 |
+| 3 | 277 | 512 | 4211 | **-53** | -61 to -46 |
+
+p < 1e-4 on every seed. The mechanism is in the summary rows: walk lifts the
+average bid from 301 to 322 and its made rate falls from 73.2% to 69.2%, with
+auto-SET hands rising from 7.1% to 9.9%. It is buying the distribution with
+sets, at a bad exchange rate.
+
+`WALK_CONFIDENCE` buys the loss back and cannot buy enough of it. A greedy walk
+stops at the highest rung the model still tolerates, which is by construction the
+marginal one — probability barely past a coin flip — so it lands on the worst
+contract it is willing to hold, every deal. Requiring more confidence per rung
+helps monotonically: -48 at 0.60, -43 at 0.70, -26 at 0.80, and -7 (CI -14 to
++0) at 0.90. But the only setting whose interval touches zero lifts the average
+bid by 8 points, to 309, which is not the distribution the change was asked for.
+Roughly three points of score margin per point of bid lift, the whole way down.
+There is no free rung. The model was fitted to measured rollouts and it is right
+that the cheap contract is a good price.
+
+**The number that answers Paul's actual question is not in the A/B table.** A
+paired A/B asks whether walk *beats* fixed, but in a real game every AI seat runs
+the same policy, so the head-to-head penalty is not what a player experiences.
+Running each arm against itself (`selftest`, 2000 pairs) gives the house feel
+instead:
+
+| all-`fixed` table | all-`walk` table |
+|---|---|
+| avg bid 301, set 26.3% | avg bid 322, set 30.5% |
+
+That is the honest price of the distribution Paul asked for: symmetric, nobody
+disadvantaged, contracts going down about one extra time in every 24. Whether
+that is worse *play* or just a livelier game is a house-rules question and not a
+measurement one — which is why #204 is `ready-for-human` and why the dial ships
+wired-live and flag-off (#101) rather than being argued either way.
+
 `bench/index.html` is the browser side of the latency measurement, served by
 `npm run dev` at `/bench/` (it follows `base`, which is `/`). It is never an
 input to `vite build`, so it cannot reach a player or the PWA precache.

--- a/web/README.md
+++ b/web/README.md
@@ -861,6 +861,12 @@ with a change in how often the AI bids at all.
 | 2 | 264 | 509 | 4227 | **-56** | -65 to -48 |
 | 3 | 277 | 512 | 4211 | **-53** | -61 to -46 |
 
+These numbers were taken before #206 merged and were re-run against it, the way
+#158's table was re-run against #178. They did not move by a single point — same
+-52, same -59 to -44 interval, same 265/484/4251 sweep — which is the full-game
+confirmation of what #206's auction fingerprint already showed: a rule that only
+fires with a human in a seat is inert in a harness that has none.
+
 p < 1e-4 on every seed. The mechanism is in the summary rows: walk lifts the
 average bid from 301 to 322 and its made rate falls from 73.2% to 69.2%, with
 auto-SET hands rising from 7.1% to 9.9%. It is buying the distribution with

--- a/web/src/ab/ab.test.ts
+++ b/web/src/ab/ab.test.ts
@@ -21,6 +21,7 @@ import {
   BID_AB_POLICIES,
   DISTILLED_LEVEL,
   FOLD_AB_POLICIES,
+  OPENING_AB_POLICIES,
   PLAY_AB_POLICIES,
   SAFE_COUNTER_CONTROL,
   STATIC_LEVEL,
@@ -97,7 +98,7 @@ describe('the policy override', () => {
     // attributed to. Cheap to assert, and it is the assertion that keeps the
     // next map (#154 onward) honest as the union of policies grows.
     const safeCounter = safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)
-    const maps = [BID_AB_POLICIES, FOLD_AB_POLICIES, AUTO_SET_AB_POLICIES, PLAY_AB_POLICIES, safeCounter]
+    const maps = [BID_AB_POLICIES, FOLD_AB_POLICIES, AUTO_SET_AB_POLICIES, PLAY_AB_POLICIES, OPENING_AB_POLICIES, safeCounter]
     for (const policies of maps) {
       const [a, b] = Object.values(policies)
       const differing = (Object.keys(a) as (keyof typeof a)[]).filter((field) => a[field] !== b[field])
@@ -320,6 +321,8 @@ describe('the A/B self-test', () => {
     // the most scope to desynchronise dealer rotation or scoring between the
     // two orientations of a pair — exactly what a zero paired margin rules out.
     ['auto-set', DISTILLED_LEVEL, AUTO_SET_AB_POLICIES],
+    ['walk', DISTILLED_LEVEL, OPENING_AB_POLICIES],
+    ['fixed-open', STATIC_LEVEL, OPENING_AB_POLICIES],
     // #158's two arms, both of which now play behind auto-SET.
     ['counted', 'expert', safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)],
     ['uncounted', SAFE_COUNTER_CONTROL.expert, safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)],

--- a/web/src/ab/abRun.ts
+++ b/web/src/ab/abRun.ts
@@ -70,6 +70,7 @@ export const BID_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -78,6 +79,7 @@ export const BID_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
 }
 
@@ -98,6 +100,7 @@ export const FOLD_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -106,6 +109,7 @@ export const FOLD_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
 }
 
@@ -134,6 +138,7 @@ export const AUTO_SET_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'off',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -142,6 +147,48 @@ export const AUTO_SET_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
+  },
+}
+
+/**
+ * Opening-level A/B (#204): identical appetites, differing only in what number
+ * a seat that has already decided to open actually names.
+ *
+ * Both arms bid `'distilled'`, fold with the model and play the cascade — the
+ * same choice `FOLD_AB_POLICIES` and `PLAY_AB_POLICIES` make, and for the same
+ * reason: this describes the change as it would ship on `hard` and above.
+ *
+ * What makes this map worth reading carefully is that the two arms do not
+ * disagree about *which* hands are worth a contract. `openingPolicy` is
+ * consulted only after `worthContract` has already returned true, so both sides
+ * open on exactly the same deals and pass on exactly the same deals. The only
+ * difference is the price on the table, which means a negative result here has
+ * one clean interpretation — naming a higher number buys contracts that get
+ * set — rather than being confounded with a change in how often the AI bids
+ * at all.
+ *
+ * Side A (`DISTILLED_LEVEL`) carries the arm under test, matching every other
+ * map in this file.
+ */
+export const OPENING_AB_POLICIES: Record<string, SkillParams> = {
+  [STATIC_LEVEL]: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+    autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
+  },
+  [DISTILLED_LEVEL]: {
+    handValuation: 'base_bid',
+    bidPolicy: 'distilled',
+    foldPolicy: 'model',
+    playPolicy: 'cascade',
+    autoSetPolicy: 'forced',
+    safeCounterPolicy: 'counted',
+    openingPolicy: 'walk',
   },
 }
 
@@ -176,6 +223,7 @@ export const PLAY_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'simple',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -184,6 +232,7 @@ export const PLAY_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
 }
 
@@ -231,6 +280,7 @@ export function safeCounterAbPolicies(
       playPolicy: 'cascade',
       autoSetPolicy: 'forced',
       safeCounterPolicy: 'counted',
+      openingPolicy: 'fixed',
     },
     [offLevel]: {
       handValuation: 'base_bid',
@@ -239,6 +289,7 @@ export function safeCounterAbPolicies(
       playPolicy: 'cascade',
       autoSetPolicy: 'forced',
       safeCounterPolicy: 'off',
+      openingPolicy: 'fixed',
     },
   }
 }
@@ -283,6 +334,7 @@ export function safeCounterCapacityPolicies(
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   }
   return { [highLevel]: counted, [lowLevel]: counted }
 }

--- a/web/src/ab/cli.ts
+++ b/web/src/ab/cli.ts
@@ -6,6 +6,7 @@
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts ab --pairs 400
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts fold --pairs 400
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts play --pairs 400
+//   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts opening --pairs 5000
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts autoset --pairs 5000
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts safe --pairs 400 --level expert
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts capacity --high expert --low easy
@@ -39,6 +40,7 @@ import {
   BID_AB_POLICIES,
   DISTILLED_LEVEL,
   FOLD_AB_POLICIES,
+  OPENING_AB_POLICIES,
   PLAY_AB_POLICIES,
   SAFE_COUNTER_CONTROL,
   STATIC_LEVEL,
@@ -60,6 +62,8 @@ const SELFTEST_ARMS: Record<string, { level: SkillLevel; policies: Record<string
   simple: { level: STATIC_LEVEL, policies: PLAY_AB_POLICIES },
   cascade: { level: DISTILLED_LEVEL, policies: PLAY_AB_POLICIES },
   'auto-set': { level: DISTILLED_LEVEL, policies: AUTO_SET_AB_POLICIES },
+  walk: { level: DISTILLED_LEVEL, policies: OPENING_AB_POLICIES },
+  'fixed-open': { level: STATIC_LEVEL, policies: OPENING_AB_POLICIES },
   // #158's two arms. `counted` doubles up the expert capacity against itself;
   // `uncounted` doubles up the baseline, which is the control that says the
   // safe-counter change is the only thing separating the two sides of a `safe`
@@ -105,6 +109,20 @@ if (command === 'fold') {
     labelA: 'auto-set',
     labelB: 'play-it-out',
     policies: AUTO_SET_AB_POLICIES,
+  })
+  console.log(summarise(report, analyse(report, seed)))
+} else if (command === 'opening') {
+  // #204's measurement: identical distilled bidders opening on identical hands,
+  // one naming `OPENING_BID` and one naming the highest rung its own policy
+  // still says the hand is worth.
+  const pairs = flag('pairs', 400)
+  const seed = flag('seed', 1)
+  const report = runAb({
+    nPairs: pairs,
+    seed,
+    labelA: 'walk',
+    labelB: 'fixed-open',
+    policies: OPENING_AB_POLICIES,
   })
   console.log(summarise(report, analyse(report, seed)))
 } else if (command === 'play') {

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -20,6 +20,7 @@ import {
   PARTNER_RAISE_FLOOR,
 } from './bidding'
 import { partnerOf } from './round'
+import { SKILL_PARAMS } from './skills'
 import type { PlayerIndex } from './trick'
 
 const trump = Suit.Spades
@@ -720,6 +721,111 @@ describe('raising over a bid our own team already holds (#206)', () => {
         passedPlayers: [],
       }
       expect(chooseBid(2, weakHand, oppBid, 10, context, 'hard')).toBe(oppBid + 10)
+    }
+  })
+})
+
+// -- openingPolicy: 'walk' (#204) -------------------------------------------
+//
+// No shipped `SKILL_PARAMS` row selects `'walk'`, so these install it the way
+// `abRun.ts` does. The measurement said `'fixed'` wins on score margin and the
+// dial ships off; these exist so the arm stays correct and re-measurable rather
+// than rotting into something the harness can no longer trust.
+describe("openingPolicy: 'walk'", () => {
+  // Base Bid 210 (Run 150 + extra Royal Marriage 40 + Ace 20) -> ceiling 340 at
+  // the 0/0 adjustment, so it clears OPENER_THRESHOLD and has room above the
+  // opening rung for the walk to actually climb into.
+  const strongHand = [
+    ...RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1)),
+    new Card(Suit.Hearts, 'K', 2),
+    new Card(Suit.Hearts, 'Q', 2),
+  ]
+
+  // Dealer 1, so dealer-protection (which keys off the partner being dealer)
+  // does not fire and the opening branch is a hand judgement.
+  const context: AuctionContext = {
+    everBid: false,
+    passesSoFar: 0,
+    bidHistory: [],
+    dealer: 1,
+    scores: { 0: 0, 1: 0 },
+    passedPlayers: [],
+  }
+
+  const withWalk = (level: SkillLevel, run: () => void) => {
+    const saved = SKILL_PARAMS[level]
+    SKILL_PARAMS[level] = { ...saved, openingPolicy: 'walk' }
+    try {
+      run()
+    } finally {
+      SKILL_PARAMS[level] = saved
+    }
+  }
+
+  it('opens above OPENING_BID on a hand worth more than the opening rung', () => {
+    // The defect #204 names: `'fixed'` prices this hand at whatever rung the
+    // auction happens to start on, however much it is holding.
+    expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
+    withWalk('hard', () => {
+      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'hard')).toBeGreaterThan(OPENING_BID)
+    })
+  })
+
+  it('never opens a hand that would have passed — it changes price, not appetite', () => {
+    // `openingLevelFor` runs only once `opens` is already true, so both arms
+    // open on an identical set of deals. That is what lets #204's A/B attribute
+    // its result to the level named and not to a change in how often the AI
+    // bids at all.
+    const realRandom = Math.random
+    Math.random = seededRandom(20260820)
+    try {
+      for (let i = 0; i < 100; i++) {
+        const deck = new Deck()
+        deck.shuffle()
+        const hands = deck.deal()
+        for (const level of ['medium', 'hard'] as SkillLevel[]) {
+          for (const seat of SEATS) {
+            const fixed = chooseBid(seat, hands[seat], OPENING_BID - 10, 10, context, level)
+            withWalk(level, () => {
+              const walked = chooseBid(seat, hands[seat], OPENING_BID - 10, 10, context, level)
+              expect(walked === null).toBe(fixed === null)
+            })
+          }
+        }
+      }
+    } finally {
+      Math.random = realRandom
+    }
+  })
+
+  it('stays on the multiple-of-ten grid and never exceeds the hand ceiling (#177)', () => {
+    const realRandom = Math.random
+    Math.random = seededRandom(4242)
+    try {
+      withWalk('hard', () => {
+        for (let i = 0; i < 200; i++) {
+          const deck = new Deck()
+          deck.shuffle()
+          const hands = deck.deal()
+          const opened = chooseBid(0, hands[0], OPENING_BID - 10, 10, context, 'hard')
+          if (opened === null) continue
+          expect(opened % 10).toBe(0)
+          expect(opened).toBeGreaterThanOrEqual(OPENING_BID)
+          // The walk is ceiling-bounded; the opening *floor* is not — a
+          // distilled seat may take OPENING_BID on a hand whose speculative
+          // ceiling is under it, and always could. What must never happen is
+          // the walk carrying a seat above what its cards are worth.
+          expect(opened).toBeLessThanOrEqual(Math.max(OPENING_BID, bestBaseBid(hands[0], 0, 0).total))
+        }
+      })
+    } finally {
+      Math.random = realRandom
+    }
+  })
+
+  it('leaves every shipped level on the fixed opening rung', () => {
+    for (const level of SKILL_LEVELS) {
+      expect(SKILL_PARAMS[level].openingPolicy).toBe('fixed')
     }
   })
 })

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -109,6 +109,41 @@ export const DEFENSIVE_PUSH_FLOOR = 200
  * of three seeds (`web/README.md`, "The partner-passed bid floor").
  */
 export const PARTNER_PASSED_FLOOR = 320
+/**
+ * How sure the evaluator has to be before an `openingPolicy: 'walk'` seat steps
+ * its opening up another rung (#204).
+ *
+ * `modelDecision` uses the model's own `threshold` (0.5), which means a greedy
+ * walk stops at the *highest* rung the model still tolerates — and that rung is
+ * by construction the marginal one, where the model is barely past a coin flip.
+ * Walking to it therefore lands the seat on the worst contract it is willing to
+ * hold, systematically, on every deal it opens.
+ *
+ * That is the mechanism behind #204's headline result, and raising this number
+ * buys it back, monotonically and at a fixed exchange rate. Measured on `hard`,
+ * 3000 paired deals, seed 1, against the `'fixed'` arm:
+ *
+ * | confidence | avg bid | set % | margin/deal |
+ * |---|---|---|---|
+ * | 0.50 | 322 | 30.5% | -53 (-61 to -46) |
+ * | 0.60 | 320 | 29.8% | -48 (-59 to -38) |
+ * | 0.70 | 317 | 29.4% | -43 (-53 to -33) |
+ * | 0.80 | 314 | 28.2% | -26 (-35 to -17) |
+ * | 0.90 | 309 | 27.0% | -7 (-14 to +0) |
+ *
+ * There is no free rung on that curve: roughly three points of score margin per
+ * point of bid lift, all the way down to the one setting whose CI touches zero,
+ * which lifts the average bid by 8 and does not reach the distribution the
+ * change was asked for. That is the finding, not a tuning failure — the model
+ * was fitted to measured rollouts, and it is right that the cheap contract is a
+ * good price.
+ *
+ * Left at the model's own threshold because that is the arm the three-seed
+ * headline measurement ran, so the committed constant and the recorded number
+ * describe the same thing. Anyone enabling `'walk'` should move this first and
+ * re-measure, not inherit the greedy walk by default.
+ */
+export const WALK_CONFIDENCE = 0.5
 
 /**
  * The bid a seat must commit to when it raises **over its own partner** (#206).
@@ -547,6 +582,45 @@ export function chooseBid(
         })
       : staticVerdict
 
+  // What number to put on the table once `opens` is true (#204). Under
+  // `'fixed'` — every shipped row today — that is the floor and nothing else,
+  // which is the behaviour this dial was split off to make measurable rather
+  // than to change. Under `'walk'` the seat steps up while its own policy still
+  // says the hand is worth the next rung, so the level it names reflects the
+  // hand it is holding instead of the rung the auction happens to start on.
+  //
+  // Bounded above by `ceiling`, so the walk cannot talk a seat past what its
+  // cards are worth, and it steps by `minIncrement` so it cannot leave the
+  // multiple-of-ten grid (#177). The static verdict keeps the cushion
+  // `OPENER_THRESHOLD` already implies over `OPENING_BID` — 70 points — so a
+  // static seat asked about level L wants a ceiling of L + 70, which at the
+  // opening rung is exactly `OPENER_THRESHOLD` and stays self-consistent as the
+  // level climbs. Without that the level-independent static verdict would walk
+  // every opener to its ceiling.
+  const openingLevelFor = (floor: number): number => {
+    if (SKILL_PARAMS[skill].openingPolicy !== 'walk') return floor
+    const cushion = OPENER_THRESHOLD - OPENING_BID
+    const accepts = (level: number): boolean =>
+      distilled
+        ? shouldBid(
+            {
+              hand,
+              bid: level,
+              ourScore: myScore,
+              theirScore: oppScore,
+              partnerHasBid,
+              partnerHasPassed: partnerPassed,
+            },
+            WALK_CONFIDENCE,
+          )
+        : ceiling >= level + cushion
+    let level = floor
+    while (level + minIncrement <= ceiling && accepts(level + minIncrement)) {
+      level += minIncrement
+    }
+    return level
+  }
+
   if (!context.everBid) {
     // Dealer-protection, restored from `Player.choose_bid` by the #126 audit.
     // This tier was dropped in aeb97b3 — the same hand-port slip that took
@@ -567,8 +641,9 @@ export function chooseBid(
     // retired the two branches say the same thing, so they are one. The level
     // being committed to still differs: a partner-passed seat opens at the
     // floor rather than at OPENING_BID.
-    const openingLevel = partnerPassed ? minBidAfterPartnerPass : OPENING_BID
-    const opens = worthContract(openingLevel, ceiling >= OPENER_THRESHOLD)
+    const floorLevel = partnerPassed ? minBidAfterPartnerPass : OPENING_BID
+    const opens = worthContract(floorLevel, ceiling >= OPENER_THRESHOLD)
+    const openingLevel = opens ? openingLevelFor(floorLevel) : floorLevel
 
     // 3rd bidder opens cheap.
     if (context.passesSoFar === 2) {
@@ -578,7 +653,7 @@ export function chooseBid(
       // Positional, not a hand judgement: with partner still to speak this
       // seat opens on anything to deny the last player a cheap contract, so
       // neither policy is consulted.
-      return partnerPassed ? (opens ? openingLevel : null) : OPENING_BID
+      return partnerPassed ? (opens ? openingLevel : null) : opens ? openingLevel : OPENING_BID
     }
 
     // Normal opener threshold (4th bidder / dealer — partner has already

--- a/web/src/engine/evaluator.ts
+++ b/web/src/engine/evaluator.ts
@@ -166,8 +166,9 @@ export function evaluateBid(situation: BidSituation): Evaluation {
 }
 
 /** True when the evaluator says taking the contract at `bid` beats defending it. */
-export function shouldBid(situation: BidSituation): boolean {
-  return evaluateBid(situation).decision
+export function shouldBid(situation: BidSituation, threshold?: number): boolean {
+  const evaluation = evaluateBid(situation)
+  return threshold === undefined ? evaluation.decision : evaluation.probability >= threshold
 }
 
 // -- The concede decision ---------------------------------------------------

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -136,6 +136,35 @@ export type AutoSetPolicy = 'forced' | 'off'
  */
 export type SafeCounterPolicy = 'off' | 'counted'
 
+/**
+ * What number a seat that decides to open actually puts on the table (#204).
+ *
+ *   `'fixed'`  open at `OPENING_BID` — 250 — whatever the hand is worth. What
+ *              every level has always done.
+ *   `'walk'`   open at the highest rung the seat's own bid policy still says
+ *              the hand is worth, starting from `OPENING_BID` and stepping by
+ *              the auction's minimum increment.
+ *
+ * The distinction exists because `chooseBid` asks two separable questions and
+ * has only ever acted on the first: *should* I open, and *at what level*. The
+ * opening branch answers the first with `worthContract(OPENING_BID, ...)` and
+ * then hard-codes the second to `OPENING_BID`, so a seat holding a 400-ceiling
+ * hand opens at 250 and, if the other three pass, buys the contract for 250.
+ * Measured over 4000 AI-vs-AI auctions on `hard`, that is 27.4% of all deals,
+ * and 44.5% of those hands were worth 320 or more.
+ *
+ * `'walk'` does not make a seat open on hands it would have passed: the loop
+ * only runs once `opens` is already true, and it is bounded above by the
+ * hand's own capped ceiling. It changes the *price*, not the *appetite*.
+ *
+ * This is a `SkillParams` field rather than a constant for the reason
+ * `FoldPolicy` and `PlayPolicy` are: `abRun.ts` can only sit two rules at one
+ * table by running two levels that differ in exactly one field, so a rule with
+ * no field is a rule that cannot be measured. No shipped row selects `'walk'`
+ * until #204's A/B says it should.
+ */
+export type OpeningPolicy = 'fixed' | 'walk'
+
 export interface SkillParams {
   readonly handValuation: HandValuation
   readonly bidPolicy: BidPolicy
@@ -143,6 +172,7 @@ export interface SkillParams {
   readonly playPolicy: PlayPolicy
   readonly autoSetPolicy: AutoSetPolicy
   readonly safeCounterPolicy: SafeCounterPolicy
+  readonly openingPolicy: OpeningPolicy
 }
 
 /**
@@ -261,6 +291,7 @@ export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
   medium: {
     handValuation: 'base_bid',
@@ -269,6 +300,7 @@ export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
   hard: {
     handValuation: 'base_bid',
@@ -277,6 +309,7 @@ export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
   proficient: {
     handValuation: 'base_bid',
@@ -285,6 +318,7 @@ export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
   expert: {
     handValuation: 'base_bid',
@@ -293,6 +327,7 @@ export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
+    openingPolicy: 'fixed',
   },
 }
 


### PR DESCRIPTION
Runs the A/B #204 asked for, and records a negative.

## What this adds

`openingPolicy: 'fixed' | 'walk'` on `SkillParams`, plus `OPENING_AB_POLICIES`
and an `opening` command in `src/ab/cli.ts`. **Every shipped row is `'fixed'`,
which is the existing behaviour byte for byte** — all 459 tests pass unchanged,
including the ones written before this branch.

`'walk'` steps a seat's opening up from `OPENING_BID` while its own bid policy
still says the hand is worth the next rung. It is consulted only after
`worthContract` has already returned true, so both arms open on an identical set
of deals and pass on an identical set (`bidding.test.ts` asserts this directly).
It changes the price, not the appetite — which is what makes the result readable
rather than confounded with a change in bidding frequency.

## The defect it was aiming at

`chooseBid` asks two separable questions — *should* I open, and *at what level* —
and has only ever acted on the first, answering the second with `OPENING_BID`.
Over 4000 AI-vs-AI auctions on `hard`: 41.1% of deals settle at 250, 51.7% at
320–350, and **0% anywhere in between**. On the 27.4% of deals where somebody
opened and nobody raised, the winner's ceiling ran median 310 / p75 370, and
44.5% of those hands were worth 320 or more.

## The measurement

Self-test first, as `cli.ts` requires: both new arms against themselves split
every pair with a paired margin of exactly zero.

`opening`, 5000 pairs × 3 seeds, both arms `distilled`/`model`/`cascade`:

| seed | walk swept | fixed swept | split | margin/deal | 95% CI |
|---|---|---|---|---|---|
| 1 | 265 | 484 | 4251 | **-52** | -59 to -44 |
| 2 | 264 | 509 | 4227 | **-56** | -65 to -48 |
| 3 | 277 | 512 | 4211 | **-53** | -61 to -46 |

p < 1e-4 on every seed. Walk lifts the average bid 301 → 322 and drops its made
rate 73.2% → 69.2%; auto-SET hands rise 7.1% → 9.9%. It buys the distribution
with sets.

`WALK_CONFIDENCE` buys the loss back monotonically and never enough: -48 at
0.60, -43 at 0.70, -26 at 0.80, -7 (CI -14 to +0) at 0.90 — but 0.90 lifts the
average bid by only 8 points. About three margin points per point of bid lift,
the whole way down.

## The number that actually answers the question

A paired A/B asks whether walk *beats* fixed. In a real game every AI seat runs
the same policy, so that penalty is not what a player experiences. Same-policy
tables (`selftest`, 2000 pairs):

| all-`fixed` | all-`walk` |
|---|---|
| avg bid 301, set 26.3% | avg bid 322, set 30.5% |

That is the real price of the distribution: symmetric, nobody disadvantaged,
contracts going down about one extra time in 24.

## Why this merges rather than gets deleted

#101's rule — null and negative results are recorded and shipped disabled, not
argued away. Merging changes no player-visible behaviour; it keeps the dial
measurable and the finding reproducible. **Whether to turn `'walk'` on is a
house-rules call and stays Paul's**, so #204 remains `ready-for-human`.

Closes nothing. Related: #185 — both models involved were fitted to a dataset
the engine has since moved out from under.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
