### PR TITLE
refactor(play): import trick constants from round.ts instead of redeclaring (#218)

### DIFF
--- a/web/src/components/trickPlayReducer.ts
+++ b/web/src/components/trickPlayReducer.ts
@@ -15,12 +15,18 @@
 // per-trick resolution one play at a time.
 
 import type { Card, Suit } from '../engine/card'
-import { findClaim, partnerOf, teamOf, type ClaimResult, type Hands, type TeamId } from '../engine/round'
+import {
+  LAST_TRICK_BONUS,
+  TRICK_COUNT,
+  findClaim,
+  partnerOf,
+  teamOf,
+  type ClaimResult,
+  type Hands,
+  type TeamId,
+} from '../engine/round'
 import { type PlayerIndex, Trick, type TrickPlay } from '../engine/trick'
 import type { ClaimSummary, TrickPlayLogEntry } from './trickPlayTypes'
-
-const TRICK_COUNT = 12
-const LAST_TRICK_BONUS = 10 // team that wins the 12th trick gets +10, matches round.ts
 
 export type TrickPlayPhase = 'playing' | 'trick-complete' | 'complete'
 

--- a/web/src/engine/round.test.ts
+++ b/web/src/engine/round.test.ts
@@ -14,8 +14,9 @@ import {
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from './tracker'
 import { type PlayerIndex, Trick } from './trick'
 
-/** The +10 the 12th trick carries, restated here rather than exported from
- *  round.ts — a test that reads the constant it is checking proves nothing. */
+/** The +10 the 12th trick carries, restated here rather than imported from
+ *  round.ts (which does now export it, #218) — a test that reads the constant
+ *  it is checking proves nothing. */
 const LAST_TRICK_BONUS = 10
 
 describe('teamOf', () => {

--- a/web/src/engine/round.ts
+++ b/web/src/engine/round.ts
@@ -49,8 +49,17 @@ export interface TrickTakingResult {
   trickWinners: PlayerIndex[]
 }
 
-const TRICK_COUNT = 12
-const LAST_TRICK_BONUS = 10 // team that wins the 12th trick gets +10
+/**
+ * Tricks in a round, and the bonus the 12th carries. Exported because
+ * `trickPlayReducer.ts` runs the same per-trick resolution one play at a
+ * time for the UI and must award the bonus on the same trick this module's
+ * `scoreRound` and `findClaim` do — previously it kept its own copies with
+ * a `// matches round.ts` comment as the only thing holding them in step
+ * (#218). This module owns them: it is where every other trick-scoring
+ * constant lives, and `MAX_TRICK_POINTS` below derives from one of them.
+ */
+export const TRICK_COUNT = 12
+export const LAST_TRICK_BONUS = 10 // team that wins the 12th trick gets +10
 
 /**
  * Every trick point that exists in one round: each counter rank, in each


### PR DESCRIPTION
Closes #218.

`TRICK_COUNT` and `LAST_TRICK_BONUS` were declared in both `web/src/engine/round.ts` and `web/src/components/trickPlayReducer.ts`, with a `// matches round.ts` comment as the only thing keeping the two copies in step. This exports them from `round.ts` and imports them in the reducer. Values are unchanged — behaviour is identical.

## The engine/component boundary is not deliberate here

The issue asked me to check whether the reducer avoids importing from `web/src/engine/` on purpose before crossing that line. It does not: `trickPlayReducer.ts` already imported `findClaim`, `partnerOf`, `teamOf`, `ClaimResult`, `Hands`, and `TeamId` from `../engine/round` before this change. Its own module docstring names `round.ts`'s `playTrickTakingPhase` as the "frozen reference for the rules" and says the reducer "reimplements the same per-trick resolution one play at a time" — the reducer is *supposed* to lean on the engine for rules, and it splits from `TrickPlayFlow.tsx` for an oxlint fast-refresh reason, not a layering one.

So this adds two names to an import that already existed rather than opening a new dependency edge, and the direction the issue proposed (engine owns, component imports) is the one the codebase was already using.

## Why `round.ts` owns them

It has `scoreRound`, `findClaim`, and `MAX_TRICK_POINTS`, and `MAX_TRICK_POINTS` derives from `LAST_TRICK_BONUS`. This also matches the pattern `card.ts`'s `COPIES_PER_CARD` and `trick.ts`'s `POINT_RANKS` already document for themselves.

## `round.test.ts` keeps its own copy on purpose

`round.test.ts:19` holds a third `LAST_TRICK_BONUS = 10`, which I deliberately left alone — its comment explains that "a test that reads the constant it is checking proves nothing", which is right. Only the comment changed, since it said "restated here rather than *exported* from round.ts" and `round.ts` now does export it.

## Two related things found, not fixed here

- `web/src/components/auctionTypes.ts:89` declares its own `partnerOf` with `/** Fixed team pairing, matches round.ts's `teamOf`. */` — the same failure mode the issue flagged, one layer over (a duplicated *function*, and the comment names the wrong function). Worth its own issue; out of scope for a constants dedupe.
- The issue's closing line says `CODING_STANDARDS.md`'s TypeScript part "now documents the rule this violates, under *Shared values live in one module and are imported*". That section does not exist on `main` — `CODING_STANDARDS.md` is currently Python-only and has no TypeScript part. I did not add one, since writing a standards section is a separate call from the maintainer and the file's own preamble says it documents established patterns rather than aspirational rules.

## Verification

- `npm test` in `web/`: **485 passed, 42 files** (the first run hit the known #170 vitest worker-startup flake — 23/42 files executed, correctly self-reported as INCOMPLETE; the re-run was clean).
- `npm run build`: clean, `tsc -b` included.
- `npx oxlint src`: only the three pre-existing `exhaustive-deps` warnings in `AuctionFlow.tsx` / `TrickPlayFlow.tsx`, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
