### PR TITLE
refactor(engine): four shared values get one home each (#241)

### DIFF
--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -29,7 +29,7 @@
 // components/auctionReducer.ts (#34), under gameFlowReducer.ts (#47).
 
 import type { SkillLevel } from '../persistence/options'
-import { type Card, GAME_WIN_SCORE, OPENING_BID, type Rank, Suit, SUITS } from './card'
+import { type Card, GAME_WIN_SCORE, handCount, OPENING_BID, type Rank, Suit, SUITS } from './card'
 import { shouldBid } from './evaluator'
 import { MELD_ONLY_BID_NOISE, MELD_ONLY_TRICK_ESTIMATE, SKILL_PARAMS } from './skills'
 import {
@@ -197,10 +197,6 @@ export const WALK_CONFIDENCE = 0.5
  * happens.
  */
 export const PARTNER_RAISE_FLOOR = 340
-
-function handCount(hand: readonly Card[], suit: Suit, rank: Rank): number {
-  return hand.reduce((count, c) => count + (c.suit === suit && c.rank === rank ? 1 : 0), 0)
-}
 
 /** Remove up to `count` cards matching suit/rank from `pool` in place; returns how many were removed. */
 function claim(pool: Card[], suit: Suit, rank: Rank, count = 1): number {

--- a/web/src/engine/card.ts
+++ b/web/src/engine/card.ts
@@ -36,6 +36,14 @@ export type CopyId = 1 | 2
  *  below, `round.ts`'s MAX_TRICK_POINTS — derives from one place. */
 export const COPIES_PER_CARD: readonly CopyId[] = [1, 2]
 
+/** Every copy of one suit in a full deck: 6 ranks x 2 copies. Named for trump
+ *  because trump is the only suit anyone counts to exhaustion — `tracker.ts`
+ *  calls trump "secure" once this many are accounted for, and `trumpMemory.ts`
+ *  sizes a seat's recall against it (#158). Same name and value as Python's
+ *  `TOTAL_TRUMP_COPIES`, derived here rather than written as 12 so it follows
+ *  the deck the way MAX_TRICK_POINTS does (#241). */
+export const TOTAL_TRUMP_COPIES = RANKS.length * COPIES_PER_CARD.length
+
 export const GAME_WIN_SCORE = 1000
 export const GAME_LOSE_SCORE = -1000
 // Lowest rung the auction can open at. **250 since #200** (was 300): a house
@@ -94,6 +102,37 @@ export class Card {
   toString(): string {
     return `${this.rank}${this.suit}_${this.copyId}`
   }
+}
+
+// Card-collection helpers. Pure queries over an array of cards, with no rules
+// or strategy in them, which is why they live beside Card rather than in the
+// module that happened to need one first: bidding.ts and tracker.ts each had
+// their own byte-identical `handCount`, and trick.ts and tracker.ts their own
+// `maxByRank` (#241). Python keeps the same pairing, `_hand_count` next to
+// `_suit_length`.
+
+/** How many copies of one exact card (suit + rank) a hand holds: 0, 1 or 2. */
+export function handCount(hand: readonly Card[], suit: Suit, rank: Rank): number {
+  return hand.reduce((count, c) => count + (c.suit === suit && c.rank === rank ? 1 : 0), 0)
+}
+
+/** How many cards of a suit a hand holds. */
+export function suitLength(hand: readonly Card[], suit: Suit): number {
+  return hand.reduce((count, c) => count + (c.suit === suit ? 1 : 0), 0)
+}
+
+/** Highest-ranked card of a non-empty set, in pinochle rank order (10 beats
+ *  King). Ties keep the first element, since only a strictly greater rank
+ *  replaces the running best — the same stability Python's `max()` has.
+ *  Compares rank alone, so the caller is responsible for passing cards that
+ *  are actually comparable (one suit, or all trump). */
+export function maxByRank(cards: readonly Card[]): Card {
+  return cards.reduce((best, c) => (c.rankValue > best.rankValue ? c : best))
+}
+
+/** Lowest-ranked card of a non-empty set. Mirror of `maxByRank`, same caveats. */
+export function minByRank(cards: readonly Card[]): Card {
+  return cards.reduce((lowest, c) => (c.rankValue < lowest.rankValue ? c : lowest))
 }
 
 /**

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -19,15 +19,21 @@
 // that behaves differently at different skill levels.
 
 import type { SkillLevel } from '../persistence/options'
-import { type Card, RANK_VALUE, RANKS, type Rank, type Suit } from './card'
-import type { PlayerIndex, TrickPlay } from './trick'
+import {
+  type Card,
+  handCount,
+  maxByRank,
+  minByRank,
+  RANK_VALUE,
+  RANKS,
+  type Rank,
+  suitLength,
+  type Suit,
+  TOTAL_TRUMP_COPIES,
+} from './card'
+import { POINT_RANKS, type PlayerIndex, type TrickPlay } from './trick'
 import { SKILL_PARAMS } from './skills'
 import type { TrumpMemory } from './trumpMemory'
-
-const POINT_RANKS = new Set(['A', '10', 'K'])
-/** 6 ranks x 2 copies, matching Python's `TOTAL_TRUMP_COPIES`. `chooseFollowCard`
- *  calls trump "secure" once this many copies are accounted for. */
-const TOTAL_TRUMP_COPIES = 12
 
 /** Tracks cards played so far this round, across all 4 hands. */
 export class PlayTracker {
@@ -45,14 +51,6 @@ export class PlayTracker {
   playedCount(suit: Suit, rank: Rank): number {
     return this.played.get(PlayTracker.key(suit, rank)) ?? 0
   }
-}
-
-function handCount(hand: readonly Card[], suit: Suit, rank: Rank): number {
-  return hand.reduce((count, c) => count + (c.suit === suit && c.rank === rank ? 1 : 0), 0)
-}
-
-function suitLength(hand: readonly Card[], suit: Suit): number {
-  return hand.reduce((count, c) => count + (c.suit === suit ? 1 : 0), 0)
 }
 
 /**
@@ -349,14 +347,6 @@ export function chooseLeadCard(
 
   // Fallback when side is unknown (old callers): original safe-card cascade
   return leadSafeCascade(hand, trump, tracker, memory)
-}
-
-function minByRank(cards: readonly Card[]): Card {
-  return cards.reduce((lowest, c) => (c.rankValue < lowest.rankValue ? c : lowest))
-}
-
-function maxByRank(cards: readonly Card[]): Card {
-  return cards.reduce((highest, c) => (c.rankValue > highest.rankValue ? c : highest))
 }
 
 /**

--- a/web/src/engine/trick.ts
+++ b/web/src/engine/trick.ts
@@ -8,7 +8,7 @@
 // no dependency on however bidding/passing (#17) would end up representing
 // players. round.ts's teamOf() maps a PlayerIndex to its team.
 
-import type { Card, Rank, Suit } from './card'
+import { type Card, maxByRank, type Rank, type Suit } from './card'
 
 export type PlayerIndex = 0 | 1 | 2 | 3
 
@@ -108,10 +108,9 @@ export class Trick {
   }
 }
 
-function maxByRank(cards: readonly Card[]): Card {
-  return cards.reduce((best, c) => (c.rankValue > best.rankValue ? c : best))
-}
-
+/** Deliberately not card.ts's `maxByRank` (#241): this takes plays, not cards,
+ *  and its first-wins tie-break *is* the trick-winner rule — the seat, not just
+ *  the card, is the answer. Keep the two separate. */
 function firstMaxByRank(plays: readonly TrickPlay[]): TrickPlay {
   return plays.reduce((best, p) => (p.card.rankValue > best.card.rankValue ? p : best))
 }

--- a/web/src/engine/trumpMemory.test.ts
+++ b/web/src/engine/trumpMemory.test.ts
@@ -1,13 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type { SkillLevel } from '../persistence/options'
-import { type CopyId, Card, RANKS, Suit } from './card'
+import { type CopyId, Card, RANKS, Suit, TOTAL_TRUMP_COPIES } from './card'
 import { TRUMP_MEMORY_CAPACITY, TrumpMemory, newTrumpMemories } from './trumpMemory'
 
 const TRUMP = Suit.Spades
-
-/** 6 ranks x 2 copies — the same 12 `tracker.ts` calls `TOTAL_TRUMP_COPIES`,
- *  derived here rather than hard-coded so this drifts if the deck ever does. */
-const TOTAL_TRUMP = RANKS.length * 2
 
 /** Every trump in the deck, in a fixed order: both copies of 9, then J, and so
  *  on up to A. Order is what these tests are about, so it must not be random. */
@@ -27,8 +23,8 @@ describe('TRUMP_MEMORY_CAPACITY', () => {
   })
 
   it('leaves even expert short of the full 12 trump', () => {
-    expect(TOTAL_TRUMP).toBe(12)
-    expect(TRUMP_MEMORY_CAPACITY.expert).toBeLessThan(TOTAL_TRUMP)
+    expect(TOTAL_TRUMP_COPIES).toBe(12)
+    expect(TRUMP_MEMORY_CAPACITY.expert).toBeLessThan(TOTAL_TRUMP_COPIES)
   })
 
   const levels: [SkillLevel, number][] = [
@@ -116,7 +112,7 @@ describe('TrumpMemory forgetting', () => {
     const memory = new TrumpMemory(TRUMP, 'expert') // capacity 10
     memory.seeAll(allTrumpInOrder()) // 9,9,J,J,Q,Q,K,K,10,10,A,A
     expect(memory.size).toBe(10)
-    expect(memory.forgottenCount).toBe(TOTAL_TRUMP - TRUMP_MEMORY_CAPACITY.expert)
+    expect(memory.forgottenCount).toBe(TOTAL_TRUMP_COPIES - TRUMP_MEMORY_CAPACITY.expert)
     expect(memory.seenCount('9')).toBe(0) // the two earliest sightings
     expect(memory.seenCount('J')).toBe(2)
     expect(memory.seenCount('A')).toBe(2)

--- a/web/src/engine/trumpMemory.ts
+++ b/web/src/engine/trumpMemory.ts
@@ -42,11 +42,10 @@ import type { PlayerIndex } from './trick'
  * card is not a strong player, it is a different kind of thing to play against,
  * and the top of the dial is meant to still be beatable.
  *
- * The 12-copy total (6 ranks x 2 copies) is `TOTAL_TRUMP_COPIES` in
- * `tracker.ts`, which is module-private there. This module deliberately does
- * **not** declare a second copy of it: capacity is expressed against skill
- * level, and nothing here needs the total. When #158 needs to compare the two,
- * export the existing constant rather than adding one.
+ * The 12-copy total is `TOTAL_TRUMP_COPIES`, exported from `card.ts` and
+ * derived there from the deck (#241). This module deliberately does **not**
+ * declare a second copy of it: capacity is expressed against skill level, and
+ * nothing here needs the total. Anything that does should import that one.
  */
 export const TRUMP_MEMORY_CAPACITY: Record<SkillLevel, number> = {
   easy: 2,


### PR DESCRIPTION
`tracker.ts` restated four things other engine modules already own. Each moves to the module that owns it; no function body changes.

**What moved**

- `POINT_RANKS` — local `new Set(['A','10','K'])` deleted; `tracker.ts` now imports `trick.ts`'s exported `ReadonlySet<Rank>`, which is what `round.ts` already does. The six strategy call sites now ask the same set that scores a trick, and a mistyped rank no longer compiles.
- `handCount` / `suitLength` — the byte-identical copies in `bidding.ts` and `tracker.ts` collapse into one exported pair in `card.ts`, which already owns `Card`, `RANKS` and `RANK_VALUE`. `suitLength` travels with `handCount` (Python keeps `_hand_count` / `_suit_length` together).
- `maxByRank` / `minByRank` — the copies in `trick.ts` and `tracker.ts` (identical but for the accumulator name) collapse into `card.ts` alongside the above.
- `TOTAL_TRUMP_COPIES` — was `= 12` in `tracker.ts`, module-private, with `trumpMemory.ts` and `trumpMemory.test.ts` both restating "6 ranks x 2 copies" in prose and citing the name they could not import. Now `RANKS.length * COPIES_PER_CARD.length` in `card.ts`, the same derivation pattern as `round.ts`'s `MAX_TRICK_POINTS`. Name and value still match Python's, so cross-engine parity reads unchanged. `trumpMemory.ts`'s docstring instruction to "export the existing constant rather than adding one" is replaced with where it now lives, and `trumpMemory.test.ts` asserts on the real constant instead of a local derivation.

**Deliberately not deduped**

`trick.ts`'s `firstMaxByRank` looks like `maxByRank` but takes `TrickPlay[]` and its first-wins tie-break *is* the trick-winner rule — merging them would move that rule into `card.ts`. It stays, and now carries a comment saying so, in the same spirit as `engineParity.test.ts`'s `partnerOf` note from #231.

**Checks**

- `npm test -- --run`: 42 files, 485 tests, all passing (unchanged from before).
- `tsc -b`: clean.
- `npm run lint`: the three pre-existing `exhaustive-deps` warnings in `AuctionFlow.tsx` / `TrickPlayFlow.tsx`, untouched by this PR; nothing new.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)