### PR TITLE
docs(rules): say why the game ends at 1000 (#243)

### DIFF
--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -193,6 +193,27 @@ through, deliberately does not apply it.
   ends immediately and the **other team wins**, regardless of that
   team's own score.
 
+### Why 1000
+
+**A house rule, and a one-sitting target.** The number is chosen so a game
+is a handful of hands rather than an evening. Measured over 2000 games
+(`pinochle_engine.py`, Proficient seats, deal seeds 1000-2999): a mean of
+**4.52** hands to a win, median **4**, with **4.1%** finishing in two hands
+or fewer. Four hands is the shape this is meant to have, so 1000 stays where
+it is and is not a constant waiting to be tidied upward.
+
+The consequence is that a **Double Run** (1500) beats the whole game on its
+own, and that is known and accepted rather than an oversight. It needs no
+contract to cash: the defending team always scores their own meld, so the
+hand wins from either seat, before a card is led. It happened in 2 of the
+2000 games — **0.10%** — which reads as a story about a hand rather than a
+hole in the balance.
+
+Moving the target later would not be a one-constant change. Both engines read
+`GAME_WIN_SCORE`, but `win_probability.py` derives its `BUCKET_COUNT` from the
+win/lose pair and its `WIN_PROBABILITY_TABLE` is a hard-coded 20×20 literal
+that would have to be re-measured.
+
 ## Implementation Notes (for future chats picking this up)
 
 ### Which engine is the real one


### PR DESCRIPTION
Closes #243.

Implements the recorded decision: `GAME_WIN_SCORE` stays at 1000 and the
reason goes in `pinochle_rules.md`. **Zero code changes** — one new
`### Why 1000` subsection under `## Game Win / Loss`, 21 lines.

## What it says

- 1000 is a house rule (already flagged in the doc header) chosen as a
  one-sitting target, with the 2000-game numbers from the issue's decision
  comment: mean 4.52 hands, median 4, 4.1% in two hands or fewer.
- A Double Run (1500) exceeding the game outright is known and accepted, not
  an oversight, and it needs no contract — `pinochle_rules.md`'s "the
  defending team always scores their own meld" means it wins from either
  seat, before a card is led. 2 games in 2000, 0.10%.

## Judgement calls

**Included** the "not a one-constant change" note, trimmed to three lines:
`win_probability.py` derives `BUCKET_COUNT` from the win/lose pair and its
`WIN_PROBABILITY_TABLE` is a hard-coded 20x20 literal needing re-measurement.
It is developer detail in a player-facing section, but the doc already mixes
that register in the same voice a few sections up ("**TypeScript only.**
`pinochle_engine.py` plays every trick out"), and it is the one fact that
stops a future reader from bumping the constant and calling it done. The
`rollout_dataset.csv` shift and the "must land before #226" ordering did not
survive the trim — those stay in the issue, where the epic context lives.

**Left out** the save-and-resume argument from the original recommendation.
It was wrong: #54 shipped a localStorage autosave
(`web/src/persistence/gameSave.ts`). The paragraph rests only on the half of
the argument that holds — four hands is a good shape, and a 0.10% jackpot
reads as a story.

**Left out** the full rounds-to-win histogram and the -1000 floor rate. The
floor is a separate constant the doc already frames as a mercy rule, and it
is not what was decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)