### PR TITLE
Commit to 340 when raising over one's own partner (#206)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -597,6 +597,56 @@ a `bidFloorAbPolicies` factory, a capacity equaliser and a `cli.ts floor --a X
 column (c) exist at all: an arm carrying only the constant cannot measure the
 comparison, and would have shipped the collapse unmeasured.
 
+### The bid that only a human can see is wrong (#206)
+
+The dial has a blind spot, and this is the case that found it. Everything in
+`src/ab/` plays AI against AI. A rule that is only wrong when a *human* sits at
+the table is one the harness cannot fail on, however many deals it runs.
+
+`chooseBid`'s partner-raise branch demanded `ceiling >= 340` and then bid
+`currentBid + minIncrement`. In an all-AI auction that is not observably broken:
+the competitive branch's `Math.max(ceiling, 330)` walks the ladder to 330, so
+`+ minIncrement` lands on 340 by arithmetic accident. Over 4000 AI-vs-AI
+auctions on `hard`, 123 deals place a bid over one's own partner and **all 123
+are exactly 340** — min, median and max identical. There is no distribution to
+look at and nothing to flag.
+
+A human's bid is not on that ladder. Paul, playing the deployed PWA, bid 260 as
+the partner of an AI holding a 360 ceiling and was raised to 270 — the AI
+bidding against its own team for ten points, having just certified the hand as
+worth a 340 contract. That is the whole defect, and only the human seat can
+produce it.
+
+**What this costs the measurement programme is worth stating plainly.** Three
+separate bidding constants have now been wrong in the same way — #177's
+`320 + 1`, #180's clear-versus-reach, and this — and none of the three were
+caught by an A/B. They were caught by reading the code, and this one by playing
+the game. The harness measures which of two rules wins; it does not measure
+whether a rule does what its own constant says. Those are different questions and
+only the first has a tool.
+
+The fix is `PARTNER_RAISE_FLOOR`, the same shape as `PARTNER_PASSED_FLOOR`: the
+ceiling gate decides *whether* to raise, the floor decides *what* to raise to,
+and both are 340. Passing stays available, so the change alters what a raise says
+rather than how often one happens.
+
+Verification, in place of an A/B that would have measured nothing: a seeded
+4000-deal auction sweep on each of `easy`/`medium`/`hard` — 12,000 auctions —
+produces a **bit-identical fingerprint** of every settled contract and winner
+before and after. The change provably reaches only auctions with a human in a
+seat, which is exactly the population the harness cannot reach.
+
+`easy` is deliberately outside all of this. `meldOnlyBid` has no partner tracking
+of any kind, so it never enters the branch and answers the plain next rung;
+`bidding.test.ts` excludes it from the property with that reason attached, so the
+exclusion does not later read as an oversight.
+
+The other half of Paul's report — that a seat should not pass and let the
+opponents buy it cheap after both partners have bid — needed no change and is
+recorded so it does not get re-fixed. `Math.max(ceiling, 330)` already makes a
+seat whose partner has bid push the opponents to 330 on any hand at all; probed
+with a ceiling-190 hand, it answers 270/290/310/330 and only passes at 330.
+
 ### "Cannot be beaten", and the first place skill decides a card (#158)
 
 The last child of epic #152, and the one that makes #157's trump memory do

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -17,6 +17,7 @@ import {
   NEAR_RUN_VALUE,
   OPENER_THRESHOLD,
   PARTNER_PASSED_FLOOR,
+  PARTNER_RAISE_FLOOR,
 } from './bidding'
 import { partnerOf } from './round'
 import type { PlayerIndex } from './trick'
@@ -330,7 +331,7 @@ describe('chooseBid', () => {
       expect(chooseBid(0, strongHand, 320, 10, context)).toBeNull()
     })
 
-    it('matches a partner raise over my own earlier bid when the ceiling supports it', () => {
+    it('commits to PARTNER_RAISE_FLOOR on a partner raise over my own earlier bid (#206)', () => {
       const context = baseContext({
         everBid: true,
         bidHistory: [
@@ -339,7 +340,10 @@ describe('chooseBid', () => {
           { player: 2, amount: 320 },
         ],
       })
-      expect(chooseBid(0, strongHand, 320, 10, context)).toBe(330)
+      // Was 330 — `currentBid + minIncrement` — while the branch above it
+      // required a 340-worthy ceiling to get here at all. #206 makes the number
+      // the rule already demanded the number that reaches the table.
+      expect(chooseBid(0, strongHand, 320, 10, context)).toBe(PARTNER_RAISE_FLOOR)
     })
 
     it('backs off a partner raise over my own earlier bid when the ceiling does not support it', () => {
@@ -606,5 +610,116 @@ describe('every bid chooseBid can return is legal (#177)', () => {
       passedPlayers: [2],
     }
     expect(chooseBid(0, ceiling320Hand, OPENING_BID - 10, 10, context, 'medium')).toBe(PARTNER_PASSED_FLOOR)
+  })
+})
+
+// -- PARTNER_RAISE_FLOOR (#206) ----------------------------------------------
+//
+// The AI-vs-AI harness cannot see this rule. `Math.max(ceiling, 330)` in the
+// competitive branch means an all-AI ladder arrives at 330 and `+ minIncrement`
+// lands on 340 by arithmetic accident, so every bid an AI has ever placed over
+// its own partner was already exactly 340 and a 4000-deal sweep shows nothing
+// wrong. A human partner's bid is not on that ladder, which is the only reason
+// the defect was ever visible — so these tests drive the branch from an
+// off-ladder `currentBid` on purpose. Do not "simplify" them onto round AI
+// numbers; that is precisely the blind spot.
+describe('raising over a bid our own team already holds (#206)', () => {
+  // Ceiling 360 — clears PARTNER_RAISE_FLOOR with room above it.
+  const strongHand = [
+    ...RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1)),
+    new Card(Suit.Hearts, 'K', 2),
+    new Card(Suit.Hearts, 'Q', 2),
+    new Card(Suit.Spades, 'A', 1),
+  ]
+  // Ceiling 320 — opens happily, but cannot support a 340 commitment.
+  const modestHand = [...RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1)), new Card(Suit.Spades, 'A', 1)]
+
+  /** Seat 2 opened at OPENING_BID; its partner (seat 0) then bid `partnerBid`. */
+  const afterPartnerRaise = (partnerBid: number): AuctionContext => ({
+    everBid: true,
+    passesSoFar: 0,
+    bidHistory: [
+      { player: 2 as PlayerIndex, amount: OPENING_BID },
+      { player: 0 as PlayerIndex, amount: partnerBid },
+    ],
+    dealer: 1,
+    scores: { 0: 0, 1: 0 },
+    passedPlayers: [],
+  })
+
+  it('commits to PARTNER_RAISE_FLOOR rather than nudging its partner by ten', () => {
+    expect(bestBaseBid(strongHand, 0, 0).total).toBe(360)
+    // Every one of these used to answer `partnerBid + 10` — 270 over a 260 —
+    // while requiring a 340-worthy hand to say it.
+    for (const partnerBid of [260, 270, 280, 290, 300, 310, 320, 330]) {
+      expect(chooseBid(2, strongHand, partnerBid, 10, afterPartnerRaise(partnerBid), 'hard')).toBe(
+        PARTNER_RAISE_FLOOR,
+      )
+    }
+  })
+
+  it('still takes the ordinary next rung once the partner is already past the floor', () => {
+    // The floor is a floor, not a fixed bid: above it the normal ladder applies.
+    expect(chooseBid(2, strongHand, 350, 10, afterPartnerRaise(350), 'hard')).toBe(360)
+  })
+
+  it('backs off instead of being talked into a commitment it cannot make', () => {
+    expect(bestBaseBid(modestHand, 0, 0).total).toBeLessThan(PARTNER_RAISE_FLOOR)
+    for (const partnerBid of [260, 300, 330]) {
+      expect(chooseBid(2, modestHand, partnerBid, 10, afterPartnerRaise(partnerBid), 'hard')).toBeNull()
+    }
+  })
+
+  it('never places a bid over its own partner below the floor, on any hand', () => {
+    const realRandom = Math.random
+    Math.random = seededRandom(0x2060_2026)
+    try {
+      for (let i = 0; i < 300; i++) {
+        const deck = new Deck()
+        deck.shuffle()
+        const hands = deck.deal()
+        for (const partnerBid of [260, 275, 290, 305, 330]) {
+          // `easy` is excluded on purpose, not because it fails: `meldOnlyBid`
+          // is the deliberately-weak skill-1 path with no partner tracking of
+          // any kind (see its docstring), so it never reaches this branch and
+          // answers the plain next rung. Sweeping it here would assert that
+          // skill 1 has partner logic, which is the opposite of what it is for.
+          for (const level of SKILL_LEVELS.filter((l) => l !== 'easy')) {
+            const out = chooseBid(2, hands[2], partnerBid, 10, afterPartnerRaise(partnerBid), level)
+            if (out === null) continue
+            expect(out).toBeGreaterThanOrEqual(PARTNER_RAISE_FLOOR)
+          }
+        }
+      }
+    } finally {
+      Math.random = realRandom
+    }
+  })
+
+  it('pushes opponents rather than handing them a cheap contract once the partner has bid', () => {
+    // The other half of Paul's report: passing here would let the opponents buy
+    // it low after both seats have shown cards. `Math.max(ceiling, 330)` already
+    // covers it, and this pins that down — a ceiling-190 hand still pushes.
+    const weakHand = [
+      new Card(Suit.Hearts, 'K', 1),
+      new Card(Suit.Hearts, 'Q', 1),
+      new Card(Suit.Spades, 'A', 1),
+    ]
+    expect(bestBaseBid(weakHand, 0, 0).total).toBeLessThan(330)
+    for (const oppBid of [260, 280, 300, 320]) {
+      const context: AuctionContext = {
+        everBid: true,
+        passesSoFar: 0,
+        bidHistory: [
+          { player: 2 as PlayerIndex, amount: OPENING_BID },
+          { player: 0 as PlayerIndex, amount: 260 },
+          { player: 1 as PlayerIndex, amount: oppBid },
+        ],
+        dealer: 3,
+        scores: { 0: 0, 1: 0 },
+        passedPlayers: [],
+      }
+      expect(chooseBid(2, weakHand, oppBid, 10, context, 'hard')).toBe(oppBid + 10)
+    }
   })
 })

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -110,6 +110,39 @@ export const DEFENSIVE_PUSH_FLOOR = 200
  */
 export const PARTNER_PASSED_FLOOR = 320
 
+/**
+ * The bid a seat must commit to when it raises **over its own partner** (#206).
+ *
+ * Read `PARTNER_PASSED_FLOOR` above first; this is the same kind of number and
+ * it was the same kind of bug. `340` has always been in `chooseBid`, gating the
+ * one branch where a seat bids over a bid its own team already holds — but it
+ * gated the *ceiling* and the seat then bid `currentBid + minIncrement`. So the
+ * rule read "I need a hand worth a 340 contract to do this" and the action was
+ * "raise my partner by ten". The constant never reached the table.
+ *
+ * That is #177 exactly, one branch over, and it hid for the same reason: in an
+ * all-AI auction it is invisible. The competitive branch's `Math.max(ceiling,
+ * 330)` means the ladder arrives at 330 and `+ minIncrement` lands on 340 by
+ * arithmetic accident, so a 4000-deal AI-vs-AI sweep shows every such bid at
+ * exactly 340 and nothing wrong. **The human seat is what exposes it**, because
+ * a human's bid is not on the AI ladder: bid 260 as the partner of an AI holding
+ * a 360 ceiling and it answers 270, having just required a 340-worthy hand to
+ * say so.
+ *
+ * Paul's call (2026-08-20), and his reasoning is the rule's justification rather
+ * than a preference laid on top of it: raising your own partner costs your team
+ * points and gains it nothing, so the only thing that can justify it is holding
+ * substantially more than your partner's bid already showed. A raise that means
+ * that should say it. Ten points does not say it — it just looks like the AI
+ * bidding against itself, which is what made the table confusing to read.
+ *
+ * The alternative is to pass, and the ceiling gate is what keeps that available:
+ * a seat that cannot support 340 still backs off rather than being talked into a
+ * commitment it cannot make. This changes what a raise *says*, not how often one
+ * happens.
+ */
+export const PARTNER_RAISE_FLOOR = 340
+
 function handCount(hand: readonly Card[], suit: Suit, rank: Rank): number {
   return hand.reduce((count, c) => count + (c.suit === suit && c.rank === rank ? 1 : 0), 0)
 }
@@ -446,8 +479,9 @@ function meldOnlyBid(
  *   - My team currently holds the bid:
  *     - Partner has already bid twice this auction - back off, they're
  *       carrying it.
- *     - Partner just raised over my own earlier bid - match it if my
- *       ceiling supports at least 340, otherwise back off.
+ *     - Partner just raised over my own earlier bid - commit to
+ *       PARTNER_RAISE_FLOOR (340) if my ceiling supports it, else back off.
+ *       Never a ten-point nudge over one's own partner (#206).
  *     - Otherwise my own (or partner's) bid already stands - no need to
  *       raise myself.
  *   - The opponents currently hold the bid: raise to current + minIncrement
@@ -563,8 +597,13 @@ export function chooseBid(
     if (partnerBidCount >= 2) return null // partner's carrying it, back off
 
     if (lastBidder === partner && myOwnBids.length > 0 && currentBid > myOwnBids[myOwnBids.length - 1]) {
-      // partner raised over my own earlier bid
-      return ceiling < 340 ? null : currentBid + minIncrement
+      // Partner raised over my own earlier bid, so this seat is being asked
+      // whether to bid over a contract its own team already holds. The ceiling
+      // gate decides *whether* (#206 left it exactly where it was); the floor
+      // decides *what*, and it is the same number, because a raise that cannot
+      // reach PARTNER_RAISE_FLOOR is not worth making at all.
+      if (ceiling < PARTNER_RAISE_FLOOR) return null
+      return Math.max(PARTNER_RAISE_FLOOR, currentBid + minIncrement)
     }
 
     return null // our own bid already stands, no need to raise ourselves


### PR DESCRIPTION
Closes #206.

Paul, playing the deployed PWA: his AI partner raises him by ten, which reads as
the AI bidding against its own team.

## The defect

`chooseBid`'s partner-raise branch:

```ts
return ceiling < 340 ? null : currentBid + minIncrement
```

The `340` gates the **ceiling** — "I need a hand worth a 340 contract to do
this" — and the seat then bids `currentBid + minIncrement`. The number the rule
demands never reaches the table. #177's bug shape, one branch over.

## Why no A/B caught it, and why none is run here

**In an all-AI auction the defect is invisible.** `Math.max(ceiling, 330)` in the
competitive branch walks the ladder to 330, so `+ minIncrement` lands on 340 by
arithmetic accident. Over 4000 AI-vs-AI auctions on `hard`, 123 deals place a bid
over one's own partner and **all 123 are exactly 340** — min, median and max
identical. There is no distribution to look at.

A human's bid is not on that ladder. Seat 2 (AI, ceiling 360), human partner in
seat 0:

| human partner bids | before | after |
|---|---|---|
| 260 | 270 | **340** |
| 280 | 290 | **340** |
| 300 | 310 | **340** |
| 330 | 340 | 340 |
| 350 | 360 | 360 |

A ceiling-320 hand passes at every row, before and after — the gate is untouched.

## The change

`PARTNER_RAISE_FLOOR = 340`, the same shape as `PARTNER_PASSED_FLOOR`: the
ceiling gate decides *whether* to raise, the floor decides *what* to raise to.

Paul's reasoning is the justification, not a preference laid on top of one:
raising your own partner costs your team points and gains it nothing, so the only
thing that can justify it is holding substantially more than your partner's bid
already showed. Ten points does not say that.

## Verification, in place of a measurement that would measure nothing

A seeded 4000-deal auction sweep on each of `easy`/`medium`/`hard` — 12,000
auctions — produces a **bit-identical fingerprint** of every settled contract and
winner before and after. The change provably reaches only auctions with a human
in a seat, which is the population `src/ab/` cannot reach at all. 458 tests pass.

That blind spot is written up in `web/README.md` rather than left implicit: three
bidding constants have now been wrong in the same way (#177, #180, this), and
none of the three were caught by an A/B. The harness measures which of two rules
wins, not whether a rule does what its own constant says.

## Scope notes

- **`easy` is excluded deliberately.** `meldOnlyBid` has no partner tracking of
  any kind, so it never enters this branch. The property test excludes it with
  that reason attached so the exclusion does not later read as an oversight.
- **The other half of Paul's report needed no change.** He also asked not to be
  left passing a cheap contract to the opponents after both partners have bid.
  `Math.max(ceiling, 330)` already covers it — probed with a ceiling-190 hand, a
  seat whose partner has bid answers 270/290/310/330 to opponent bids of
  260/280/300/320 and only passes at 330. Now pinned by a test rather than left
  to be rediscovered and re-fixed.

Independent of #205 (branched from `main`), though both touch `bidding.ts` and
`web/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
