### PR TITLE
docs(engine): say what authority Python actually has, not "frozen" (#219)

### DIFF
--- a/web/src/components/trickPlayReducer.ts
+++ b/web/src/components/trickPlayReducer.ts
@@ -4,8 +4,8 @@
 // rule flags mixed component+logic exports since it breaks fast refresh
 // (same reason auctionReducer.ts is split out from AuctionFlow.tsx).
 //
-// Mirrors round.ts's playTrickTakingPhase loop (frozen reference for the
-// rules: Trick.legalMoves/winner/points, teamOf, the 12th-trick bonus) but
+// Mirrors round.ts's playTrickTakingPhase loop (which owns the rules:
+// Trick.legalMoves/winner/points, teamOf, the 12th-trick bonus) but
 // broken into individual PLAY_CARD/CLEAR_TRICK actions instead of running
 // all 12 tricks synchronously in one call — the UI needs to pause after
 // each AI play (a brief delay, #35) and after each completed trick (so the

--- a/web/src/components/trickPlayTypes.ts
+++ b/web/src/components/trickPlayTypes.ts
@@ -1,8 +1,9 @@
 // Shared data shapes for the trick-play flow (#35). Built from the real
 // engine types (card.ts/round.ts/trick.ts) rather than ad-hoc UI types,
 // same approach auctionTypes.ts took for the auction/pass flow (#34) — so
-// a live Round orchestrator (#47, once it lands) can drive this UI and
-// consume its result without the component/reducer shapes changing.
+// the round orchestrator that followed (gameFlowReducer.ts, #47) could drive
+// this UI and consume its result without the component/reducer shapes
+// changing, which is how it landed.
 
 import type { Card } from '../engine/card'
 import type { TeamId } from '../engine/round'

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -411,9 +411,13 @@ describe('chooseBid', () => {
 
 // -- Parity with the Python reference engine (#118) -------------------------
 //
-// `pinochle_engine.py` is the frozen reference implementation this module was
-// ported from (CLAUDE.md). NEAR_RUN_VALUE and NEAR_DOUBLE_PINOCHLE_VALUE
-// silently shipped at 60/60 against Python's 120/225 - a hand-port slip that
+// `pinochle_engine.py` is the reference implementation this module was ported
+// from (CLAUDE.md), and it stays authoritative for the valuation constants
+// this block pins — the auction floors are the other way round since #213, so
+// this suite deliberately checks the Base Bid constants and not those.
+//
+// NEAR_RUN_VALUE and NEAR_DOUBLE_PINOCHLE_VALUE silently shipped at 60/60
+// against Python's 120/225 - a hand-port slip that
 // survived because both of this file's cases asserted loosely: one against the
 // constant itself, the other against a hardcoded 60 under a title saying 225.
 //

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -1,4 +1,17 @@
-// Bidding — ported from pinochle_engine.py (frozen Python reference).
+// Bidding — ported from pinochle_engine.py, but no longer downstream of it.
+// #213 settled the split: Python stays authoritative for rules constants
+// (card.ts, melds.ts, round.ts), while the auction *strategy* in this module
+// is authoritative on the TS side. PARTNER_PASSED_FLOOR (#180),
+// PARTNER_RAISE_FLOOR (#206) and the 330 competitive floor were measured or
+// decided here — in web/src/ab/, against a human partner — and are
+// deliberately not ported back. The matching Python branches still hold
+// their own bare literals; #213 traced that divergence and found it inert on
+// every path that still consumes Python's bidding, so it is a decision to
+// read, not a parity bug to fix.
+//
+// The Base Bid constants below are the exception and still track Python
+// (#118). Python is not frozen either — it is the live AI-research and
+// measurement platform — it simply does not rule this file.
 //
 // Two layers. Valuation: computeBaseBid (guaranteed + speculative hand
 // value) -> computeCompetitiveAdjustment (score-context) -> the 400-cap /
@@ -7,8 +20,8 @@
 // Decision: chooseBid/chooseTrump wrap that valuation with the stateful
 // auction rules (dealer protection, 3rd-bidder-opens-cheap, when to raise
 // vs. pass) - ported from Player.choose_bid / Player.choose_trump. This
-// module only decides; it does not run an auction loop (that's a future
-// Round orchestrator, see round.ts's module docstring).
+// module only decides; it does not run an auction loop — that lives in
+// components/auctionReducer.ts (#34), under gameFlowReducer.ts (#47).
 
 import type { SkillLevel } from '../persistence/options'
 import { type Card, GAME_WIN_SCORE, OPENING_BID, type Rank, Suit, SUITS } from './card'
@@ -36,7 +49,9 @@ import type { PlayerIndex } from './trick'
 // estimate), not the actual guaranteed meld. ------------------------------
 
 // These two are ported from pinochle_engine.py, which CLAUDE.md names the
-// frozen reference implementation for this port. They read 60/60 here until
+// reference implementation for this port and which is still authoritative
+// here — valuation is a ported constant, unlike the auction floors below,
+// which #213 put on the TS side. They read 60/60 here until
 // #118 — a hand-port slip, not a deliberate divergence: every other constant
 // in this block already matched Python exactly, and `bidding.test.ts`'s own
 // case is titled "credits a near-run ... at 120" while asserting against the

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -1,10 +1,15 @@
 // Bidding — ported from pinochle_engine.py, but no longer downstream of it.
 // #213 settled the split: Python stays authoritative for rules constants
 // (card.ts, melds.ts, round.ts), while the auction *strategy* in this module
-// is authoritative on the TS side. PARTNER_PASSED_FLOOR (#180),
-// PARTNER_RAISE_FLOOR (#206) and the 330 competitive floor were measured or
-// decided here — in web/src/ab/, against a human partner — and are
-// deliberately not ported back. The matching Python branches still hold
+// is authoritative on the TS side. PARTNER_PASSED_FLOOR (#180) was measured
+// here — 5000 paired deals on three seeds, in web/src/ab/. PARTNER_RAISE_FLOOR
+// (#206) was reasoned rather than measured: the argument is what a raise says
+// to a *human* partner, which has no referent in an all-AI Python game. It is
+// reasoning because no harness in this project seats a human — every A/B run,
+// on both sides, is AI-vs-AI, and ROADMAP.md carries "is a stronger AI a
+// better partner for a human?" as a standing open question no measurement
+// here can answer. The 330 competitive floor is likewise a TS-side decision.
+// None of the three are ported back. The matching Python branches still hold
 // their own bare literals; #213 traced that divergence and found it inert on
 // every path that still consumes Python's bidding, so it is a decision to
 // read, not a parity bug to fix.

--- a/web/src/engine/card.ts
+++ b/web/src/engine/card.ts
@@ -1,4 +1,9 @@
-// Card / Deck — ported from pinochle_engine.py (frozen Python reference).
+// Card / Deck — ported from pinochle_engine.py, the reference implementation
+// this engine is checked against (engineParity.test.ts, #125). Python is not
+// frozen — it is still where the AI research and measurement run — but it does
+// stay authoritative for the rules constants in this file (the +-1000 bounds,
+// OPENING_BID/FORCED_BID): if the two engines disagree on one of these, Python
+// is right and this side has drifted. That is #118's bug class, #126's audit.
 
 export const Suit = {
   Spades: 'S',

--- a/web/src/engine/game.ts
+++ b/web/src/engine/game.ts
@@ -1,11 +1,12 @@
 // Game — cumulative team scores and the +-1000 win/loss thresholds.
-// Ported from pinochle_engine.py's Game class (frozen Python reference).
+// Ported from pinochle_engine.py's Game class, which stays authoritative
+// for the bounds and the tie rule below — they are rules constants, and a
+// disagreement between the two engines is TS drift (#118, #126).
 //
-// Deliberately scoped to just the threshold check, not a full game loop:
-// running an actual multi-round game needs Round's bidding/pass phases
-// (#17) to exist first. A future Game orchestrator adds each round's
-// scoreRound() result (round.ts) onto each team's running total, then
-// calls checkGameOutcome() to see whether the game just ended.
+// Deliberately scoped to just the threshold check, not a full game loop.
+// The orchestrator arrived as components/gameFlowReducer.ts (#47): it adds
+// each round's scoreRound() result (round.ts) onto each team's running
+// total, then calls checkGameOutcome() to see whether the game just ended.
 
 import { GAME_LOSE_SCORE, GAME_WIN_SCORE } from './card'
 import type { TeamId } from './round'

--- a/web/src/engine/melds.ts
+++ b/web/src/engine/melds.ts
@@ -1,4 +1,8 @@
-// Melding — ported from pinochle_engine.py (frozen Python reference).
+// Melding — ported from pinochle_engine.py, which stays authoritative for the
+// meld values below: they are rules constants, so a disagreement between the
+// two engines is TS drift rather than a house rule (#118's bug class, #126's
+// audit). Python being actively developed does not loosen that — what moves
+// there is AI research, not the value of a Double Run.
 //
 // A pure function over a hand and the trump suit, not a player decision.
 // A card can count toward multiple *different* meld types at once (a trump

--- a/web/src/engine/passing.ts
+++ b/web/src/engine/passing.ts
@@ -1,4 +1,7 @@
-// 3-card pass — ported from pinochle_engine.py (frozen Python reference).
+// 3-card pass — ported from pinochle_engine.py, which stays authoritative for
+// the rule itself: three cards each way, per pinochle_rules.md. Which three is
+// AI strategy, and strategy is the half of the port that is allowed to diverge
+// on the TS side (#213) — PASS_COUNT is not.
 //
 // Skill-level-proficient strategy, split by trump category (Diamonds/
 // Spades vs Hearts/Clubs) and role (bidder vs partner). choosePassCards

--- a/web/src/engine/round.ts
+++ b/web/src/engine/round.ts
@@ -1,16 +1,18 @@
 // Round — trick-taking phase and round-level (contract) scoring. Ported
-// from pinochle_engine.py's Round._trick_taking_loop / Round._score_round
-// (frozen Python reference).
+// from pinochle_engine.py's Round._trick_taking_loop / Round._score_round,
+// which stays authoritative for the scoring rules below (MAX_TRICK_POINTS,
+// LAST_TRICK_BONUS, made-vs-set): engineParity.test.ts replays a complete
+// Python round against this module, and a mismatch is TS drift (#125).
 //
-// Bidding and the 3-card pass (#17) aren't reimplemented here — this
-// module picks up *after* trump is set and hands are finalized (post
-// pass), taking the bid winner and the agreed contract as given inputs.
-// A future Round orchestrator (once #17 lands) is expected to run, in
-// order: deal -> bidding (#17) -> passing (#17) -> scoreMelds (melds.ts,
-// per player) -> playTrickTakingPhase -> scoreRound -> feed the result
-// into game.ts's checkGameOutcome. Using PlayerIndex/TeamId from this
-// module and trick.ts keeps that future glue code consistent with
-// however bidding/passing chooses to represent players/hands.
+// Bidding and the 3-card pass aren't reimplemented here — this module
+// picks up *after* trump is set and hands are finalized (post pass),
+// taking the bid winner and the agreed contract as given inputs. The
+// orchestrator that runs the whole round is components/gameFlowReducer.ts
+// (#47): deal -> auctionReducer.ts's bidding/passing (#34) -> scoreMelds
+// (melds.ts, per player) -> playTrickTakingPhase -> scoreRound -> feed the
+// result into game.ts's checkGameOutcome. It uses PlayerIndex/TeamId from
+// this module and trick.ts, which is what keeps that glue consistent with
+// how bidding/passing represent players/hands.
 
 import { COPIES_PER_CARD, type Card, type Suit, SUITS } from './card'
 import { COUNTER_VALUE, POINT_RANKS, type PlayerIndex, Trick } from './trick'

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -1,6 +1,10 @@
 // Card-counting tracker + lead-card/follow-card AI — ported from
 // pinochle_engine.py's PlayTracker class, choose_lead_card, and
-// choose_follow_card functions (frozen Python reference).
+// choose_follow_card functions. Python is the reference implementation this
+// was ported from, but what lives here is trick-play *strategy*, not rules,
+// and strategy is the half that is allowed to diverge on the TS side (#213).
+// TrumpMemory below (#158) is exactly that: it has no Python counterpart, and
+// is not a parity gap to close.
 //
 // PlayTracker accumulates played-card counts across a round; both the
 // lead-card strategy and the follow-card strategy here consume the same

--- a/web/src/engine/trick.ts
+++ b/web/src/engine/trick.ts
@@ -1,12 +1,12 @@
 // Trick — owns lead suit, trump, legal-move filtering, and winner
-// resolution. Ported from pinochle_engine.py's Trick class (frozen
-// Python reference).
+// resolution. Ported from pinochle_engine.py's Trick class, which stays
+// authoritative for these rules: engineParity.test.ts replays a full
+// Python round through legalMoves/winner and a mismatch is TS drift (#125).
 //
 // Trick doesn't know about Player/Team objects — plays are recorded by
-// PlayerIndex (0-3, matching clockwise table seating) so this module has
-// no dependency on however Round ends up representing players once
-// bidding/passing (#17) lands. round.ts's teamOf() maps a PlayerIndex to
-// its team.
+// PlayerIndex (0-3, matching clockwise table seating), so this module took
+// no dependency on however bidding/passing (#17) would end up representing
+// players. round.ts's teamOf() maps a PlayerIndex to its team.
 
 import type { Card, Rank, Suit } from './card'
 


### PR DESCRIPTION
Closes #219.

## What changed

Ten source files — not seven — opened by calling `pinochle_engine.py` a
**frozen Python reference**. The issue's list missed three: `round.ts` and
`trick.ts` split the phrase across a line break so a single-line grep drops
them, and `bidding.ts` says it twice (header, and again over the Base Bid
constants) with a fourth instance in `bidding.test.ts`.

Every document in the repo disowns that premise — CLAUDE.md ("Python is
**not** frozen"), ROADMAP.md ("wrong in both halves"), `pinochle_rules.md`.
Only the comments a contributor reads first still said it.

## Not a find-and-replace

These headers exist to tell a reader what authority Python has over the file
in front of them. That authority is real; it just is not "frozen". Per the
#213 decision it is also not uniform, so the replacements are not either:

| | Says |
|---|---|
| `card.ts`, `melds.ts`, `round.ts`, `trick.ts`, `game.ts` | Python stays **authoritative for rules constants** — a disagreement is TS drift (#118's bug class, #125/#126 the net and the audit) |
| `passing.ts` | Python owns the *rule* (three cards each way); which three is strategy |
| `bidding.ts` | **Not downstream of Python.** `PARTNER_PASSED_FLOOR` (#180) was measured in `web/src/ab/` (5000 paired deals, three seeds); `PARTNER_RAISE_FLOOR` (#206) was *reasoned*, about what a raise says to a human partner — reasoning, not measurement, because no harness here seats a human. The 330 floor is likewise a TS-side decision. None ported back; #213 traced the divergence as inert. Base Bid constants are the exception and still track Python (#118) |
| `tracker.ts` | Same shape — trick-play strategy, and `TrumpMemory` (#158) has no Python counterpart, so it is not a parity gap |

`card.ts` and `bidding.ts` deliberately do not read alike; that distinction is
the substance of the issue.

## Second family: stale forward references

`game.ts`, `round.ts` and `trickPlayTypes.ts` awaited an orchestrator that
landed as `components/gameFlowReducer.ts` (#47) — now named, in the past
tense. `bidding.ts` and `trick.ts` carried their own "(once #17 lands)" waits
and now point at `auctionReducer.ts` (#34) instead. This is what
CODING_STANDARDS.md's "Doc comments" rule asks for.

## `trickPlayReducer.ts` — judged, not swept

Its `frozen reference` refers to **`round.ts`**, not Python: a claim about the
engine/component boundary. The substance is true and the comment restates it
accurately three sentences later ("stays the source of truth"). But `round.ts`
is not frozen either — #208 added `findClaim` to it and this very reducer
imports it — so only the misleading word changed, to "which owns the rules".
No other part of that header touched.

## Verification

Comments only, zero behaviour change. `npm test` — **485 passed, 42 files**
(48.8s). `npm run build` clean. `npm run lint` shows only the three
pre-existing `exhaustive-deps` warnings in `AuctionFlow.tsx`/`TrickPlayFlow.tsx`.
11 files changed, +77/-38.

The one surviving "frozen" outside the corrected framing is `web/README.md`'s
"the frozen loop stays a faithful port", about `playTrickTakingPhase` — a
different and still-true claim, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

