### PR TITLE
refactor(engine): one home for the game win/loss rule (#6)

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -2956,6 +2956,38 @@ class Round:
 # Game — persistent scores across rounds, win condition.
 # ---------------------------------------------------------------------------
 
+def determine_winner(teams, bidding_team):
+    """
+    Decide whether the game has ended, given cumulative team scores that
+    already include the round just scored. Returns the winning Team, or
+    None if the game continues.
+
+    This is the single home for the rule (issue #6); `Game.play` and
+    `play_local.py` both go through it rather than re-deriving it, which
+    is how the tie-break below stayed correct in one copy and not the
+    other. Per pinochle_rules.md "Game Win / Loss":
+
+      - A team whose cumulative score is at or below GAME_LOSE_SCORE ends
+        the game immediately and the OTHER team wins, regardless of that
+        team's own score. Busting is checked first.
+      - Otherwise, if either team has reached GAME_WIN_SCORE, that team
+        wins - and if both crossed it in the same round, the bidding team
+        wins the tie.
+
+    Mirrors `checkGameOutcome` in web/src/engine/game.ts, including
+    returning None in the degenerate case where every team busted at once.
+    """
+    busted = [t for t in teams if t.score <= GAME_LOSE_SCORE]
+    if busted:
+        return next((t for t in teams if t not in busted), None)
+
+    over = [t for t in teams if t.score >= GAME_WIN_SCORE]
+    if over:
+        return bidding_team if bidding_team in over else over[0]
+
+    return None
+
+
 class Game:
     def __init__(self, player_names):
         players = [Player(name, None) for name in player_names]
@@ -3023,13 +3055,7 @@ class Game:
             for team in self.teams:
                 team.score += round_scores[team]
 
-            busted = [t for t in self.teams if t.score <= GAME_LOSE_SCORE]
-            if busted:
-                winner = next(t for t in self.teams if t not in busted)
-            else:
-                over = [t for t in self.teams if t.score >= GAME_WIN_SCORE]
-                if over:
-                    winner = bidding_team if bidding_team in over else over[0]
+            winner = determine_winner(self.teams, bidding_team)
 
             self.dealer_index = (self.dealer_index + 1) % 4
 

--- a/play_local.py
+++ b/play_local.py
@@ -13,7 +13,7 @@ import os
 
 sys.path.insert(0, os.path.dirname(__file__))
 from human_play import HumanPlayer, InteractiveRound, NeedsHumanInput, hand_grouped
-from pinochle_engine import Player, Team, GAME_WIN_SCORE, GAME_LOSE_SCORE
+from pinochle_engine import Player, Team, GAME_LOSE_SCORE, determine_winner
 from pinochle_rollout import MAX_TRICK_POINTS
 
 SUIT_NAME = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"}
@@ -140,17 +140,14 @@ def play_game():
             team.score += score
             print(f"{team.name}: {'+' if score >= 0 else ''}{score} -> total {team.score}")
 
-        busted = [t for t in (team_a, team_b) if t.score <= GAME_LOSE_SCORE]
-        if busted:
-            winner = team_a if team_a not in busted else team_b
-            print(f"\n{winner.name} WINS! (opponent dropped to {GAME_LOSE_SCORE} or below)")
-            break
-
-        over = [t for t in (team_a, team_b) if t.score >= GAME_WIN_SCORE]
-        if over:
-            bidding_team = round_.bid_winner.team
-            winner = bidding_team if bidding_team in over else over[0]
-            print(f"\n{winner.name} WINS!")
+        winner = determine_winner([team_a, team_b], round_.bid_winner.team)
+        if winner is not None:
+            # The rule itself lives in determine_winner; all that's left
+            # here is picking which of the two endings to announce.
+            if any(t.score <= GAME_LOSE_SCORE for t in (team_a, team_b)):
+                print(f"\n{winner.name} WINS! (opponent dropped to {GAME_LOSE_SCORE} or below)")
+            else:
+                print(f"\n{winner.name} WINS!")
             break
 
         dealer_index = (dealer_index + 1) % 4

--- a/test_determine_winner.py
+++ b/test_determine_winner.py
@@ -1,0 +1,79 @@
+"""
+Tests for `determine_winner` in pinochle_engine.py - the single home for
+pinochle_rules.md's "Game Win / Loss" rule after issue #6 pulled it out
+of `Game.play` and `play_local.py`.
+
+The tie-break (both teams over 1000 in the same round, bidding team
+wins) and the bust-before-win ordering are the two clauses that were
+previously stated twice with nothing checking them against each other,
+so they get explicit cases here.
+
+Run directly (`python test_determine_winner.py`) or via pytest.
+"""
+
+from pinochle_engine import (
+    GAME_LOSE_SCORE,
+    GAME_WIN_SCORE,
+    Player,
+    Team,
+    determine_winner,
+)
+
+
+def make_teams(score_a, score_b):
+    team_a = Team("Team A", [Player("N", None), Player("S", None)])
+    team_b = Team("Team B", [Player("E", None), Player("W", None)])
+    team_a.score = score_a
+    team_b.score = score_b
+    return team_a, team_b
+
+
+def test_game_continues_below_thresholds():
+    team_a, team_b = make_teams(900, -400)
+    assert determine_winner([team_a, team_b], team_a) is None
+
+
+def test_single_team_over_wins_even_if_it_was_not_bidding():
+    team_a, team_b = make_teams(GAME_WIN_SCORE, 300)
+    assert determine_winner([team_a, team_b], team_b) is team_a
+
+
+def test_exactly_at_win_score_counts():
+    team_a, team_b = make_teams(999, 500)
+    assert determine_winner([team_a, team_b], team_a) is None
+    team_a.score = GAME_WIN_SCORE
+    assert determine_winner([team_a, team_b], team_a) is team_a
+
+
+def test_both_over_in_same_round_bidding_team_wins_the_tie():
+    team_a, team_b = make_teams(1100, 1050)
+    assert determine_winner([team_a, team_b], team_b) is team_b
+    # ...and the same scores decided the other way when A held the bid,
+    # so the result tracks the bid and not the higher score or the order.
+    assert determine_winner([team_a, team_b], team_a) is team_a
+
+
+def test_bust_hands_the_game_to_the_other_team():
+    team_a, team_b = make_teams(200, GAME_LOSE_SCORE)
+    assert determine_winner([team_a, team_b], team_b) is team_a
+    team_b.score = GAME_LOSE_SCORE - 50
+    assert determine_winner([team_a, team_b], team_b) is team_a
+
+
+def test_bust_is_checked_before_the_win_condition():
+    # The busting team's opponent wins regardless of its own score, and
+    # the bidding team's tie-break never gets a say.
+    team_a, team_b = make_teams(1200, GAME_LOSE_SCORE)
+    assert determine_winner([team_a, team_b], team_b) is team_a
+
+    # And the surviving team wins on any score at all, including a bad
+    # one - "regardless of that team's own score" is the rule's wording.
+    team_a, team_b = make_teams(-800, GAME_LOSE_SCORE)
+    assert determine_winner([team_a, team_b], team_a) is team_a
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(list(globals().items())):
+        if name.startswith("test_"):
+            fn()
+            print(f"{name} passed")


### PR DESCRIPTION
Closes #6.

The game win/loss rule was implemented independently in two Python
places — `Game.play` in `pinochle_engine.py` and `play_game` in
`play_local.py`. They shared `GAME_WIN_SCORE` / `GAME_LOSE_SCORE` but
not the logic, so the tie-break clause (both teams over +1000 in the
same round → bidding team wins) lived in two copies with nothing
checking them against each other.

The target shape already existed in TypeScript: `checkGameOutcome` in
`web/src/engine/game.ts` states the rule once in a docstring against
`pinochle_rules.md`'s "Game Win / Loss". So for once the port runs
TS → Python. **No TypeScript was changed.**

## What changed

- **`pinochle_engine.py`** — new `determine_winner(teams, bidding_team)`
  in the `Game` section, returning the winning `Team` or `None`. The
  docstring states the rule once and cites `pinochle_rules.md`. It
  mirrors `checkGameOutcome` exactly, including returning `None` in the
  degenerate all-busted case (the old `next(...)` there would have
  raised `StopIteration`).
- **`Game.play`** — seven lines of inline rule replaced by one call.
- **`play_local.py`** — same, and it keeps both of its distinct endgame
  messages; the branch there is now purely about which ending to
  announce, not about deciding the winner.
- **`test_determine_winner.py`** (new) — 6 cases, including the
  bidding-team tie-break asserted both ways on identical scores (so the
  result tracks the bid, not the higher score or the list order), and
  busting resolving before the win condition.

Behaviour is unchanged — this is a dedupe. Deliberately scoped to just
this; no part of #214's file split is attempted here.

## Verification

- `python -m pytest -q` → **310 passed** in 135s (304 before, +6 new).
- `python pinochle_engine.py` → all sanity checks and demo games pass
  (10/10 full games, 3/3 mixed-tier).
- `play_local.py` imports and compiles cleanly.

Note: unrelated in-flight TypeScript work under `web/src/engine/` from a
concurrent session was present in the working tree and was deliberately
left uncommitted — this branch touches Python only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
