### PR TITLE
docs(build): vite `base` comment says the app is hosted (#212)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -127,11 +127,17 @@ const suiteCompletenessReporter = {
   },
 }
 
-// The app is not currently hosted anywhere — GitHub holds the code only.
-// Root base works for `npm run dev` / `npm run preview` and for any host that
-// serves the build at a domain root. If it is ever deployed under a subpath
-// (e.g. a project page at `example.com/pinochle/`), set this to that subpath
-// or built asset URLs will not resolve.
+// The app is served from Netlify at a domain root
+// (<https://pinochle-house-rulez.netlify.app>), which is why this is `/`; the
+// same value is what `npm run dev` / `npm run preview` want. Deploys are manual
+// uploads of a locally built `web/dist` (see `netlify.toml`), so changing this
+// does not reach the live site until someone deploys.
+//
+// If the site ever moves under a subpath (e.g. `example.com/pinochle/`), set
+// this to that subpath *and* move the manifest's `id`/`start_url`/`scope` below
+// with it. Built asset URLs will not resolve otherwise, and a manifest left
+// behind installs an app that launches into a 404 — #141 shipped exactly that
+// and it stayed invisible until #143.
 const base = '/'
 
 // https://vite.dev/config/


### PR DESCRIPTION
Closes #212.

## What was wrong

The comment directly above `base` in `web/vite.config.ts` opened with:

> The app is not currently hosted anywhere — GitHub holds the code only.

The app **is** hosted: <https://pinochle-house-rulez.netlify.app>, since
#143/#144 on 2026-08-01. The sentence is a leftover from the window between
#141 removing the GitHub Pages deploy and Netlify landing.

## Why it mattered

`base = '/'` is correct for a Netlify root deploy, so nothing was broken today.
The problem is *where* the false sentence sits. This comment is one half of the
project's only in-code record of a standing constraint; the other half — the
manifest block twelve lines below — states it correctly: `id`, `start_url`, and
`scope` must track `base`, and move when it moves.

A reader who comes to change `base` reads "not hosted anywhere" first, concludes
the setting is theoretical, and is one step from repeating #141: change `base`,
leave the manifest, and ship an installed PWA whose home-screen icon launches
into a 404. That failure was invisible until #143 caught it. The comment meant
to prevent it should not open by denying the deploy exists.

## The change

Comment text only. The first sentence now states what is true — served from
Netlify at a domain root, which is why `base` is `/`, and deploys are manual
uploads of a locally built `web/dist` (per `netlify.toml`), so merging does not
change what is served. The subpath warning is kept and now names the manifest
coupling and the #141 failure at the point a reader would trip over it. The
manifest comment below is untouched; it was already right.

`base` itself, and every other line of config, is unchanged.

## Verification

- `npm run build` in `web/` — passes; `dist/index.html` still emits
  root-relative asset URLs (`/assets/…`, `/manifest.webmanifest`,
  `/registerSW.js`).
- `npm test` — 42 files, 485 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
