### PR TITLE
refactor(play): one home for partnerOf, in round.ts (#231)

### DIFF
--- a/web/src/components/auctionTypes.test.ts
+++ b/web/src/components/auctionTypes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { Suit } from '../engine/card'
-import { formatAuctionLogEntry, partnerOf } from './auctionTypes'
+import { formatAuctionLogEntry } from './auctionTypes'
 
 describe('formatAuctionLogEntry', () => {
   it('formats a bid entry', () => {
@@ -45,14 +45,5 @@ describe('formatAuctionLogEntry', () => {
       count: 1,
     })
     expect(text).toBe('Partner passed 1 card to You')
-  })
-})
-
-describe('partnerOf', () => {
-  it('pairs seats two apart, matching round.ts teamOf', () => {
-    expect(partnerOf(0)).toBe(2)
-    expect(partnerOf(1)).toBe(3)
-    expect(partnerOf(2)).toBe(0)
-    expect(partnerOf(3)).toBe(1)
   })
 })

--- a/web/src/components/auctionTypes.ts
+++ b/web/src/components/auctionTypes.ts
@@ -86,9 +86,4 @@ export interface AuctionResult {
   readonly log: readonly AuctionLogEntry[]
 }
 
-/** Fixed team pairing, matches round.ts's `teamOf`. */
-export function partnerOf(player: PlayerIndex): PlayerIndex {
-  return ((player + 2) % 4) as PlayerIndex
-}
-
 export type ScoresByTeam = Record<TeamId, number>

--- a/web/src/engine/engineParity.test.ts
+++ b/web/src/engine/engineParity.test.ts
@@ -60,6 +60,13 @@ function handTokens(hand: readonly Card[]): string {
 const SEATS: readonly PlayerIndex[] = [0, 1, 2, 3]
 const TEAMS: readonly TeamId[] = [0, 1]
 
+/**
+ * Reimplemented here rather than imported from `round.ts`, deliberately: this
+ * file is the parity net between the Python engine and the TypeScript one
+ * (#125), and a parity test that calls the very function it is checking
+ * asserts nothing. The independent copy is the point — do not dedupe it
+ * (#231).
+ */
 function partnerOf(player: PlayerIndex): PlayerIndex {
   return ((player + 2) % 4) as PlayerIndex
 }

--- a/web/src/engine/round.test.ts
+++ b/web/src/engine/round.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_TRICK_POINTS,
   findClaim,
   isAutoSet,
+  partnerOf,
   playTrickTakingPhase,
   scoreRound,
   teamOf,
@@ -25,6 +26,15 @@ describe('teamOf', () => {
     expect(teamOf(2)).toBe(0)
     expect(teamOf(1)).toBe(1)
     expect(teamOf(3)).toBe(1)
+  })
+})
+
+describe('partnerOf', () => {
+  it('pairs seats two apart, onto the team teamOf reports', () => {
+    expect(partnerOf(0)).toBe(2)
+    expect(partnerOf(1)).toBe(3)
+    expect(partnerOf(2)).toBe(0)
+    expect(partnerOf(3)).toBe(1)
   })
 })
 


### PR DESCRIPTION
Closes #231.

`partnerOf` was declared twice: `web/src/engine/round.ts:26` and
`web/src/components/auctionTypes.ts:90`. The second carried
`/** Fixed team pairing, matches round.ts's `teamOf`. */` — the same
comment-as-contract #218 was filed about, one file over, and it survived
PR #229. Nothing checked that the two bodies agreed.

Every production caller — `AuctionFlow.tsx`, `auctionReducer.ts`,
`TrickPlayFlow.tsx`, `trickPlayReducer.ts`, `bidding.ts` — already imported
the `round.ts` one, so the duplicate's only consumer was its own unit test.

## What changed

- `auctionTypes.ts` drops the declaration. It had no internal use for
  `partnerOf`, so there is nothing left for it to import — under
  `noUnusedLocals` a re-export would have been indirection with no caller.
- `auctionTypes.test.ts`, the one import site, drops it too, and its
  `describe('partnerOf')` block moves to `round.test.ts` beside `teamOf`.
  Tests are colocated with what they test, and `round.test.ts` had no
  `partnerOf` coverage of its own — so this keeps the assertions rather
  than deleting them.
- `engineParity.test.ts`'s third copy **stays**, and now carries a comment
  saying why: that file is #125's parity net against the Python engine, and
  a parity test that calls the very function it is checking asserts nothing.
  The independent reimplementation is the point. The comment is there so the
  next dedupe pass does not walk into it the way this one nearly did.

The function body is unchanged everywhere. This is a dedupe; behaviour is
identical.

## Verification

- `npm test` — 485 tests, 42 files, all passing. (First run hit the known
  #170 worker-pool flake and self-reported 23/42; the re-run was clean.)
- `npm run build` — passes.
- `npm run lint` — three pre-existing `exhaustive-deps` warnings in files
  this PR does not touch; no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
