### PR TITLE
"The rest are mine": claim the remaining tricks (#208)

### DIFF
--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -138,6 +138,36 @@ Legal-move rules, applied in order:
   Spades) go to whichever copy was played **first**.
 - The trick winner collects all 4 cards and leads the next trick.
 
+### Claiming the rest ("the rest are mine")
+
+A **house shortcut, not a rule of the game.** When the player on lead holds a
+hand in which no card can be beaten, the remaining tricks are awarded to their
+team instead of being played out, and the game shows the hand face up. This
+saves the clicks; it never changes a score.
+
+"Cannot be beaten" is stricter than "holds all the trump", and the difference is
+the whole point:
+
+- A **trump** card is unbeatable when no other seat holds any trump.
+- A **side** card is unbeatable when no other seat holds a higher card of that
+  suit. Equal rank is fine — the deck has two of each card and a tie goes to the
+  one played first, which is the claimer's, because the claimer is on lead.
+
+Holding every remaining trump is *not* sufficient. A seat with all the trump and
+two low hearts wins the trump tricks and then has to lead a heart into three
+players who can beat it. Measured over 3000 played hands, awarding on "holds all
+the trump" would have handed over tricks the claiming team went on to lose in
+906 cases.
+
+Both conditions are checked only between tricks, for the seat about to lead:
+being on lead is what lets the claimer choose the suit every time, so no card of
+theirs ever meets anything above it.
+
+**TypeScript only.** `pinochle_engine.py` plays every trick out. The shortcut is
+outcome-neutral by construction, so the two engines still agree on every score —
+and `playTrickTakingPhase`, which is what the parity tests replay Python rounds
+through, deliberately does not apply it.
+
 ## Phase 5: Round Scoring
 
 - Every **Ace, 10, and King** collected in tricks = 10 points each.

--- a/web/README.md
+++ b/web/README.md
@@ -903,6 +903,83 @@ wired-live and flag-off (#101) rather than being argued either way.
 `npm run dev` at `/bench/` (it follows `base`, which is `/`). It is never an
 input to `vite build`, so it cannot reach a player or the PWA precache.
 
+## Claiming the rest (#208)
+
+Paul's rule: if one seat holds all the trump and nobody else has any, stop
+playing and give them the tricks. The idea is right and the wording is not, and
+the gap between them is the interesting part of the change.
+
+Trump can only be beaten by trump — so if no one else holds any, the claimer's
+*trump* is unbeatable. That argument says nothing about the rest of their hand.
+A seat holding every remaining trump plus two low hearts wins the trump tricks
+and then has to lead a heart into three players who can beat it. Measured over
+3000 played hands with the real AI:
+
+| reading | fires on | correct |
+|---|---|---|
+| holds all remaining trump (the literal wording) | 59.4% | **no** — in 906 of the 1624 hands where it alone applies, the claiming team went on to lose a trick |
+| hand is *nothing but* trump, nobody else has any | 7.8% | yes |
+| **on lead, no card can be beaten** | 22.8% | yes — 0 misawards in 3000 hands |
+
+The third is what shipped, on Paul's call. It is the same idea generalised past
+trump: a card is unbeatable if it is trump and no one else holds trump, or if no
+one holds a higher card of its suit — equal ranks included, since ties go to the
+card led and the claimer is on lead. That covers the trump case, covers the
+ordinary "I have the last two Aces and you have no trump" case, and triples the
+coverage of the safe trump-only reading without giving up the guarantee.
+
+**Being on lead is load-bearing, not incidental.** It is what lets the claimer
+choose the suit every trick, so none of its cards ever meets anything above it. A
+seat that is not on lead can be pulled into a suit it is void in with no trump to
+answer, and loses the trick it was about to claim. Same reason the partner
+holding trump kills the claim: the partner must overtrump if able, wins the
+trick, and is then on lead holding beatable cards.
+
+### Where it lives, and why not in the engine loop
+
+`findClaim` is in `round.ts` next to `isAutoSet`, but `playTrickTakingPhase`
+does **not** call it — and that is the part worth remembering.
+
+That function is the parity-checked port of Python's trick loop.
+`engineParity.test.ts` replays recorded Python rounds through it and asserts the
+winner and points of every individual trick, and `pinochle_engine.py` has no
+claim rule. Applying a TS-only shortcut inside it would make the parity
+guarantee conditional on the shortcut never firing in a fixture — true today,
+silently false the day someone adds a scenario. So the claim lives in
+`trickPlayReducer`, which drives the interactive game, and the frozen loop stays
+a faithful port.
+
+It was briefly wired into `playTrickTakingPhase` during development, which is
+how this was found: `round.test.ts`'s "the winner of each trick leads the next"
+started failing about one run in six, because the loop stopped producing twelve
+tricks.
+
+### The property it rests on
+
+The claim is safe only because it changes nothing. `round.test.ts` pins that
+directly rather than by argument: 1500 dealt hands played out in full with the
+real AI, and every time `findClaim` fires, the claiming seat must actually win
+every remaining trick and the awarded points must equal the points collected. It
+fires on ~340 of those hands and skips ~800 tricks, so the assertion is not
+passing vacuously — the test asserts that too.
+
+The same conservation shows up end-to-end: `TrickPlayFlow.test.tsx` plays a full
+round through the component, hits a real claim, and still finds twelve trick
+winners and 250 total points.
+
+### The notice
+
+`ClaimNotice` follows `AutoSetNotice` exactly, for the same reason it exists:
+the rule alone would skip several tricks and jump to the round summary, and an
+unexplained jump reads as the game losing cards rather than as a rule. So the
+round does not hand off until it is acknowledged, and an unacknowledged claim
+also blocks the #54 checkpoint — resuming from one would land on a summary for
+tricks the player never saw.
+
+The claimer's hand is shown face up, an AI's included. The message asserts that
+none of those cards can be beaten, and the player is entitled to check it rather
+than take it on trust; there is nothing left to conceal by then anyway.
+
 ## Portrait fit (#161)
 
 The game has to fit a phone in portrait with no scrolling, and that is a

--- a/web/src/components/ClaimNotice.test.tsx
+++ b/web/src/components/ClaimNotice.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Card, Suit } from '../engine/card'
+import { ClaimNotice } from './ClaimNotice'
+
+afterEach(cleanup)
+
+const cards = [
+  new Card(Suit.Hearts, 'A', 1),
+  new Card(Suit.Hearts, 'A', 2),
+  new Card(Suit.Hearts, '10', 1),
+]
+
+function renderNotice(overrides: Partial<Parameters<typeof ClaimNotice>[0]> = {}) {
+  const onDismiss = vi.fn()
+  render(
+    <ClaimNotice
+      claimerName="Partner"
+      teamName="Team A"
+      humanIsClaimer={false}
+      cards={cards}
+      points={110}
+      tricks={3}
+      trumpName="Hearts"
+      onDismiss={onDismiss}
+      {...overrides}
+    />,
+  )
+  return { onDismiss }
+}
+
+describe('ClaimNotice (#208)', () => {
+  it('says whose claim it is and how many tricks it takes', () => {
+    renderNotice()
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByRole('heading').textContent).toContain('The rest are mine')
+    expect(dialog.textContent).toContain('Partner holds')
+    expect(dialog.textContent).toContain('the last 3 tricks go to Team A')
+  })
+
+  it('addresses the human directly when the human is claiming', () => {
+    renderNotice({ humanIsClaimer: true })
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.textContent).toContain('You hold')
+    expect(dialog.textContent).toContain('go to you')
+  })
+
+  it("shows the claimer's whole hand face up, because a claim is checkable", () => {
+    // Including an AI's. The message asserts these cards cannot be beaten, and
+    // the player is entitled to verify it rather than take it on trust.
+    renderNotice()
+    const hand = screen.getByLabelText("Partner's remaining cards")
+    expect(within(hand).getAllByRole('img')).toHaveLength(3)
+    expect(within(hand).getAllByRole('img').map((n) => n.getAttribute('aria-label'))).toEqual([
+      'A of H',
+      'A of H',
+      '10 of H',
+    ])
+  })
+
+  it('names the points transferred and dismisses on acknowledgement', () => {
+    const { onDismiss } = renderNotice()
+    expect(screen.getByRole('dialog').textContent).toContain('110')
+    fireEvent.click(screen.getByRole('button', { name: 'See the score' }))
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+
+  it('offers no way to decline — the outcome is already decided', () => {
+    // A notice, not a confirmation. `findClaim` only fires on a position whose
+    // every remaining trick was settled, so a Cancel would imply a choice that
+    // does not exist. Same reasoning as AutoSetNotice.
+    renderNotice()
+    expect(screen.getAllByRole('button')).toHaveLength(1)
+  })
+})

--- a/web/src/components/ClaimNotice.tsx
+++ b/web/src/components/ClaimNotice.tsx
@@ -1,0 +1,111 @@
+import type { Card } from '../engine/card'
+import { PlayingCard } from './PlayingCard'
+
+export interface ClaimNoticeProps {
+  /** Display name of the seat making the claim. */
+  claimerName: string
+  /** Display name of the team the tricks go to. */
+  teamName: string
+  /** True when the human is the one claiming — changes who the message
+   *  addresses, not what happened. */
+  humanIsClaimer: boolean
+  /** The claimer's whole remaining hand, shown face up. This is the evidence,
+   *  not decoration: the claim is a statement that none of these can be beaten,
+   *  and the player is entitled to check it. */
+  cards: readonly Card[]
+  /** Trick points transferred, last-trick bonus included. */
+  points: number
+  /** How many tricks were awarded rather than played. */
+  tricks: number
+  /** Name of the trump suit, for the one-line reason. */
+  trumpName: string
+  onDismiss: () => void
+}
+
+/**
+ * Shown when a seat's remaining hand cannot be beaten and the rest of the tricks
+ * are awarded rather than played out (#208, `round.ts`'s `findClaim`).
+ *
+ * The same reasoning `AutoSetNotice` was written from: the rule alone would skip
+ * several tricks and jump to the round summary, and an unexplained jump does not
+ * read as a rule, it reads as the game losing cards. So the round does not hand
+ * off until this is acknowledged.
+ *
+ * **The hand is shown face up on purpose, including an AI's.** The claim is a
+ * claim — an assertion that every one of these cards wins — and the only way a
+ * player can believe it is to see the cards and check. Hiding them would ask for
+ * trust at exactly the moment the game takes tricks away without playing them.
+ * There is nothing to conceal by then either: the hand is over.
+ *
+ * A notice rather than a `ConfirmDialog`, for `AutoSetNotice`'s reason. The
+ * outcome is forced — `findClaim` only fires where every remaining trick was
+ * already decided — so offering a Cancel would imply a choice that does not
+ * exist.
+ */
+export function ClaimNotice({
+  claimerName,
+  teamName,
+  humanIsClaimer,
+  cards,
+  points,
+  tricks,
+  trumpName,
+  onDismiss,
+}: ClaimNoticeProps) {
+  return (
+    <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/70 p-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="claim-title"
+        className="w-full max-w-sm rounded-lg bg-white p-6 text-neutral-900 shadow-xl"
+      >
+        <h2 id="claim-title" className="text-lg font-semibold">
+          &ldquo;The rest are mine&rdquo;
+        </h2>
+
+        {/* "go to" rather than a possessive: team names are player-editable
+            (#186), and "Bosses'" / "Us's" is a coin flip nobody should have to
+            think about. */}
+        <p className="mt-3 text-sm">
+          {humanIsClaimer ? 'You hold' : `${claimerName} holds`} nothing that can
+          be beaten, so the last{' '}
+          <span className="font-semibold">{tricks}</span> tricks go to{' '}
+          {humanIsClaimer ? 'you' : teamName} without playing them out.
+        </p>
+
+        <div
+          className="mt-4 flex flex-wrap justify-center gap-1"
+          aria-label={`${claimerName}'s remaining cards`}
+        >
+          {cards.map((card, i) => (
+            <PlayingCard
+              // Two physical copies of a card are genuinely the same card, so
+              // there is no id to key on — and this list never reorders.
+              key={`${card.suit}${card.rank}-${i}`}
+              suit={card.suit}
+              rank={card.rank}
+              size="sm"
+            />
+          ))}
+        </div>
+
+        <p className="mt-4 text-sm text-neutral-600">
+          No one else holds {trumpName}, and nothing outstanding beats the rest,
+          so every trick left was already decided.{' '}
+          <span className="font-semibold">{teamName}</span> take{' '}
+          <span className="font-semibold">{points}</span> trick points,
+          last-trick bonus included.
+        </p>
+
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="mt-6 w-full rounded bg-green-800 px-4 py-2 font-semibold text-white hover:bg-green-900"
+        >
+          See the score
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/TrickPlayFlow.test.tsx
+++ b/web/src/components/TrickPlayFlow.test.tsx
@@ -219,6 +219,11 @@ describe('TrickPlayFlow (component)', { timeout: COMPONENT_SUITE_TIMEOUT_MS }, (
       )
       if (playable) {
         fireEvent.click(playable)
+      } else if (screen.queryByRole('dialog', { name: /the rest are mine/i })) {
+        // A claim (#208) ended the hand early. The notice holds `onComplete`
+        // back until it is acknowledged, exactly as the auto-SET one does, so
+        // the driver has to dismiss it the way a player would.
+        fireEvent.click(screen.getByRole('button', { name: 'See the score' }))
       } else {
         // Either an AI turn or the post-trick settle pause is in flight —
         // advancing past the longer of the two delays flushes whichever

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -11,11 +11,14 @@ import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
 import type { TableState } from './tableTypes'
+import { SUIT_NAME } from './auctionTypes'
 import { AutoSetNotice } from './AutoSetNotice'
+import { ClaimNotice } from './ClaimNotice'
 import { ConfirmDialog } from './ConfirmDialog'
 import { TrickLog } from './TrickLog'
 import {
   buildTrick,
+  applyClaimIfAvailable,
   initTrickPlayState,
   teammatesOf,
   trickPlayReducer,
@@ -117,7 +120,11 @@ export function TrickPlayFlow({
   const [state, dispatch] = useReducer(
     trickPlayReducer,
     undefined,
-    () => initialState ?? initTrickPlayState(hands, trumpSuit, bidWinner, seatNames),
+    // A claim is checked on the way in as well as after each trick (#208).
+    // A fresh deal can never be claimable — nobody holds twelve unbeatable
+    // cards — but a #54 resume can drop straight into a position that is,
+    // including a checkpoint written before this rule existed.
+    () => applyClaimIfAvailable(initialState ?? initTrickPlayState(hands, trumpSuit, bidWinner, seatNames)),
   )
   // Accumulates every card played so far this round (tracker.ts's
   // PlayTracker) — mutated directly alongside each PLAY_CARD dispatch
@@ -145,6 +152,12 @@ export function TrickPlayFlow({
   // (below) waits for this to clear before handing off, so the round summary
   // cannot appear before the explanation of why no cards were played.
   const [autoSetFired, setAutoSetFired] = useState(false)
+  // Set once a claim (#208) has been shown and acknowledged. Holds `onComplete`
+  // back for exactly the reason `autoSetFired` does: the hand is already
+  // decided, but handing off unmounts this component and takes the explanation
+  // with it, leaving the player at a summary for tricks they never saw played.
+  const [claimAcknowledged, setClaimAcknowledged] = useState(false)
+  const claimPending = state.claim !== null && !claimAcknowledged
 
   // A card hits the table once and everyone sees it — the exact tracker and all
   // four trump memories, the human's card included. Stable (`[]`), because it
@@ -266,15 +279,16 @@ export function TrickPlayFlow({
   // take the explanation with it, leaving the player at a round summary for a
   // hand they never saw played.
   useEffect(() => {
-    if (state.phase !== 'complete' || completedRef.current || autoSetFired) return
+    if (state.phase !== 'complete' || completedRef.current || autoSetFired || claimPending) return
     completedRef.current = true
     const result: TrickPlayResult = {
       trickPointsByTeam: state.trickPointsByTeam,
       trickWinners: state.trickWinners,
       ...(state.conceded ? { conceded: true } : {}),
+      ...(state.claim !== null ? { claim: state.claim } : {}),
     }
     onComplete?.(result)
-  }, [state, onComplete, autoSetFired])
+  }, [state, onComplete, autoSetFired, claimPending])
 
   // Local autosave (#54): checkpoint after each completed trick — i.e.
   // whenever currentTrick is empty (a fresh trick just started, or all 12
@@ -290,8 +304,12 @@ export function TrickPlayFlow({
     // the notice is shown again — the round is decided either way, so the only
     // difference is whether the player gets told.
     if (autoSetFired) return
+    // Same for an unacknowledged claim (#208): resuming from it would land on
+    // the round summary having silently eaten the last few tricks. Re-entering
+    // trick play instead re-detects the claim and shows the notice again.
+    if (claimPending) return
     onCheckpoint?.(state)
-  }, [state, onCheckpoint, autoSetFired])
+  }, [state, onCheckpoint, autoSetFired, claimPending])
 
   // Concede/fold (#83): show a fold button when the human won the bid, hide
   // it after they play their first card or the hand ends.
@@ -351,6 +369,18 @@ export function TrickPlayFlow({
 
   return (
     <div className="relative">
+      {claimPending && state.claim !== null && (
+        <ClaimNotice
+          claimerName={state.claim.name}
+          teamName={teamNames[teamOf(state.claim.player)]}
+          humanIsClaimer={state.claim.player === humanPlayer}
+          cards={state.claim.cards}
+          points={state.claim.points}
+          tricks={state.claim.tricks}
+          trumpName={SUIT_NAME[state.trumpSuit]}
+          onDismiss={() => setClaimAcknowledged(true)}
+        />
+      )}
       {autoSetFired && (
         <AutoSetNotice
           biddingTeamName={teamNames[biddingTeamId]}

--- a/web/src/components/trickPlayReducer.test.ts
+++ b/web/src/components/trickPlayReducer.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { Card, Suit } from '../engine/card'
+import { Card, type Rank, Suit } from '../engine/card'
 import type { PlayerIndex } from '../engine/trick'
+import { formatTrickPlayLogEntry } from './trickPlayTypes'
 import {
+  applyClaimIfAvailable,
   buildTrick,
   initTrickPlayState,
   teammatesOf,
@@ -134,5 +136,110 @@ describe('buildTrick', () => {
       { player: 1, card: new Card(Suit.Spades, '10', 1) },
     ])
     expect(trick.winner()).toBe(1)
+  })
+})
+
+describe('"the rest are mine" (#208)', () => {
+  const c = (suit: Suit, rank: Rank, copy: 1 | 2 = 1) => new Card(suit, rank, copy)
+
+  /** Trick 11 of 12: two cards each, seat 0 on lead holding only trump and
+   *  nobody else holding any. The position `findClaim` exists for. */
+  const claimableState = (): TrickPlayState => {
+    const hands = [
+      [c(Suit.Hearts, 'A'), c(Suit.Hearts, 'K')],
+      [c(Suit.Spades, 'A'), c(Suit.Spades, 'K')],
+      [c(Suit.Clubs, 'A'), c(Suit.Clubs, 'K')],
+      [c(Suit.Diamonds, 'A'), c(Suit.Diamonds, 'K')],
+    ] as [Card[], Card[], Card[], Card[]]
+    return initTrickPlayState(hands, Suit.Hearts, 0, SEAT_NAMES)
+  }
+
+  it('ends the hand and awards every remaining trick point', () => {
+    const state = applyClaimIfAvailable(claimableState())
+    expect(state.phase).toBe('complete')
+    expect(state.claim?.player).toBe(0)
+    expect(state.claim?.tricks).toBe(2)
+    // 8 counters at 10, plus the last-trick bonus, to seat 0's team.
+    expect(state.trickPointsByTeam[0]).toBe(90)
+    expect(state.trickPointsByTeam[1]).toBe(0)
+  })
+
+  it('records the claimer as the winner of every skipped trick', () => {
+    const state = applyClaimIfAvailable(claimableState())
+    expect(state.trickWinners).toEqual([0, 0])
+  })
+
+  it('carries the claimer\'s hand on the state, for the message to show', () => {
+    const state = applyClaimIfAvailable(claimableState())
+    expect(state.claim?.cards).toHaveLength(2)
+    expect(state.claim?.cards.every((card) => card.suit === Suit.Hearts)).toBe(true)
+    expect(state.claim?.name).toBe('You')
+  })
+
+  it('logs the claim so the trick log does not just stop', () => {
+    const state = applyClaimIfAvailable(claimableState())
+    const entry = state.log.at(-1)
+    expect(entry?.kind).toBe('claim')
+    expect(formatTrickPlayLogEntry(state.log.at(-1)!)).toContain('The rest are mine')
+  })
+
+  it('leaves an unclaimable position completely alone', () => {
+    // Seat 1 holds a trump, so seat 0 cannot claim.
+    const hands = [
+      [c(Suit.Hearts, 'A'), c(Suit.Hearts, 'K')],
+      [c(Suit.Hearts, 'Q'), c(Suit.Spades, 'K')],
+      [c(Suit.Clubs, 'A'), c(Suit.Clubs, 'K')],
+      [c(Suit.Diamonds, 'A'), c(Suit.Diamonds, 'K')],
+    ] as [Card[], Card[], Card[], Card[]]
+    const before = initTrickPlayState(hands, Suit.Hearts, 0, SEAT_NAMES)
+    expect(applyClaimIfAvailable(before)).toBe(before)
+  })
+
+  it('does not fire mid-trick', () => {
+    const state = claimableState()
+    const midTrick = trickPlayReducer(state, {
+      type: 'PLAY_CARD',
+      player: 0,
+      card: c(Suit.Hearts, 'A'),
+    })
+    expect(applyClaimIfAvailable(midTrick)).toBe(midTrick)
+  })
+
+  it('fires from CLEAR_TRICK, which is where a real hand reaches it', () => {
+    // Three cards each. Seat 0 holds nothing but trump, but seat 1 is on lead,
+    // so there is no claim yet — the rule is about the seat with the lead, and
+    // seat 1's spades are all trumpable. Seat 1 leads, seat 0 trumps in, and
+    // the claim becomes available the moment the lead changes hands.
+    const hands = [
+      [c(Suit.Hearts, 'A'), c(Suit.Hearts, 'K'), c(Suit.Hearts, 'Q')],
+      [c(Suit.Spades, 'A'), c(Suit.Spades, 'K'), c(Suit.Spades, 'Q')],
+      [c(Suit.Clubs, 'A'), c(Suit.Clubs, 'K'), c(Suit.Clubs, 'Q')],
+      [c(Suit.Diamonds, 'A'), c(Suit.Diamonds, 'K'), c(Suit.Diamonds, 'Q')],
+    ] as [Card[], Card[], Card[], Card[]]
+    let state = applyClaimIfAvailable(initTrickPlayState(hands, Suit.Hearts, 1, SEAT_NAMES))
+    expect(state.phase).toBe('playing')
+    expect(state.claim).toBeNull()
+
+    // The reducer removes a played card by identity, so a trick has to be
+    // dispatched with the very objects sitting in the hands — not equal copies.
+    for (const [player, card] of [
+      [1, hands[1][0]],
+      [2, hands[2][0]],
+      [3, hands[3][0]],
+      [0, hands[0][2]],
+    ] as [PlayerIndex, Card][]) {
+      state = trickPlayReducer(state, { type: 'PLAY_CARD', player, card })
+    }
+    expect(state.phase).toBe('trick-complete')
+    expect(state.trickWinners.at(-1)).toBe(0)
+
+    state = trickPlayReducer(state, { type: 'CLEAR_TRICK' })
+    // CLEAR_TRICK hands the lead to seat 0, and the claim fires there.
+    expect(state.phase).toBe('complete')
+    expect(state.claim?.player).toBe(0)
+    expect(state.claim?.tricks).toBe(2)
+    // The trick actually played still counts, and the claim adds the rest.
+    expect(state.trickPointsByTeam[0]).toBe(30 + 60)
+    expect(state.trickWinners).toEqual([0, 0, 0])
   })
 })

--- a/web/src/components/trickPlayReducer.ts
+++ b/web/src/components/trickPlayReducer.ts
@@ -15,9 +15,9 @@
 // per-trick resolution one play at a time.
 
 import type { Card, Suit } from '../engine/card'
-import { partnerOf, teamOf, type Hands, type TeamId } from '../engine/round'
+import { findClaim, partnerOf, teamOf, type ClaimResult, type Hands, type TeamId } from '../engine/round'
 import { type PlayerIndex, Trick, type TrickPlay } from '../engine/trick'
-import type { TrickPlayLogEntry } from './trickPlayTypes'
+import type { ClaimSummary, TrickPlayLogEntry } from './trickPlayTypes'
 
 const TRICK_COUNT = 12
 const LAST_TRICK_BONUS = 10 // team that wins the 12th trick gets +10, matches round.ts
@@ -44,6 +44,10 @@ export interface TrickPlayState {
   readonly log: readonly TrickPlayLogEntry[]
   /** True when the human has conceded the hand (#83). */
   readonly conceded: boolean
+  /** Set when the hand ended on "the rest are mine" (#208). The message the UI
+   *  shows, and the flag that says the remaining tricks were awarded rather
+   *  than played. */
+  readonly claim: ClaimSummary | null
 }
 
 export type TrickPlayAction =
@@ -71,6 +75,62 @@ export function initTrickPlayState(
     phase: 'playing',
     log: [],
     conceded: false,
+    claim: null,
+  }
+}
+
+/**
+ * Applies "the rest are mine" (#208) if the position allows it, else returns the
+ * state unchanged.
+ *
+ * Called wherever a seat is about to lead with a clean table — after a trick is
+ * cleared, and once at the start of the hand — because `findClaim`'s guarantee
+ * is about a clean lead and says nothing mid-trick.
+ *
+ * The awarded points are added to the running total exactly as a played-out
+ * trick would add them, so nothing downstream needs to know this happened:
+ * `scoreRound` sees the same trick points either way. That is the whole design
+ * constraint, and `round.test.ts` pins it against full play-out on random deals.
+ */
+export function applyClaimIfAvailable(state: TrickPlayState): TrickPlayState {
+  if (state.phase !== 'playing' || state.currentTrick.length > 0) return state
+  const result: ClaimResult | null = findClaim(state.hands, state.trumpSuit, state.turn)
+  if (result === null) return state
+
+  const team = teamOf(result.claimer)
+  const claim: ClaimSummary = {
+    player: result.claimer,
+    name: state.seatNames[result.claimer],
+    cards: result.cards,
+    points: result.trickPoints,
+    tricks: result.tricks,
+  }
+  return {
+    ...state,
+    phase: 'complete',
+    claim,
+    currentTrick: [],
+    trickPointsByTeam: {
+      ...state.trickPointsByTeam,
+      [team]: state.trickPointsByTeam[team] + result.trickPoints,
+    },
+    // The claimer would have won every skipped trick, so the record says so
+    // rather than leaving the hand looking like it stopped early.
+    trickWinners: [
+      ...state.trickWinners,
+      ...Array.from({ length: result.tricks }, () => result.claimer),
+    ],
+    log: [
+      ...state.log,
+      {
+        kind: 'claim',
+        player: result.claimer,
+        name: state.seatNames[result.claimer],
+        cards: result.cards,
+        points: result.trickPoints,
+        tricks: result.tricks,
+      },
+    ],
   }
 }
 
@@ -148,15 +208,16 @@ export function trickPlayReducer(state: TrickPlayState, action: TrickPlayAction)
       if (nextTrickNumber >= TRICK_COUNT) {
         return { ...state, phase: 'complete', currentTrick: [] }
       }
-      // The winner of the trick just settled leads the next one.
-      return {
+      // The winner of the trick just settled leads the next one — and is the
+      // seat a claim would be made by, so the check goes here (#208).
+      return applyClaimIfAvailable({
         ...state,
         phase: 'playing',
         currentTrick: [],
         leader: winner,
         turn: winner,
         trickNumber: nextTrickNumber,
-      }
+      })
     }
     case 'CONCEDE': {
       if (state.phase !== 'playing') return state

--- a/web/src/components/trickPlayTypes.ts
+++ b/web/src/components/trickPlayTypes.ts
@@ -31,6 +31,16 @@ export type TrickPlayLogEntry =
       readonly points: number
       readonly trickNumber: number
     }
+  | {
+      /** "The rest are mine" (#208) — the remaining tricks conceded to a seat
+       *  whose hand cannot be beaten, rather than played out one by one. */
+      readonly kind: 'claim'
+      readonly player: PlayerIndex
+      readonly name: string
+      readonly cards: readonly Card[]
+      readonly points: number
+      readonly tricks: number
+    }
 
 /** Renders one log entry as a single line of human-readable text. Pure and
  * exported on its own so TrickLog's formatting logic is unit-testable
@@ -41,6 +51,8 @@ export function formatTrickPlayLogEntry(entry: TrickPlayLogEntry): string {
       return `${entry.name} ${entry.isLead ? 'led' : 'played'} the ${entry.card.rank} of ${SUIT_NAME[entry.card.suit]}`
     case 'trick-won':
       return `${entry.name} won the trick (${entry.points} point${entry.points === 1 ? '' : 's'})`
+    case 'claim':
+      return `${entry.name}: "The rest are mine" — took the last ${entry.tricks} tricks (${entry.points} points)`
   }
 }
 
@@ -58,4 +70,18 @@ export interface TrickPlayResult {
   /** True when the bidding team conceded/folded. The bidding team's meld
    * is forfeited (they score -bid) and opponents get meld but no tricks. */
   readonly conceded?: boolean
+  /** Set when the hand ended on a claim (#208) rather than being played out.
+   * Purely informational — the trick points above already include everything
+   * the claim awarded, because a claim only fires on a position whose every
+   * remaining trick was already decided. */
+  readonly claim?: ClaimSummary
+}
+
+/** What the "The rest are mine" message needs to render. */
+export interface ClaimSummary {
+  readonly player: PlayerIndex
+  readonly name: string
+  readonly cards: readonly Card[]
+  readonly points: number
+  readonly tricks: number
 }

--- a/web/src/engine/round.test.ts
+++ b/web/src/engine/round.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, it } from 'vitest'
-import { Deck, FORCED_BID, Suit } from './card'
+import { dealFromRng, makeRng } from '../ab/headlessGame'
+import { Card, Deck, FORCED_BID, type Rank, Suit } from './card'
 import {
   type ChooseCardFn,
   type Hands,
   MAX_TRICK_POINTS,
+  findClaim,
   isAutoSet,
   playTrickTakingPhase,
   scoreRound,
   teamOf,
 } from './round'
+import { chooseFollowCard, chooseLeadCard, PlayTracker } from './tracker'
+import { type PlayerIndex, Trick } from './trick'
+
+/** The +10 the 12th trick carries, restated here rather than exported from
+ *  round.ts — a test that reads the constant it is checking proves nothing. */
+const LAST_TRICK_BONUS = 10
 
 describe('teamOf', () => {
   it('pairs player 0 & 2 as team A (0), player 1 & 3 as team B (1)', () => {
@@ -171,5 +179,209 @@ describe('scoreRound', () => {
     // Team 1 (bidding): 60 + 100 = 160 < 400 -> goes set, scores -400.
     expect(scores[1]).toBe(-400)
     expect(scores[0]).toBe(90)
+  })
+})
+
+describe('findClaim — "the rest are mine" (#208)', () => {
+  const trump = Suit.Hearts
+  const c = (suit: Suit, rank: Rank, copy: 1 | 2 = 1) => new Card(suit, rank, copy)
+  const hands = (a: Card[], b: Card[], d: Card[], e: Card[]): Hands => [a, b, d, e]
+
+  it('claims when the leader holds only trump and no one else holds any', () => {
+    const claim = findClaim(
+      hands(
+        [c(Suit.Hearts, 'A'), c(Suit.Hearts, 'K')],
+        [c(Suit.Spades, 'A'), c(Suit.Spades, 'K')],
+        [c(Suit.Clubs, 'A'), c(Suit.Clubs, 'K')],
+        [c(Suit.Diamonds, 'A'), c(Suit.Diamonds, 'K')],
+      ),
+      trump,
+      0,
+    )
+    expect(claim).not.toBeNull()
+    expect(claim?.claimer).toBe(0)
+    expect(claim?.tricks).toBe(2)
+    // Every card left is a counter (8 x 10) plus the last-trick bonus.
+    expect(claim?.trickPoints).toBe(90)
+  })
+
+  it('claims on unbeatable side cards too, which is why this is not a trump rule', () => {
+    // Nobody holds trump at all, and the leader's two Aces cannot be beaten.
+    const claim = findClaim(
+      hands(
+        [c(Suit.Spades, 'A'), c(Suit.Clubs, 'A')],
+        [c(Suit.Spades, 'K'), c(Suit.Clubs, 'K')],
+        [c(Suit.Spades, 'Q'), c(Suit.Clubs, 'Q')],
+        [c(Suit.Spades, 'J'), c(Suit.Clubs, 'J')],
+      ),
+      trump,
+      0,
+    )
+    expect(claim).not.toBeNull()
+    expect(claim?.tricks).toBe(2)
+  })
+
+  it('claims on the second copy of a rank, because ties go to the card led', () => {
+    // The other Ace of Spades is still out, but the claimer leads and
+    // `Trick.winner` gives an equal rank to whoever played first.
+    const claim = findClaim(
+      hands(
+        [c(Suit.Spades, 'A', 1), c(Suit.Clubs, 'A')],
+        [c(Suit.Spades, 'A', 2), c(Suit.Clubs, 'K')],
+        [c(Suit.Spades, 'Q'), c(Suit.Clubs, 'Q')],
+        [c(Suit.Spades, 'J'), c(Suit.Clubs, 'J')],
+      ),
+      trump,
+      0,
+    )
+    expect(claim).not.toBeNull()
+  })
+
+  it('refuses all-the-trump-plus-a-beatable-side-card, the case the literal rule got wrong', () => {
+    // Seat 0 holds every trump left *and* a low club. It wins the trump trick
+    // and then has to lead the club into a higher one. Measured over 3000
+    // hands, this shape is why the literal reading misawarded 906 times.
+    const claim = findClaim(
+      hands(
+        [c(Suit.Hearts, 'A'), c(Suit.Clubs, '9')],
+        [c(Suit.Clubs, 'A'), c(Suit.Spades, 'K')],
+        [c(Suit.Clubs, 'K'), c(Suit.Spades, 'Q')],
+        [c(Suit.Clubs, 'Q'), c(Suit.Spades, 'J')],
+      ),
+      trump,
+      0,
+    )
+    expect(claim).toBeNull()
+  })
+
+  it('refuses when the partner holds trump, since the partner can win and then lead', () => {
+    // Same team, but not every trick: seat 2 must overtrump seat 0's King with
+    // the Ace (rule 3), which puts seat 2 on lead holding a beatable club.
+    const claim = findClaim(
+      hands(
+        [c(Suit.Hearts, 'K'), c(Suit.Hearts, 'Q')],
+        [c(Suit.Spades, 'A'), c(Suit.Spades, 'K')],
+        [c(Suit.Hearts, 'A'), c(Suit.Clubs, '9')],
+        [c(Suit.Diamonds, 'A'), c(Suit.Diamonds, 'K')],
+      ),
+      trump,
+      0,
+    )
+    expect(claim).toBeNull()
+  })
+
+  it('refuses a seat that is not on lead', () => {
+    const h = hands(
+      [c(Suit.Hearts, 'A'), c(Suit.Hearts, 'K')],
+      [c(Suit.Spades, 'A'), c(Suit.Spades, 'K')],
+      [c(Suit.Clubs, 'A'), c(Suit.Clubs, 'K')],
+      [c(Suit.Diamonds, 'A'), c(Suit.Diamonds, 'K')],
+    )
+    expect(findClaim(h, trump, 0)).not.toBeNull()
+    expect(findClaim(h, trump, 1)).toBeNull()
+  })
+
+  it('refuses with one trick left — there is nothing to skip', () => {
+    const claim = findClaim(
+      hands([c(Suit.Hearts, 'A')], [c(Suit.Spades, 'A')], [c(Suit.Clubs, 'A')], [c(Suit.Diamonds, 'A')]),
+      trump,
+      0,
+    )
+    expect(claim).toBeNull()
+  })
+
+  it('refuses mid-trick, when the hands are uneven', () => {
+    const claim = findClaim(
+      hands(
+        [c(Suit.Hearts, 'A'), c(Suit.Hearts, 'K')],
+        [c(Suit.Spades, 'A')],
+        [c(Suit.Clubs, 'A'), c(Suit.Clubs, 'K')],
+        [c(Suit.Diamonds, 'A'), c(Suit.Diamonds, 'K')],
+      ),
+      trump,
+      0,
+    )
+    expect(claim).toBeNull()
+  })
+})
+
+describe('a claim awards exactly what playing it out would have (#208)', () => {
+  // The property the whole feature rests on, and the reason the rule is allowed
+  // to live outside the parity-checked engine loop: `findClaim` is safe only
+  // because it never changes a result. So this plays real deals with the real
+  // AI and checks, every time the rule fires, that the claiming seat did in
+  // fact win every remaining trick and that the points match exactly.
+  //
+  // A played-out control rather than two runs compared, because a game with the
+  // claim applied and one without are not the same state to re-run — this way
+  // the assertion is against what actually happened at the table.
+  it('the claimer wins every skipped trick, on 1500 dealt hands', () => {
+    const rand = makeRng(0x2082026)
+    let fired = 0
+    let tricksSkipped = 0
+
+    for (let g = 0; g < 1500; g++) {
+      const dealt = dealFromRng(rand)
+      const trumpSuit = [Suit.Spades, Suit.Hearts, Suit.Clubs, Suit.Diamonds][Math.floor(rand() * 4)]
+      const working = dealt.map((h) => [...h]) as Hands
+      const tracker = new PlayTracker()
+      let leader: PlayerIndex = 0
+      let claimed: { claimer: PlayerIndex; points: number; fromTrick: number } | null = null
+      let pointsAfterClaim = 0
+
+      for (let t = 0; t < 12; t++) {
+        if (claimed === null) {
+          const claim = findClaim(working, trumpSuit, leader)
+          if (claim !== null) {
+            claimed = { claimer: claim.claimer, points: claim.trickPoints, fromTrick: t }
+            fired++
+            tricksSkipped += claim.tricks
+          }
+        }
+
+        const trick = new Trick(trumpSuit)
+        let p = leader
+        for (let seat = 0; seat < 4; seat++) {
+          const legal = trick.legalMoves(working[p])
+          const card =
+            seat === 0
+              ? chooseLeadCard(working[p], trumpSuit, tracker, false, 'expert', undefined, undefined)
+              : chooseFollowCard(
+                  working[p],
+                  legal,
+                  trick.plays,
+                  trumpSuit,
+                  [p, ((p + 2) % 4) as PlayerIndex],
+                  tracker,
+                  'expert',
+                  undefined,
+                )
+          working[p].splice(
+            working[p].findIndex((x) => x.equals(card)),
+            1,
+          )
+          trick.play(p, card)
+          tracker.record(card)
+          p = ((p + 1) % 4) as PlayerIndex
+        }
+        const winner = trick.winner()
+
+        if (claimed !== null && t >= claimed.fromTrick) {
+          // The claim said this seat takes it. It must.
+          expect(winner).toBe(claimed.claimer)
+          pointsAfterClaim += trick.points() + (t === 11 ? LAST_TRICK_BONUS : 0)
+        }
+        leader = winner
+      }
+
+      if (claimed !== null) {
+        // ...and the points awarded must equal the points actually collected.
+        expect(pointsAfterClaim).toBe(claimed.points)
+      }
+    }
+
+    // Guard against the assertions above passing vacuously.
+    expect(fired).toBeGreaterThan(200)
+    expect(tricksSkipped).toBeGreaterThan(500)
   })
 })

--- a/web/src/engine/round.ts
+++ b/web/src/engine/round.ts
@@ -87,6 +87,127 @@ export function isAutoSet(biddingTeamMeld: number, bid: number): boolean {
   return biddingTeamMeld + MAX_TRICK_POINTS < bid
 }
 
+export interface ClaimResult {
+  /** The seat on lead that provably takes every remaining trick. */
+  readonly claimer: PlayerIndex
+  /** The claimer's whole remaining hand — every card of it a winner, and what
+   *  the message shows. */
+  readonly cards: readonly Card[]
+  /** Trick points transferred: every counter still held by anyone, plus the
+   *  last-trick bonus, since the claimer necessarily wins the 12th. */
+  readonly trickPoints: number
+  /** How many tricks the claim skips. */
+  readonly tricks: number
+}
+
+/**
+ * How many tricks must remain for a claim to be worth interrupting the game
+ * for. At one trick there is nothing to skip — the last card is played, the
+ * message and the play resolve identically — so a dialog there costs a tap and
+ * saves nothing.
+ */
+export const MIN_CLAIMABLE_TRICKS = 2
+
+/**
+ * "The rest are mine" — the seat on lead that is guaranteed every remaining
+ * trick, or null (#208).
+ *
+ * Paul's rule, and the reason it is not spelled the way he first said it. The
+ * idea he gave is exactly right: trump can only be beaten by trump, so if no
+ * one else holds any, playing it out is a formality. What that argument covers
+ * is the claimer's *trump*. It does not cover the rest of their hand, and the
+ * difference decides hands rather than merely tidying them.
+ *
+ * A seat holding every remaining trump plus two low hearts does not take every
+ * trick. It leads trump while it has trump and wins those, and then it has to
+ * lead a heart into three players who are free to beat it. Measured over 3000
+ * played hands, the literal reading — "holds all the trump" — fires on 59.4% of
+ * hands, and in **906 of the 1624** where it alone applies the claiming team
+ * went on to lose a trick. It is not a shortcut; it is a scoring bug.
+ *
+ * So the test is not about trump. It is about whether anything the claimer
+ * holds *can be beaten at all*:
+ *
+ *   - A trump card is a winner when no other seat holds trump.
+ *   - A side card is a winner when no other seat holds a higher card of its
+ *     suit. Equal rank is fine — the deck has two of everything, and
+ *     `Trick.winner` gives ties to the card played first, which is the
+ *     claimer's, because the claimer is on lead.
+ *
+ * That last clause is why this takes a `leader`. On lead the claimer chooses
+ * the suit every trick, so each of its cards meets only what is below it and
+ * the order it plays them in cannot matter. A seat that is *not* on lead can be
+ * dragged into a suit it is void in with no trump to answer, and would lose the
+ * trick it was about to claim.
+ *
+ * Given lead plus unbeatable-everywhere, the induction is one line: the claimer
+ * leads a winner, takes the trick, and is on lead again with a strictly smaller
+ * hand of the same kind. So every remaining counter and the last-trick bonus go
+ * to its team.
+ *
+ * Measured on the same 3000 hands: fires on 22.8%, skipping 1705 tricks, and
+ * the claiming seat won every one of those tricks in the played-out control —
+ * zero misawards. `round.test.ts` keeps that control as a test.
+ *
+ * Evaluated only between tricks, with nothing on the table. Mid-trick the cards
+ * already played change which lines are legal, and this reasoning assumes a
+ * clean lead.
+ */
+export function findClaim(
+  hands: Readonly<Hands>,
+  trumpSuit: Suit,
+  leader: PlayerIndex,
+  minTricks: number = MIN_CLAIMABLE_TRICKS,
+): ClaimResult | null {
+  const remaining = hands[leader].length
+  if (remaining < minTricks) return null
+  // Between tricks every seat holds the same number of cards. If they do not,
+  // this is being asked mid-trick and the guarantee above does not apply.
+  if (!hands.every((h) => h.length === remaining)) return null
+
+  const others = ([0, 1, 2, 3] as PlayerIndex[]).filter((p) => p !== leader)
+  const anyoneElseHasTrump = others.some((p) => hands[p].some((c) => c.suit === trumpSuit))
+
+  const unbeatable = (card: Card): boolean =>
+    card.suit === trumpSuit
+      ? !anyoneElseHasTrump
+      : !anyoneElseHasTrump &&
+        !others.some((p) => hands[p].some((o) => o.suit === card.suit && o.rankValue > card.rankValue))
+
+  if (!hands[leader].every(unbeatable)) return null
+
+  const counters = hands
+    .flat()
+    .reduce((sum, c) => sum + (POINT_RANKS.has(c.rank) ? COUNTER_VALUE : 0), 0)
+  return {
+    claimer: leader,
+    cards: [...hands[leader]],
+    trickPoints: counters + LAST_TRICK_BONUS,
+    tricks: remaining,
+  }
+}
+
+/**
+ * `playTrickTakingPhase` deliberately does **not** consult `findClaim`, and that
+ * is an architectural line rather than an omission (#208).
+ *
+ * This function is the parity-checked port of Python's `Round._trick_taking_loop`
+ * — `engineParity.test.ts` replays recorded Python rounds through it and asserts
+ * the winner and the points of every individual trick. `pinochle_engine.py` has
+ * no claim rule, so a claim firing inside a replay would have the two engines
+ * describing the same round differently even when they agree about the score.
+ * CLAUDE.md's rule is that Python is the reference; a rule that exists on only
+ * one side does not belong in the loop the two are compared through.
+ *
+ * The claim is not a rule anyway. It is a shortcut over a decided position, and
+ * `findClaim`'s guarantee is exactly that it changes no outcome — so it belongs
+ * in whatever drives an interactive game and wants to skip the formality, which
+ * is `trickPlayReducer`. `round.test.ts` pins the equivalence directly: random
+ * deals played out in full and played with the claim applied reach identical
+ * trick points, which is the property that makes the shortcut safe to take
+ * anywhere.
+ */
+
 /**
  * Plays all 12 tricks of a round. `hands` are cloned internally (not
  * mutated in place), so the caller's arrays are safe to reuse/inspect


### PR DESCRIPTION
Closes #208.

When the seat on lead holds a hand in which no card can be beaten, the remaining
tricks are awarded rather than played out, and a notice shows the hand face up.

## Not the rule as first worded, and the difference decides hands

Paul's reasoning — trump can only be beaten by trump, so if no one else holds
any, playing on is a formality — is correct about the claimer's **trump**. It
says nothing about the rest of their hand. A seat holding every remaining trump
plus two low hearts wins the trump tricks and then has to lead a heart into three
players who are free to beat it.

Measured over 3000 hands played out with the real AI:

| reading | fires on | correct? |
|---|---|---|
| holds all remaining trump (as worded) | 59.4% | **no** — in 906 of the 1624 hands where it alone applies, the claiming team went on to lose a trick |
| hand is *nothing but* trump, nobody else has any | 7.8% | yes |
| **on lead, no card can be beaten** ← shipped | 22.8% | yes — 0 misawards in 3000 |

The shipped rule is the same idea generalised past trump. A card is unbeatable
if it is trump and no other seat holds trump, or if no other seat holds a
**higher** card of its suit — equal rank included, since the deck has two of
everything and `Trick.winner` gives a tie to the card played first, which is the
claimer's because the claimer is on lead.

Being on lead is load-bearing: it lets the claimer choose the suit every trick,
so none of its cards meets anything above it. A partner holding trump kills the
claim for the same reason — the partner must overtrump if able (rule 3), wins the
trick, and is then on lead holding beatable cards.

## `playTrickTakingPhase` deliberately does not apply it

`findClaim` sits in `round.ts` beside `isAutoSet`, but the engine's trick loop
does not call it. That loop is the parity-checked port of Python's, and
`engineParity.test.ts` replays recorded Python rounds through it asserting every
individual trick. `pinochle_engine.py` has no claim rule, so a TS-only shortcut
inside it would make the parity guarantee conditional on the shortcut never
firing in a fixture — true today, silently false the day someone adds a scenario.

This surfaced by accident: it *was* wired into the engine loop during
development, and `round.test.ts`'s "the winner of each trick leads the next"
began failing about one run in six, because the loop stopped producing twelve
tricks. The claim now lives in `trickPlayReducer`, which drives the interactive
game.

## Verified outcome-neutral, not argued

The shortcut is safe only because it changes nothing, so that is tested directly:
**1500 dealt hands played out in full with the real AI**, and every time
`findClaim` fires the claiming seat must actually win every remaining trick and
the awarded points must equal the points collected. It fires on ~340 of them and
skips ~800 tricks — both asserted, so the test cannot pass vacuously.

End-to-end, `TrickPlayFlow.test.tsx`'s full-round test now hits a real claim and
still finds twelve trick winners and 250 total points.

485 tests pass (42 files), run four times for flake. `tsc -b`, `oxlint` (only the
three pre-existing warnings) and `npm run build` all clean.

## The notice

`ClaimNotice` follows `AutoSetNotice`: the round does not hand off until it is
acknowledged, and an unacknowledged claim also blocks the #54 checkpoint, so a
resume cannot land on a summary for tricks the player never saw.

The claimer's hand is shown face up, an AI's included — the message asserts these
cards cannot be beaten and the player should be able to check that rather than
take it on trust. Nothing is left to conceal by then.

Rendering checked in the browser at 375x812: six cards (the largest a claim can
show) sit on one row, no horizontal overflow, dialog fits the viewport, no
console errors.

## Not deployed

Per Paul — more changes to come before a Netlify deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
