### PR TITLE
docs(engine): say that InteractiveRound is a mirror, not just resumable (#244)

### DIFF
--- a/human_play.py
+++ b/human_play.py
@@ -171,7 +171,16 @@ class InteractiveRound(Round):
     """Same rules as Round, but every phase is resumable: state lives in
     instance attributes instead of local variables, so a NeedsHumanInput
     exception can propagate all the way out (through run()) without
-    losing progress, then pick back up on the next call to run()."""
+    losing progress, then pick back up on the next call to run().
+
+    That makes this a hand-maintained mirror of Round: only the phases
+    holding a human decision point are overridden here, so a rules change
+    in one of them has to be repeated on this side or the interactive
+    path silently plays a different game from the AI-only path, with
+    nothing at runtime comparing the two. `_check_misdeal` is where the
+    two have already diverged - deliberately, and frozen that way (issue
+    #128) - so read it as the example of the drift, not as the exception
+    to it."""
 
     def _check_misdeal(self):
         """House rule: 5+ nines in a single hand qualifies for a reshuffle.


### PR DESCRIPTION
`InteractiveRound`'s docstring explained the resumable-state mechanism and
stopped there. The mechanism's consequence — the phases now exist twice, and
the second copy is maintained by hand — was nowhere in the file, the class, or
the suite. This adds a paragraph saying it.

The claim was checked against the code before it was written, and one detail in
the issue needed narrowing. `InteractiveRound` does not reimplement *every*
phase: it overrides `run`, `_bidding_loop`, `_passing_phase` and
`_trick_taking_loop` — the ones containing a human decision point — and calls up
to `Round` for `_deal`, `_meld_phase`, `_concede_phase`, `_stamp_team_round_context`
and scoring. The docstring states that boundary, because a reader who thinks
everything is duplicated will look for a second copy of scoring that isn't there,
and one who thinks nothing is will miss the four that are.

The `_check_misdeal` asymmetry still holds exactly as described: `Round` has no
such method and `Round.run()` goes from `_deal()` to `_bidding_loop()`, so the
interactive path is the only Python code honouring the reshuffle house rule.
It is named as a pointer only — the reasoning stays in `ROADMAP.md`, which
freezes the gap on purpose (#128).

Out of scope and not done: mirroring the misdeal rule into `Round`, any
restructuring, and a test enforcing the mirror.

Documentation only, one file. `python -m pytest -q` from the repo root: 310
passed.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)