### PR TITLE
feat(rules): open the auction at 300 again, so the forced bid is a discount (#257)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,9 +109,10 @@ because nothing needs them yet (see Open questions).
 
 1. **Decisions** — done. Opening-bid mismatch resolved: the engine
    value was canonical and `pinochle_rules.md` was updated to match.
-   **Superseded by #200** — the auction now opens at 250 rather than
-   300, changed in both engines in the same commit. Stack locked
-   (above).
+   #200 then moved the opener to 250 and **#257 moved it back to 300**,
+   both times in both engines in the same commit; 300 is where it
+   stands, and `FORCED_BID` stays 250 so passing the auction out is a
+   discount again. Stack locked (above).
 2. **Rules engine port to TS** — done. `web/src/engine/` holds the core
    data model, deal, meld scoring, bidding, the 3-card pass,
    trick-taking, and round/game scoring, one file per concern with

--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -31,15 +31,21 @@ RANK_VALUE = {rank: i for i, rank in enumerate(RANKS)}
 
 GAME_WIN_SCORE = 1000
 GAME_LOSE_SCORE = -1000
-# Lowest rung the auction can open at. 250 since #200 (was 300): a house
-# preference, not a rules discovery. Only the opening rung moved - the minimum
-# raise (10), OPENER_THRESHOLD (320, the hand a bidder needs to open at all)
-# and PARTNER_PASSED_FLOOR (320) are unchanged, so the AI opens on the same set
-# of hands as before and simply commits to 250 rather than 300 when it does.
-OPENING_BID = 250
-# What the dealer is stuck with if everyone passes without ever bidding. Equal
-# to OPENING_BID since #200, so passing the auction out no longer discounts
-# anything - the dealer lands on the rung the first seat could have opened at.
+# Lowest rung the auction can open at. 300, restored by #257 after #200 had
+# moved it to 250: a house preference, not a rules discovery, and one decided
+# twice - the second time on the evidence of having played it. The rung on its
+# own was never the point; what it buys is the gap to FORCED_BID below. Only
+# the opening rung moves - the minimum raise (10), OPENER_THRESHOLD (320, the
+# hand a bidder needs to open at all) and PARTNER_PASSED_FLOOR (320) are
+# unchanged, so the AI opens on the same set of hands either way and simply
+# commits to 300 rather than 250 when it does.
+OPENING_BID = 300
+# What the dealer is stuck with if everyone passes without ever bidding. Sits
+# 50 below OPENING_BID on purpose: the dealer never chose this contract, so
+# they get it cheaper than anyone who bid for one. That discount is what #257
+# was restoring - with both numbers at 250 there was nothing left to discount,
+# and passing the auction out landed the dealer on the very rung the first
+# seat could have opened at.
 FORCED_BID = 250
 # The minimum raise, stated by pinochle_rules.md on the same line as the
 # opening rung. Passed to Player.choose_bid as its min_increment argument

--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -44,16 +44,18 @@ from standard card-game rank order.
 
 ## Phase 1: Bidding
 
-- Opening bid: **250** (300 before #200). Minimum raise: **10**.
+- Opening bid: **300**. Minimum raise: **10**, and every bid falls on the
+  multiple-of-10 grid that raise implies — 300, 310, 320, never 305.
 - Starting with the player left of the dealer, bidding rotates clockwise.
 - On your turn: bid `current_bid + 10` (or more), or pass.
 - Once you pass, you're out of the rotation for the rest of the auction.
 - Bidding ends when 3 players have passed. The 4th is the **ContractWinner**.
 - Edge case: if all 4 players pass without ever bidding, the dealer is
-  forced to take the contract at a **forced bid of 250**. Since the opening
-  bid came down to 250 (#200) this is no longer a reduction — passing the
-  auction out lands the dealer on the same rung the first seat could have
-  opened at.
+  forced to take the contract at a **forced bid of 250** — 50 below the
+  opening rung. The discount is the point: the dealer never chose this
+  contract, so they carry it more cheaply than anyone who chose to bid for
+  one. (#200 briefly moved the opening bid down to 250, which flattened the
+  discount to nothing; #257 put the opener back to 300 to restore it.)
 
 ## Phase 2: Trump & Passing
 

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -639,12 +639,26 @@ describe('raising over a bid our own team already holds (#206)', () => {
   // Ceiling 320 — opens happily, but cannot support a 340 commitment.
   const modestHand = [...RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1)), new Card(Suit.Spades, 'A', 1)]
 
-  /** Seat 2 opened at OPENING_BID; its partner (seat 0) then bid `partnerBid`. */
+  /** Seat 2 opened one rung under `partnerBid`; its partner (seat 0) then bid
+   *  `partnerBid`.
+   *
+   *  Seat 2's own number is scaffolding. The branch under test fires on
+   *  `currentBid > myOwnBids.at(-1)` — all it needs is that the partner's bid
+   *  is above seat 2's — so the open is derived from the raise rather than
+   *  pinned to `OPENING_BID`. It was `OPENING_BID` until #257 moved that rung
+   *  back to 300, at which point every `partnerBid` below 300 described an
+   *  auction that ran *downhill*: seat 2 opened 300 and its partner "raised"
+   *  to 260, so `chooseBid` correctly answered null on the grounds that its
+   *  own bid still stood, and the test failed for a reason that had nothing to
+   *  do with PARTNER_RAISE_FLOOR. Deriving the open keeps the off-ladder
+   *  `partnerBid` values this block exists to exercise (see the note above)
+   *  and stops the fixture tracking an opening rung it does not care about.
+   */
   const afterPartnerRaise = (partnerBid: number): AuctionContext => ({
     everBid: true,
     passesSoFar: 0,
     bidHistory: [
-      { player: 2 as PlayerIndex, amount: OPENING_BID },
+      { player: 2 as PlayerIndex, amount: partnerBid - 10 },
       { player: 0 as PlayerIndex, amount: partnerBid },
     ],
     dealer: 1,

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -84,10 +84,11 @@ export const MAX_BID_MELD_THRESHOLD = 300
 
 // Minimum Base Bid to justify opening at all.
 export const OPENER_THRESHOLD = 320
-// Minimum ceiling to justify a defensive push against an opening bid (250
-// since #200, 300 before). Hands at or above this floor should almost always
-// raise an opener, since even moderate hands can contribute toward making it
-// with partner's help, and pushing deprives the opponent of a cheap contract.
+// Minimum ceiling to justify a defensive push against an opening bid (300
+// again since #257, 250 in between under #200). Hands at or above this floor
+// should almost always raise an opener, since even moderate hands can
+// contribute toward making it with partner's help, and pushing deprives the
+// opponent of a cheap contract.
 // "Truly hopeless" hands (no meld, no aces — ceiling ~130) fall below this
 // floor. It is a hand-strength threshold, not a bid level, so it did not move
 // with the opener.
@@ -608,11 +609,19 @@ export function chooseBid(
   // Bounded above by `ceiling`, so the walk cannot talk a seat past what its
   // cards are worth, and it steps by `minIncrement` so it cannot leave the
   // multiple-of-ten grid (#177). The static verdict keeps the cushion
-  // `OPENER_THRESHOLD` already implies over `OPENING_BID` — 70 points — so a
-  // static seat asked about level L wants a ceiling of L + 70, which at the
-  // opening rung is exactly `OPENER_THRESHOLD` and stays self-consistent as the
-  // level climbs. Without that the level-independent static verdict would walk
-  // every opener to its ceiling.
+  // `OPENER_THRESHOLD` already implies over `OPENING_BID` — **20 points** at
+  // today's 320/300 pair — so a static seat asked about level L wants a
+  // ceiling of L + 20, which at the opening rung is exactly `OPENER_THRESHOLD`
+  // and stays self-consistent as the level climbs. Without that the
+  // level-independent static verdict would walk every opener to its ceiling.
+  //
+  // The cushion is derived rather than written down precisely because it is
+  // not a fixed quantity: it was 20 before #200, 70 while the opener sat at
+  // 250, and is 20 again since #257 put the opener back to 300. A narrower
+  // cushion is a more permissive walk — a static seat now accepts a level only
+  // 20 under its ceiling — so `'walk'` climbs further per hand than it did
+  // last week. That arm measured negative and is queued for deletion (#221);
+  // nothing shipped selects it, so this is a note, not a regression.
   const openingLevelFor = (floor: number): number => {
     if (SKILL_PARAMS[skill].openingPolicy !== 'walk') return floor
     const cushion = OPENER_THRESHOLD - OPENING_BID
@@ -709,7 +718,11 @@ export function chooseBid(
   const nextBid = currentBid + minIncrement
 
   // Defensive push (#78): when opponent opened at the minimum (OPENING_BID —
-  // 250 since #200), respond unless the hand is truly hopeless. The static
+  // 300 again since #257), respond unless the hand is truly hopeless. The gate
+  // is `currentBid <= OPENING_BID`, so it follows the opening rung wherever it
+  // goes: it now fires on a bid of 300 and stops at 310, where last week it
+  // fired at 250 and stopped at 260. One rung later in absolute terms, the
+  // same rung relative to the auction. The static
   // rule is a ceiling floor (DEFENSIVE_PUSH_FLOOR) on the reasoning that the
   // opening rung is the absolute floor and is almost always raised — even a
   // moderate hand can contribute toward making it with partner's help, and

--- a/web/src/engine/card.ts
+++ b/web/src/engine/card.ts
@@ -46,25 +46,29 @@ export const TOTAL_TRUMP_COPIES = RANKS.length * COPIES_PER_CARD.length
 
 export const GAME_WIN_SCORE = 1000
 export const GAME_LOSE_SCORE = -1000
-// Lowest rung the auction can open at. **250 since #200** (was 300): a house
-// preference, not a rules discovery. Only the opening rung moved — the minimum
-// raise (MIN_BID_INCREMENT below), OPENER_THRESHOLD (320, the hand an AI needs
-// to open at all) and PARTNER_PASSED_FLOOR (320) are unchanged, so the AI opens
-// on the same set of hands as before and simply commits to 250 rather than 300
-// when it does.
-export const OPENING_BID = 250
-// What the dealer is stuck with if everyone passes without ever bidding.
-// Equal to OPENING_BID since #200, so passing the auction out no longer
-// discounts anything — the dealer lands on the rung the first seat could have
-// opened at. Kept as its own constant because the two mean different things
-// and only one of them is a house preference.
+// Lowest rung the auction can open at. **300, restored by #257** after #200
+// had moved it to 250: a house preference, not a rules discovery, and one
+// decided twice — the second time on the evidence of having played it. The
+// rung on its own was never the point; what it buys is the gap to FORCED_BID
+// below. Only the opening rung moves — the minimum raise (MIN_BID_INCREMENT
+// below), OPENER_THRESHOLD (320, the hand an AI needs to open at all) and
+// PARTNER_PASSED_FLOOR (320) are unchanged, so the AI opens on the same set of
+// hands either way and simply commits to 300 rather than 250 when it does.
+export const OPENING_BID = 300
+// What the dealer is stuck with if everyone passes without ever bidding. Sits
+// 50 below OPENING_BID on purpose: the dealer never chose this contract, so
+// they get it cheaper than anyone who bid for one. That 50-point discount is
+// what #257 was restoring — with both numbers at 250 there was nothing left to
+// discount, and passing the auction out landed the dealer on the very rung the
+// first seat could have opened at. Kept as its own constant because the two
+// mean different things and only one of them is a house preference.
 // Coincidentally equal to round.ts's MAX_TRICK_POINTS and entirely unrelated
 // to it — one is an auction floor, the other the trick points in a deck. Do
 // not use either in place of the other (#178).
 export const FORCED_BID = 250
 
 /** The minimum raise, stated by pinochle_rules.md on the same line as the
- *  opening rung ("Opening bid: **250**... Minimum raise: **10**") and living
+ *  opening rung ("Opening bid: **300**... Minimum raise: **10**") and living
  *  here beside OPENING_BID for that reason. Exported because three callers —
  *  AuctionFlow and both A/B drivers in web/src/ab/ — feed it to `chooseBid`'s
  *  `minIncrement` parameter, and each of them used to write out its own `10`.

--- a/web/src/engine/evaluator.test.ts
+++ b/web/src/engine/evaluator.test.ts
@@ -226,21 +226,24 @@ describe('the skill dial selects the bid policy (#114, opened by #115)', () => {
     // This hand melds 190 under Hearts (Run 150 + Royal Marriage 40), so the
     // meld-only ceiling is 190 + 60 flat + noise in [-30, 30] = [220, 280].
     //
-    // The noise has to be pinned. Against the old 300 opener the whole range
-    // fell short and a bare `toBeNull()` was deterministic; #200's 250 opener
-    // sits *inside* it, so the same assertion became a coin flip that passed
-    // roughly half the time. Pinning it is also a sharper check than the old
-    // one: at minimum noise `easy` declines a hand the evaluator opens, which
-    // is the divergence this test is named for, and at maximum noise the
-    // decision follows meld + flat arithmetic rather than the model.
+    // The noise stays pinned even though it no longer has to be. #200's 250
+    // opener sat *inside* [220, 280], which turned a bare `toBeNull()` into a
+    // coin flip that passed roughly half the time; #257 put the opener back to
+    // 300 and the whole range falls short again, so the bare assertion would be
+    // deterministic once more. Pinning is kept because it asserts the
+    // arithmetic rather than the outcome: both extremes are named, and the
+    // upper one records that the miss is by 20 points, not by miles. If either
+    // MELD_ONLY_TRICK_ESTIMATE or the opening rung moves back toward the other,
+    // this fails on the specific number instead of going quietly random.
     const random = vi.spyOn(Math, 'random')
     try {
-      random.mockReturnValue(0) // noise -30 -> ceiling 220, under the opener
+      random.mockReturnValue(0) // noise -30 -> ceiling 220, 80 under the opener
       expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'easy')).toBeNull()
       expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
 
-      random.mockReturnValue(1) // noise +30 -> ceiling 280, over it
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'easy')).toBe(OPENING_BID)
+      random.mockReturnValue(1) // noise +30 -> ceiling 280, still 20 under it
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'easy')).toBeNull()
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
     } finally {
       random.mockRestore()
     }

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -139,8 +139,8 @@ export type SafeCounterPolicy = 'off' | 'counted'
 /**
  * What number a seat that decides to open actually puts on the table (#204).
  *
- *   `'fixed'`  open at `OPENING_BID` — 250 — whatever the hand is worth. What
- *              every level has always done.
+ *   `'fixed'`  open at `OPENING_BID` — 300 since #257 — whatever the hand is
+ *              worth. What every level has always done.
  *   `'walk'`   open at the highest rung the seat's own bid policy still says
  *              the hand is worth, starting from `OPENING_BID` and stepping by
  *              the auction's minimum increment.
@@ -149,9 +149,12 @@ export type SafeCounterPolicy = 'off' | 'counted'
  * has only ever acted on the first: *should* I open, and *at what level*. The
  * opening branch answers the first with `worthContract(OPENING_BID, ...)` and
  * then hard-codes the second to `OPENING_BID`, so a seat holding a 400-ceiling
- * hand opens at 250 and, if the other three pass, buys the contract for 250.
+ * hand opens at the rung and, if the other three pass, buys the contract there.
  * Measured over 4000 AI-vs-AI auctions on `hard`, that is 27.4% of all deals,
- * and 44.5% of those hands were worth 320 or more.
+ * and 44.5% of those hands were worth 320 or more. Those figures were taken
+ * while `OPENING_BID` was 250 (#200) and have not been re-run since #257 put
+ * it back to 300 — the shape of the finding survives the move, the exact
+ * percentages are not claimed to.
  *
  * `'walk'` does not make a seat open on hands it would have passed: the loop
  * only runs once `opens` is already true, and it is bounded above by the


### PR DESCRIPTION
Closes #257.

`OPENING_BID` 250 -> **300** in both engines in one commit (`pinochle_engine.py`, `web/src/engine/card.ts`). `FORCED_BID` stays **250**, so the dealer who is stuck with a contract after four passes carries it 50 points cheaper than anyone who chose to bid for one. That discount is the point of the change; the rung is the mechanism. This reverses #200 on the evidence of having played it, and the commit body says so plainly so the history reads as a decision rather than as churn.

`card.ts`'s `FORCED_BID` comment no longer claims equality with `OPENING_BID` — it now says it is a 50-point discount and why (the dealer never chose the contract). `pinochle_rules.md:47` and the forced-bid paragraph are both rewritten, and :47 gains the **multiple-of-10 grid** as a clause on the line that already carries the opening rung and the raise. #210's other doc silences are untouched.

## The four knock-ons

**1. Opener cushion, `bidding.ts` `openingLevelFor`.** #221 has **not** landed (still open), so the `'walk'` arm is still here and the comment had to be corrected rather than deleted. `OPENER_THRESHOLD - OPENING_BID` is now **20**, not 70. The self-consistency argument survives — a static seat asked about level L wants ceiling L + 20, which at the opening rung is exactly `OPENER_THRESHOLD` — but the cushion is *narrower*, so `'walk'` is more permissive and climbs further per hand than it did last week. The comment now states the value is derived precisely because it is not fixed (20 before #200, 70 under #200, 20 again now). Nothing shipped selects `'walk'`, so this is a note rather than a regression, and #221 deleting the arm makes it moot.

**2. Defensive push fires a rung later.** Confirmed. The gate is `currentBid <= OPENING_BID` (`bidding.ts:~720`, `pinochle_engine.py:~1880`) and it follows the rung: it now fires on a bid of 300 and declines at 310, where last week it fired at 250 and declined at 260. One rung later in absolute terms, the same rung relative to the auction. #200 recorded this in the opposite direction; the comment is updated. `DEFENSIVE_PUSH_FLOOR` is 200 in both engines and did not move — it is a hand-strength threshold, not a bid level.

**3. Positional opens now put 300 on the table.** Confirmed, both paths, both engines: dealer-protection (`partnerIsDealer && myScore >= 850 && oppScore < 500`) and the third-bidder open (`passesSoFar === 2`, score <= 800) `return OPENING_BID` with no hand test at all. They now commit 300 rather than 250 on any hand. This does not create a new problem — it is exactly the behaviour **#255** ("the AI bids on hands worth well under 320, from three separate paths") is already open about, and it makes that issue's numbers *larger*, not different: the same hands, 50 points more exposed. **#256** (the AI bidding 390 at 910-110 instead of melding out) is unaffected in mechanism — neither bidding path can see the endgame either way — but the higher floor means the positional opens reach a score-relevant number sooner. Both stay separate; nothing here pre-empts them.

**4. `OPENER_THRESHOLD` unchanged.** Confirmed 320 in both engines, alongside `PARTNER_PASSED_FLOOR` 320, `PARTNER_RAISE_FLOOR` 340, `MIN_BID_INCREMENT` 10. The AI opens on exactly the same set of *hands* and only commits to a different number when it does.

## What regenerated

**Nothing.** Both generated-artifact checks pass against the committed files untouched:

- `export_parity_scenarios.py --check` -> "generated files are up to date". By design: `--check` re-renders `web/src/engine/engineParity.fixture.ts` from the committed `parity_scenarios.json` and does **not** re-record, so an AI or constant change cannot move it. The 40 recorded scenarios include 11 with `bid: 250`, some of which were 250 *openers* under #200 and are no longer legal opening rungs. Those are pinned *inputs* to a rules-vs-rules comparison, not assertions about a legal auction, so they stay valid and re-recording would churn all 40 for no rules reason. Deliberately not re-recorded.
- `export_evaluator.py --check` -> "generated files are up to date". The model is fitted from a stored dataset, not from a live auction.

That dataset is the sequencing point #257 raises: it carries `bid` as a feature and was generated at the 250 opener, so this and #242 both belong **before #226** in epic #185 or the dataset gets regenerated twice. Not this PR's to fix.

## Test changes, and why they are not incidental

Two tests failed for real reasons and were fixed rather than pinned around:

- `evaluator.test.ts` "leaves easy on the meld-only path". #200 rewrote this because the 250 opener sat *inside* the hand's [220, 280] meld-only ceiling range, turning a bare `toBeNull()` into a coin flip. At 300 the whole range falls short again and both noise extremes decline. The `Math.random` pin is **kept anyway** — it asserts the arithmetic rather than the outcome and records that the near miss is 20 points, so a future move of `MELD_ONLY_TRICK_ESTIMATE` or the rung fails on a number instead of going quietly random.
- `bidding.test.ts` `afterPartnerRaise` (#206 block). The helper hardcoded seat 2's open at `OPENING_BID` and then had its partner "raise" to 260 — an auction running *downhill* once the opener passed those values, so `chooseBid` correctly answered null on the grounds its own bid still stood, and the test failed for a reason unrelated to `PARTNER_RAISE_FLOOR`. The open is now derived as `partnerBid - 10`, which is all the branch under test actually requires (`currentBid > myOwnBids.at(-1)`), and it preserves the off-ladder `partnerBid` values that block's header explicitly says not to simplify away.

## Noticed, not fixed

The `'pushes opponents rather than handing them a cheap contract'` test in the same #206 block builds its own fixture recording an `OPENING_BID` open followed by a 260, which is now also downhill. It passes, and for the right reason (it exercises the *opponent* branch, where only `currentBid` matters), so it is left alone rather than folded into a rules change. Worth a separate cleanup pass over that block's fixtures.

## Verification

- `python -m pytest -q` from the repo root: **310 passed** (183s).
- `cd web && npm test -- --run --maxWorkers=2`: **42 files / 485 tests, all passing**. Full count, not a short run (#170).
- `npx tsc --noEmit -p tsconfig.app.json`: clean.
- Grepped both engines for bare `250`/`300` in bidding paths (the #126 / #118 constant class). Found and fixed three stale comments: `bidding.ts`'s `DEFENSIVE_PUSH_FLOOR` header ("250 since #200, 300 before"), `skills.ts`'s `openingPolicy` doc (which stated 250 as the fixed open, and whose 27.4%/44.5% measurement was taken on 2026-08-20 under the 250 opener — now labelled as such rather than silently reattributed to 300), and `card.ts`'s `MIN_BID_INCREMENT` docstring, which quotes the rules-doc line verbatim. Two Python comments that read "300" were *wrong* under #200 and are correct again without edits: `pinochle_engine.py:228-230` (`DEFENSIVE_PUSH_FLOOR`) and `:1882-1884` (defensive push). `ROADMAP.md`'s "Superseded by #200" note is updated.

**Player-visible. Needs a deploy after merge** — `npm run build` in `web/`, then `npx netlify deploy --prod` from the repo root. Merging does not ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
