### PR TITLE
refactor(engine): one home for the minimum bid raise (#240)

### DIFF
--- a/human_play.py
+++ b/human_play.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 from names import NAME_POOL
 from pinochle_engine import (
     Player, Team, Round, Trick, Suit, RANKS, RANK_VALUE,
-    OPENING_BID, FORCED_BID, PASS_COUNT,
+    OPENING_BID, FORCED_BID, MIN_BID_INCREMENT, PASS_COUNT,
 )
 
 STATE_PATH = os.path.join(os.path.dirname(__file__), "game_state.pkl")
@@ -271,7 +271,7 @@ class InteractiveRound(Round):
         while self._bid_passes < 3:
             if self._bid_active[self._bid_idx]:
                 player = self.players[self._bid_idx]
-                min_bid = OPENING_BID if not self._bid_ever else self._bid_current + 10
+                min_bid = OPENING_BID if not self._bid_ever else self._bid_current + MIN_BID_INCREMENT
                 context = {
                     "ever_bid": self._bid_ever,
                     "passes_so_far": self._bid_passes_so_far,
@@ -281,7 +281,9 @@ class InteractiveRound(Round):
                     "players": self.players,
                 }
                 bid = player.choose_bid(
-                    self._bid_current if self._bid_ever else OPENING_BID - 10, 10, context
+                    self._bid_current if self._bid_ever else OPENING_BID - MIN_BID_INCREMENT,
+                    MIN_BID_INCREMENT,
+                    context,
                 )
                 if bid is not None and bid >= min_bid:
                     self._bid_current = bid

--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -41,6 +41,11 @@ OPENING_BID = 250
 # to OPENING_BID since #200, so passing the auction out no longer discounts
 # anything - the dealer lands on the rung the first seat could have opened at.
 FORCED_BID = 250
+# The minimum raise, stated by pinochle_rules.md on the same line as the
+# opening rung. Passed to Player.choose_bid as its min_increment argument
+# rather than read there directly - the parameter is deliberate, so a caller
+# can drive an auction on a different rung size.
+MIN_BID_INCREMENT = 10
 
 
 class Card:
@@ -2777,7 +2782,7 @@ class Round:
         while passes < 3:
             if active[idx]:
                 player = self.players[idx]
-                min_bid = OPENING_BID if not ever_bid else current_bid + 10
+                min_bid = OPENING_BID if not ever_bid else current_bid + MIN_BID_INCREMENT
                 context = {
                     "ever_bid": ever_bid,
                     "passes_so_far": passes_so_far,
@@ -2787,7 +2792,11 @@ class Round:
                     "dealer": dealer,
                     "teams": self.teams,
                 }
-                bid = player.choose_bid(current_bid if ever_bid else OPENING_BID - 10, 10, context)
+                bid = player.choose_bid(
+                    current_bid if ever_bid else OPENING_BID - MIN_BID_INCREMENT,
+                    MIN_BID_INCREMENT,
+                    context,
+                )
                 if bid is not None and bid >= min_bid:
                     current_bid = bid
                     ever_bid = True

--- a/web/src/ab/headlessGame.ts
+++ b/web/src/ab/headlessGame.ts
@@ -30,7 +30,7 @@ import { auctionReducer, initAuctionState, passedPlayersOf, type AuctionState } 
 import { meldPointsByTeam } from '../components/gameFlowReducer'
 import { teammatesOf } from '../components/trickPlayReducer'
 import { type AuctionContext, chooseBid, chooseTrump } from '../engine/bidding'
-import { Card, type CopyId, RANKS, type Suit, SUITS } from '../engine/card'
+import { Card, type CopyId, MIN_BID_INCREMENT, RANKS, type Suit, SUITS } from '../engine/card'
 import { shouldConcede } from '../engine/evaluator'
 import { checkGameOutcome } from '../engine/game'
 import { isMisdealEligible } from '../engine/misdeal'
@@ -42,8 +42,6 @@ import { newTrumpMemories } from '../engine/trumpMemory'
 import type { PlayerIndex } from '../engine/trick'
 import type { SkillLevel } from '../persistence/options'
 
-/** Matches AuctionFlow's MIN_INCREMENT. */
-const MIN_INCREMENT = 10
 const SEATS: readonly PlayerIndex[] = [0, 1, 2, 3]
 const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'S0', 1: 'S1', 2: 'S2', 3: 'S3' }
 /** A real game reaches 1000 in well under this. The guard exists so a rules
@@ -192,7 +190,7 @@ export function playHeadlessGame(options: HeadlessGameOptions): GameResult {
         turn,
         state.hands[turn],
         state.bidding.currentBid,
-        MIN_INCREMENT,
+        MIN_BID_INCREMENT,
         context,
         seatSkills[turn],
       )

--- a/web/src/ab/latency.ts
+++ b/web/src/ab/latency.ts
@@ -22,14 +22,12 @@
 // single-shot samples, which is where jitter would show up; the CLI prints both.
 
 import { type AuctionContext, chooseBid } from '../engine/bidding'
-import type { Card } from '../engine/card'
+import { MIN_BID_INCREMENT, type Card } from '../engine/card'
 import type { PlayerIndex } from '../engine/trick'
 import type { SkillLevel } from '../persistence/options'
 import { type BidSituationSample, makeRng, playHeadlessGame } from './headlessGame'
 import { DISTILLED_LEVEL, STATIC_LEVEL, installPolicies } from './abRun'
 import { percentile } from './stats'
-
-const MIN_INCREMENT = 10
 
 /** Collects auction positions by playing real games. Both seats run `level` so
  *  the positions are the ones that policy actually produces. */
@@ -81,7 +79,7 @@ function callOnce(s: BidSituationSample, level: SkillLevel): number {
     s.player,
     s.hand as readonly Card[],
     s.currentBid,
-    MIN_INCREMENT,
+    MIN_BID_INCREMENT,
     s.context as AuctionContext,
     level,
   )

--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useReducer, useRef } from 'react'
 import { bestBaseBid, chooseBid, chooseTrump, type AuctionContext } from '../engine/bidding'
-import { OPENING_BID } from '../engine/card'
+import { MIN_BID_INCREMENT, OPENING_BID } from '../engine/card'
 import { PASS_COUNT, choosePassCards } from '../engine/passing'
 import { partnerOf, teamOf, type Hands, type TeamId } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
@@ -17,8 +17,6 @@ import type { SeatCall, SeatState, TableState } from './tableTypes'
 import { TrumpSelector } from './TrumpSelector'
 
 export const AI_BID_DELAY_MS = 600
-
-const MIN_INCREMENT = 10
 
 /** Returns the SkillLevel to use for a given AI player, based on options. */
 function skillForPlayer(player: PlayerIndex, humanPlayer: PlayerIndex, options: GameOptions): SkillLevel {
@@ -68,7 +66,7 @@ export function AuctionFlow({
         passedPlayers: passedPlayersOf(state.bidding.active),
       }
       const skill = skillForPlayer(turn, humanPlayer, options)
-      const decision = chooseBid(turn, state.hands[turn], state.bidding.currentBid, MIN_INCREMENT, context, skill)
+      const decision = chooseBid(turn, state.hands[turn], state.bidding.currentBid, MIN_BID_INCREMENT, context, skill)
       const timer = setTimeout(() => {
         if (decision === null) dispatch({ type: 'PASS_BID', player: turn })
         else dispatch({ type: 'BID', player: turn, amount: decision })

--- a/web/src/engine/card.ts
+++ b/web/src/engine/card.ts
@@ -40,9 +40,10 @@ export const GAME_WIN_SCORE = 1000
 export const GAME_LOSE_SCORE = -1000
 // Lowest rung the auction can open at. **250 since #200** (was 300): a house
 // preference, not a rules discovery. Only the opening rung moved — the minimum
-// raise (10), OPENER_THRESHOLD (320, the hand an AI needs to open at all) and
-// PARTNER_PASSED_FLOOR (320) are unchanged, so the AI opens on the same set of
-// hands as before and simply commits to 250 rather than 300 when it does.
+// raise (MIN_BID_INCREMENT below), OPENER_THRESHOLD (320, the hand an AI needs
+// to open at all) and PARTNER_PASSED_FLOOR (320) are unchanged, so the AI opens
+// on the same set of hands as before and simply commits to 250 rather than 300
+// when it does.
 export const OPENING_BID = 250
 // What the dealer is stuck with if everyone passes without ever bidding.
 // Equal to OPENING_BID since #200, so passing the auction out no longer
@@ -53,6 +54,15 @@ export const OPENING_BID = 250
 // to it — one is an auction floor, the other the trick points in a deck. Do
 // not use either in place of the other (#178).
 export const FORCED_BID = 250
+
+/** The minimum raise, stated by pinochle_rules.md on the same line as the
+ *  opening rung ("Opening bid: **250**... Minimum raise: **10**") and living
+ *  here beside OPENING_BID for that reason. Exported because three callers —
+ *  AuctionFlow and both A/B drivers in web/src/ab/ — feed it to `chooseBid`'s
+ *  `minIncrement` parameter, and each of them used to write out its own `10`.
+ *  `chooseBid` still takes it as a parameter rather than reading it directly,
+ *  mirroring Python's `choose_bid(current_bid, min_increment, ...)`. */
+export const MIN_BID_INCREMENT = 10
 
 export class Card {
   readonly suit: Suit


### PR DESCRIPTION
`MIN_INCREMENT = 10` was declared three times in `web/src`, once with
`/** Matches AuctionFlow's MIN_INCREMENT. */` over it — the comment form
`CODING_STANDARDS.md`'s "Shared values live in one module and are imported"
names as what the rule looks like while it is being broken, and the same one
#218 and #231 removed elsewhere. `ab/latency.ts` was already the stage after,
holding a third copy with nothing recording that it was one.

## What moved

- `web/src/engine/card.ts` — new `export const MIN_BID_INCREMENT = 10`, beside
  `OPENING_BID`/`FORCED_BID`. `OPENING_BID`'s comment already referred to "the
  minimum raise (10)" as a rules value living next to it; it now names the
  constant instead of restating the literal.
- `web/src/components/AuctionFlow.tsx`, `web/src/ab/headlessGame.ts`,
  `web/src/ab/latency.ts` — local `MIN_INCREMENT` deleted, constant imported.
  `headlessGame.ts`'s "Matches AuctionFlow's" comment goes with it.
- `pinochle_engine.py`, `human_play.py` — Python had no name for it either.
  `MIN_BID_INCREMENT` added beside `OPENING_BID`/`FORCED_BID` and fed to the
  same `min_increment` parameter at both auction loops (`Round._bidding_loop`
  and `InteractiveRound`'s resumable copy). The parameter threading through
  `choose_bid`/`_meld_only_bid`/`_rollout_ev_bid` is deliberate and untouched —
  signatures are unchanged.

## On the issue's nomination of `card.ts`

Agreed, and worth stating why the other candidate loses. `engine/bidding.ts`
is the module that runs the auction, but its header (per #213) makes it the
*strategy* side — `PARTNER_PASSED_FLOOR`, `PARTNER_RAISE_FLOOR`, the 330
competitive floor, all TS-authoritative and deliberately not ported back to
Python. The minimum raise is the opposite kind of value: `pinochle_rules.md`
states it on the same line as the opening rung ("Opening bid: **250**...
Minimum raise: **10**"), which makes it a rules constant, and `card.ts` is the
file whose header says Python stays authoritative for those. Putting it in
`bidding.ts` would blur a split that module spends a paragraph drawing.
`AuctionFlow.tsx` was never an option — `react/only-export-components` forbids
a component file exporting logic.

## Behaviour

Identical. Same value, same arguments at every call site.

- `npm test -- --run` in `web/`: 42 files / 485 tests passed.
- `npx tsc --noEmit -p tsconfig.app.json`: clean. `npx oxlint`: only the three
  pre-existing `exhaustive-deps` warnings.
- `python -m pytest -q`: 310 passed.

## Noted, not changed

`web/src/components/BiddingControls.tsx` steps its bid input by bare `10`
literals (lines 49, 56, 66) and its docstring cites "round.ts's `_bidding_loop`
increment" — `_bidding_loop` is Python's, in `pinochle_engine.py`, not
`round.ts`. Same value, but a UI stepper rather than a `chooseBid` argument, and
outside what #240 enumerated. Left for a follow-up so this diff stays small
against #241, which also touches `card.ts`.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)
