### PR TITLE
refactor(ui): the bid stepper reads the raise instead of restating it (#248)

### DIFF
--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -164,7 +164,7 @@ export function AuctionFlow({
 
   const overlay = useMemo(() => {
     if (state.phase === 'bidding' && state.bidding.turn === humanPlayer) {
-      const minBid = state.bidding.everBid ? state.bidding.currentBid + 10 : OPENING_BID
+      const minBid = state.bidding.everBid ? state.bidding.currentBid + MIN_BID_INCREMENT : OPENING_BID
       const myTeam = teamOf(humanPlayer)
       const oppTeam: TeamId = myTeam === 0 ? 1 : 0
       const { total: suggestedCeiling } = bestBaseBid(

--- a/web/src/components/BiddingControls.tsx
+++ b/web/src/components/BiddingControls.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
+import { MIN_BID_INCREMENT } from '../engine/card'
 
 export interface BiddingControlsProps {
   /** Lowest legal bid right now — `OPENING_BID` before anyone has bid,
-   * `currentBid + 10` afterward (round.ts's `_bidding_loop` increment). */
+   * `currentBid + MIN_BID_INCREMENT` afterward. Both constants live in
+   * `card.ts`; `AuctionFlow` does that arithmetic and passes the result in. */
   minBid: number
   /** The standing bid, for display context ("current bid: N"). Only
    * meaningful once someone has bid; 0 beforehand. */
@@ -45,15 +47,15 @@ export function BiddingControls({
       <div className="mt-3 flex items-center gap-2">
         <button
           type="button"
-          aria-label="Decrease bid by 10"
-          onClick={() => setAmount((a) => Math.max(minBid, a - 10))}
+          aria-label={`Decrease bid by ${MIN_BID_INCREMENT}`}
+          onClick={() => setAmount((a) => Math.max(minBid, a - MIN_BID_INCREMENT))}
           className="rounded bg-neutral-200 px-3 py-1 font-semibold hover:bg-neutral-300"
         >
           −
         </button>
         <input
           type="number"
-          step={10}
+          step={MIN_BID_INCREMENT}
           min={minBid}
           value={amount}
           onChange={(e) => setAmount(Number(e.target.value))}
@@ -62,8 +64,8 @@ export function BiddingControls({
         />
         <button
           type="button"
-          aria-label="Increase bid by 10"
-          onClick={() => setAmount((a) => a + 10)}
+          aria-label={`Increase bid by ${MIN_BID_INCREMENT}`}
+          onClick={() => setAmount((a) => a + MIN_BID_INCREMENT)}
           className="rounded bg-neutral-200 px-3 py-1 font-semibold hover:bg-neutral-300"
         >
           +


### PR DESCRIPTION
Closes #248.

The follow-up #240 (PR #247) deliberately left out. `MIN_BID_INCREMENT` now
exists in `web/src/engine/card.ts`, so the human bid stepper can read it
instead of writing 10 four more times.

## What changed

- `web/src/components/BiddingControls.tsx` — the decrement's
  `Math.max(minBid, a - 10)`, the input's `step={10}` and the increment's
  `a + 10` all read `MIN_BID_INCREMENT`, and both aria-labels are derived
  from it (`` `Increase bid by ${MIN_BID_INCREMENT}` ``) so the announced
  step cannot drift from the taken one.
- Same file, the `minBid` prop docstring. It read:

  > Lowest legal bid right now — `OPENING_BID` before anyone has bid,
  > `currentBid + 10` afterward (round.ts's `_bidding_loop` increment).

  `_bidding_loop` is a Python method on `Round` in `pinochle_engine.py`;
  `web/src/engine/round.ts` has no such function. It now points at `card.ts`
  and names `AuctionFlow` as what does the arithmetic.
- `web/src/components/AuctionFlow.tsx` line 167 computed that prop as
  `currentBid + 10` while already importing `MIN_BID_INCREMENT` for
  `chooseBid`. Included because it is the sole caller of the prop whose
  docstring this PR corrects; strip it if you would rather it went on its own.

## Deliberately not changed

`isValid` still gates the Bid button on `amount % 10 === 0`. That is the
legal-bid grid rather than the step, and the two coincide only because
`OPENING_BID` is a multiple of 10 — a 20 raise off 250 would make legal bids
250/270/290 and the modulo wrong. `bidding.ts`'s `PARTNER_PASSED_FLOOR`
docstring cites that check by name for that reason (#177). What the grid is
derived from is a design question, not a dedupe.

Stepping behaviour is untouched (#248's out-of-scope note).

## Verification

- `npm test -- --run --maxWorkers=2` — **42 files / 485 tests passed**
  (full file set per #170, not a partial run).
- `npx tsc --noEmit -p tsconfig.app.json` clean; `npm run lint` shows only
  the three pre-existing `exhaustive-deps` warnings.
- `BiddingControls.test.tsx` asserts on the literal `'Increase bid by 10'`
  and is untouched — it passes against the derived label and keeps pinning
  the rendered value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)