### PR TITLE
feat(ai): stop bidding once the game is one meld from over (#256)

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -232,6 +232,69 @@ OPENER_THRESHOLD = 320  # minimum Base Bid to justify opening at all
 # hopeless" hands (no meld, no aces — ceiling ~130) fall below this floor.
 DEFENSIVE_PUSH_FLOOR = 200
 
+# -- Endgame protection (#256). The one bidding rule that is about the *game*
+# rather than about the hand: a team this close to 1000 banks its meld and
+# lets the contract go, because the contract is worth little to it - the
+# defending team scores its own meld either way - while being set costs the
+# whole bid and hands back a game that was one hand from over. Both thresholds
+# are derived from GAME_WIN_SCORE so they follow the target if it ever moves;
+# #243 records why moving it is expensive. 750 is "within 250 of going out",
+# which one ordinary meld plus a share of the tricks reaches. 450 is "more
+# than 550 away", more than the opponents can plausibly take off a single
+# hand, so there is a next hand to fight it out in.
+ENDGAME_SCORE_FLOOR = GAME_WIN_SCORE - 250
+ENDGAME_OPP_SCORE_CAP = GAME_WIN_SCORE - 550
+# The one hand check in the rule, and the only thing that puts a bid back on
+# the table while the trigger holds. This is the Max Bid *ceiling* (Base Bid
+# plus the competitive adjustment, capped), not the Base Bid: in the score
+# band this rule fires in `compute_competitive_adjustment` returns +100, so
+# the effective bar is a Base Bid a little over 100 and few hands fail it.
+# That is a deliberate choice rather than an oversight - if the rescue turns
+# out to fire on hands that cannot carry OPENING_BID, this is the number to
+# revisit, not the choice of measure.
+ENDGAME_RESCUE_CEILING = 200
+
+
+def endgame_protection_applies(my_score, opp_score):
+    """True when this team should be banking its meld rather than buying a
+    contract: within 250 of going out while the opponents are more than 550
+    away. It is a property of the *team*, so both its seats are covered, not
+    only the one holding a good hand."""
+    return my_score >= ENDGAME_SCORE_FLOOR and opp_score < ENDGAME_OPP_SCORE_CAP
+
+
+def endgame_protection_bid(context, opponents, partner_is_dealer, ceiling):
+    """
+    What a seat bids while `endgame_protection_applies` holds. The default is
+    None - pass, for the whole auction, on any hand, opening or over anyone.
+    If the dealer is an opponent the auction passes out and they are stuck at
+    FORCED_BID, which is the outcome this rule is happy to buy.
+
+    The single exception is a partner who is dealing: passing out would stick
+    *us* with a contract nobody chose, so this seat opens at OPENING_BID
+    instead - but only holding a hand worth more than ENDGAME_RESCUE_CEILING,
+    and only while no opponent has bid. An opponent who has bid has already
+    taken the contract off our hands, which is what we wanted.
+
+    Reading only one opponent is a seat-order fact rather than a
+    simplification. The auction opens left of the dealer and rotates
+    clockwise, so a partner-of-the-dealer seat speaks *second*: after exactly
+    one opponent, and before both the other opponent and the dealer. There is
+    no later turn at which this seat knows more, because to still be in the
+    auction it would have had to bid. `context` carries the auction record but
+    no seat indices (see `GeneralStrategy._auction_evidence`), so "the
+    opponent who spoke immediately before me has passed" is read here as "an
+    opponent has passed and none has bid" - at this seat, and only at this
+    seat, those are the same statement.
+    """
+    if not partner_is_dealer:
+        return None
+    if any(p in opponents for p, _ in context.get("bid_history", [])):
+        return None
+    if not any(p in opponents for p in context.get("passed_players", [])):
+        return None
+    return OPENING_BID if ceiling > ENDGAME_RESCUE_CEILING else None
+
 
 def compute_base_bid(hand, trump):
     """
@@ -1836,13 +1899,20 @@ class Player:
         is_dealer = (self is context["dealer"])
         partner_is_dealer = (partner is context["dealer"])
 
-        if not context["ever_bid"]:
-            # Dealer-protection: partner is dealer, score makes them a
-            # target for a "pass out and stick them with FORCED_BID" play -
-            # always open regardless of hand.
-            if partner_is_dealer and my_score >= 850 and opp_score < 500:
-                return OPENING_BID
+        # Endgame protection (#256) sits in front of every other bidding rule
+        # and in front of the valuation, because it is not a judgement about
+        # the hand at all - once the trigger holds, what the cards are worth
+        # stops being the question. It replaces the old dealer-protection
+        # tier outright (partner dealing, my_score >= 850, opp_score < 500,
+        # open on anything): the new rule supersedes it on thresholds, adds
+        # the hand floor whose absence was half of #255, and asks whether the
+        # opponent ahead of us has actually passed rather than assuming it.
+        if endgame_protection_applies(my_score, opp_score):
+            return endgame_protection_bid(
+                context, opp_team.players, partner_is_dealer, ceiling,
+            )
 
+        if not context["ever_bid"]:
             # 3rd bidder (2 passes already, no one's bid) - always open
             # to deny the last player a cheap contract, unless our score
             # is high enough (>800) that we'd rather play it safe.
@@ -2384,6 +2454,27 @@ class GeneralStrategy(Player):
         opp_team = next((t for t in context["teams"] if t is not self.team), None)
         opp_score = opp_team.score if opp_team is not None else 0
         trump, base_bid, _ = best_base_bid(self.hand, my_score, opp_score)
+
+        # Endgame protection (#256) is a hard rule in front of the simulation,
+        # not an input to it. `Player.choose_bid` applies it for the skill
+        # levels that route through the static path, but this one does not
+        # take its answer from `static_bid` above - it only consults it for
+        # the positional back-off - so the check is repeated here rather than
+        # left to leak through. A rollout that says "taking this contract has
+        # the higher EV" is answering a different question from the one the
+        # rule asks, which is whether to put a nearly-won game at risk at all.
+        if endgame_protection_applies(my_score, opp_score):
+            partner = None if self.team is None else next(
+                (p for p in self.team.players if p is not self), None
+            )
+            cap = max_bid(self.hand, trump)
+            ceiling = base_bid if cap is None else min(base_bid, cap)
+            return endgame_protection_bid(
+                context,
+                opp_team.players if opp_team is not None else [],
+                partner is not None and partner is context.get("dealer"),
+                ceiling,
+            )
 
         # Cheap hard floor, same "prune before the expensive simulation"
         # spirit as the Auto-SET guard elsewhere in this epic: a hand

--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -248,9 +248,8 @@ Proficient tier landed. What they actually do:
 
 - `choose_bid` — Proficient bidding on the layered Base Bid valuation
   (`best_base_bid` → `compute_competitive_adjustment` → `max_bid`'s
-  cap), plus positional and score-context rules: the opener threshold,
-  a forced open as third bidder, dealer protection when a partner
-  dealing near 1000 is a target for a pass-out, the
+  cap), plus positional and score-context rules: endgame protection
+  (below), the opener threshold, a forced open as third bidder, the
   `DEFENSIVE_PUSH_FLOOR` response to a minimum opener, and backing off
   once a partner is carrying the auction.
 - `choose_trump` — the same per-suit Base Bid comparison, so trump
@@ -271,6 +270,66 @@ explicit fallbacks for when a method is called with no context
 (`context is None`, no `trump_suit`/`is_bid_winner`, no `trick`). They
 keep the methods usable in isolation and keep older tests working; a
 real `Round` never reaches them.
+
+### Endgame protection: when the AI stops bidding
+
+A strategy rule, not a rule of the game — nothing in Phase 1 forbids the
+bid it declines to make, and a human player is free to bid anyway. It
+lives in `Player.choose_bid` (`pinochle_engine.py`) and `chooseBid`
+(`web/src/engine/bidding.ts`), in front of every other bidding rule and
+in front of both bid policies: while it holds, the fitted evaluator is
+not consulted at all.
+
+**Trigger**, evaluated for the team it applies to:
+
+- `my_score >= ENDGAME_SCORE_FLOOR` — within 250 of going out, and
+- `opp_score < ENDGAME_OPP_SCORE_CAP` — more than 550 away from it.
+
+Both are derived from `GAME_WIN_SCORE`, so they follow the target rather
+than restating it: 750 and 450 at today's 1000.
+
+**Default: pass the whole auction.** Not merely decline to open — a seat
+under the trigger does not bid at all, on any hand, whether opening, over
+an opponent, or over its own partner. Both seats on the team do it. If
+the dealer is an opponent the auction passes out and they take the
+contract at the forced bid of 250.
+
+The reasoning is about how the game ends rather than about the hand. Meld
+alone routinely clears 250, and the defending team scores its own meld
+(see Contract Check), so at this score the contract is worth little and
+being set is worth the whole bid — a 390 that goes down drops the team
+from 910 to 520 and hands back a game that was one hand from over. The
+opponents at under 450 cannot make up the difference in one hand either
+way, so there is a next hand to fight it out in.
+
+**One exception — saving a partner who is dealing.** Passing out sticks
+*us* with a contract nobody chose, so a seat opens at `OPENING_BID` when
+all of:
+
+1. its partner is the dealer,
+2. the opponent who spoke immediately before it has passed, and
+3. its Max Bid ceiling is over `ENDGAME_RESCUE_CEILING` (200) — the
+   ceiling after the competitive adjustment, not the Base Bid.
+
+If any opponent has bid, the exception is off and the seat passes like
+the other: an opponent who has bid has already taken the contract off
+our hands.
+
+The exception reads only one opponent because only one has spoken. The
+auction opens left of the dealer and rotates clockwise, so a
+partner-of-the-dealer seat is `dealer + 2` and speaks second — after
+exactly one opponent, and before both the other opponent and the dealer.
+There is no later turn at which that seat knows more, because to still be
+in the auction it would have had to bid.
+
+This replaces an older dealer-protection rule (partner dealing,
+`my_score >= 850`, `opp_score < 500`, open at `OPENING_BID` on any hand
+whatsoever), which it supersedes on thresholds, on the hand floor it did
+not have, and on asking whether the opponent ahead actually passed.
+
+`EasyPlayer` and skill 1 have no endgame protection, the same way they
+have no other score awareness: their bidding is meld value plus noise by
+design.
 
 ### Tiers and the skill dial
 

--- a/test_endgame_bidding.py
+++ b/test_endgame_bidding.py
@@ -1,0 +1,265 @@
+"""
+Tests for issue #256 - endgame protection in the auction. Plain assert-based,
+pytest-discoverable.
+
+The rule under test: a team within 250 of going out, against opponents more
+than 550 away, passes the entire auction and banks its meld. The one exception
+opens at OPENING_BID to keep a partner who is dealing off the forced bid, and
+only on a hand whose Max Bid ceiling clears ENDGAME_RESCUE_CEILING.
+
+What is covered here:
+
+  1. The trigger boundaries, one point either side on both axes - 749/750 and
+     449/450 - because the rule is a threshold effect and a threshold is
+     exactly the kind of thing an off-by-one hides in.
+  2. The default really is "pass everything", not "decline to open": the same
+     seat with a hand worth a contract still passes when opening, over an
+     opponent's bid, and over its partner's.
+  3. Each of the exception's conditions failing on its own, so a test that
+     goes green cannot be leaning on a second condition to do the work.
+  4. The retired dealer-protection rule is actually gone - its own scores and
+     a hand with nothing in it used to produce an opening bid.
+"""
+
+from pinochle_engine import (
+    Card,
+    ENDGAME_OPP_SCORE_CAP,
+    ENDGAME_RESCUE_CEILING,
+    ENDGAME_SCORE_FLOOR,
+    GAME_WIN_SCORE,
+    OPENING_BID,
+    Player,
+    Suit,
+    Team,
+    best_base_bid,
+    max_bid,
+)
+
+
+# A trump Run plus a second Royal Marriage and an off-suit Ace. Comfortably
+# over ENDGAME_RESCUE_CEILING at any score, and over OPENER_THRESHOLD too, so
+# "this seat passed" is never confusable with "this hand was not worth a bid".
+STRONG_HAND = [
+    Card(Suit.HEARTS, "A", 1),
+    Card(Suit.HEARTS, "10", 1),
+    Card(Suit.HEARTS, "K", 1),
+    Card(Suit.HEARTS, "Q", 1),
+    Card(Suit.HEARTS, "J", 1),
+    Card(Suit.HEARTS, "K", 2),
+    Card(Suit.HEARTS, "Q", 2),
+    Card(Suit.SPADES, "A", 1),
+]
+
+# No meld, no Aces, nothing near a Run. Its ceiling is the competitive
+# adjustment and nothing else, which is what puts it under the rescue floor.
+JUNK_HAND = [
+    Card(Suit.SPADES, "9", 1),
+    Card(Suit.SPADES, "J", 1),
+    Card(Suit.DIAMONDS, "9", 1),
+    Card(Suit.DIAMONDS, "J", 2),
+    Card(Suit.CLUBS, "9", 2),
+    Card(Suit.HEARTS, "9", 1),
+]
+
+
+def _ceiling(hand, my_score, opp_score):
+    """The same Max Bid ceiling `Player.choose_bid` computes, so the fixtures
+    above can be asserted against the floor rather than assumed to sit where
+    the comment says."""
+    trump, base, _ = best_base_bid(hand, my_score, opp_score)
+    cap = max_bid(hand, trump)
+    return base if cap is None else min(base, cap)
+
+
+def _table(hand, my_score, opp_score):
+    """Four seats, two teams, scores set. Returns (me, partner, opp_before,
+    opp_after) where `opp_before` is the seat that speaks immediately before
+    me when my partner is the dealer."""
+    me = Player("Me", None)
+    partner = Player("Partner", None)
+    opp_before = Player("OppBefore", None)
+    opp_after = Player("OppAfter", None)
+    me.hand = list(hand)
+    us = Team("Us", [me, partner])
+    them = Team("Them", [opp_before, opp_after])
+    me.team = partner.team = us
+    opp_before.team = opp_after.team = them
+    us.score = my_score
+    them.score = opp_score
+    return me, partner, opp_before, opp_after
+
+
+def _context(dealer, teams, *, ever_bid=False, passes_so_far=0,
+             bid_history=(), passed_players=()):
+    return {
+        "ever_bid": ever_bid,
+        "passes_so_far": passes_so_far,
+        "bid_history": list(bid_history),
+        "pass_history": [(p, OPENING_BID) for p in passed_players],
+        "passed_players": list(passed_players),
+        "dealer": dealer,
+        "teams": teams,
+    }
+
+
+def _opening_call(hand, my_score, opp_score, *, dealer_is_partner=True,
+                  opponent_passed=True):
+    """The partner-of-the-dealer seat's one turn: second to speak, after
+    exactly one opponent."""
+    me, partner, opp_before, opp_after = _table(hand, my_score, opp_score)
+    dealer = partner if dealer_is_partner else opp_after
+    context = _context(
+        dealer,
+        [me.team, opp_before.team],
+        passes_so_far=1 if opponent_passed else 0,
+        passed_players=[opp_before] if opponent_passed else [],
+    )
+    return me.choose_bid(OPENING_BID - 10, 10, context)
+
+
+# ---------------------------------------------------------------------------
+# 0. The fixtures are what the rest of the file assumes they are.
+# ---------------------------------------------------------------------------
+
+def test_fixture_hands_sit_either_side_of_the_rescue_floor():
+    my_score, opp_score = ENDGAME_SCORE_FLOOR, 100
+    assert _ceiling(STRONG_HAND, my_score, opp_score) > ENDGAME_RESCUE_CEILING
+    assert _ceiling(JUNK_HAND, my_score, opp_score) <= ENDGAME_RESCUE_CEILING
+
+
+def test_thresholds_are_derived_from_the_game_target():
+    assert ENDGAME_SCORE_FLOOR == GAME_WIN_SCORE - 250
+    assert ENDGAME_OPP_SCORE_CAP == GAME_WIN_SCORE - 550
+
+
+# ---------------------------------------------------------------------------
+# 1. Trigger boundaries.
+# ---------------------------------------------------------------------------
+
+def test_trigger_fires_at_the_score_floor_and_not_one_point_below():
+    # Dealer is an opponent, so the exception cannot apply and the only thing
+    # separating the two calls is the trigger itself.
+    at_floor = _opening_call(STRONG_HAND, ENDGAME_SCORE_FLOOR, 100,
+                             dealer_is_partner=False)
+    below = _opening_call(STRONG_HAND, ENDGAME_SCORE_FLOOR - 1, 100,
+                          dealer_is_partner=False)
+    assert at_floor is None
+    assert below == OPENING_BID
+
+
+def test_trigger_fires_under_the_opponent_cap_and_not_at_it():
+    under_cap = _opening_call(STRONG_HAND, ENDGAME_SCORE_FLOOR,
+                              ENDGAME_OPP_SCORE_CAP - 1, dealer_is_partner=False)
+    at_cap = _opening_call(STRONG_HAND, ENDGAME_SCORE_FLOOR,
+                           ENDGAME_OPP_SCORE_CAP, dealer_is_partner=False)
+    assert under_cap is None
+    assert at_cap == OPENING_BID
+
+
+# ---------------------------------------------------------------------------
+# 2. The default is to pass the whole auction, not merely to decline to open.
+# ---------------------------------------------------------------------------
+
+def test_passes_when_opening_however_good_the_hand():
+    assert _opening_call(STRONG_HAND, 910, 110, dealer_is_partner=False) is None
+
+
+def test_passes_over_an_opponents_bid():
+    me, _partner, opp_before, opp_after = _table(STRONG_HAND, 910, 110)
+    context = _context(
+        opp_after, [me.team, opp_before.team],
+        ever_bid=True, bid_history=[(opp_before, 310)],
+    )
+    assert me.choose_bid(310, 10, context) is None
+
+
+def test_passes_over_its_own_partners_bid():
+    me, partner, opp_before, opp_after = _table(STRONG_HAND, 910, 110)
+    context = _context(
+        opp_after, [me.team, opp_before.team],
+        ever_bid=True, bid_history=[(opp_before, 310), (partner, 320)],
+    )
+    assert me.choose_bid(320, 10, context) is None
+
+
+def test_both_seats_of_the_team_pass_the_same_auction():
+    # The rule is a property of the team, so the partner seat gets the strong
+    # hand here and must pass on it too.
+    me, partner, opp_before, opp_after = _table(JUNK_HAND, 910, 110)
+    partner.hand = list(STRONG_HAND)
+    context = _context(opp_after, [me.team, opp_before.team], passes_so_far=1,
+                       passed_players=[opp_before])
+    assert me.choose_bid(OPENING_BID - 10, 10, context) is None
+    assert partner.choose_bid(OPENING_BID - 10, 10, context) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. The exception, and each of its conditions failing on its own.
+# ---------------------------------------------------------------------------
+
+def test_opens_to_save_a_dealing_partner_when_all_three_conditions_hold():
+    assert _opening_call(STRONG_HAND, 910, 110) == OPENING_BID
+
+
+def test_no_rescue_when_the_dealer_is_an_opponent():
+    assert _opening_call(STRONG_HAND, 910, 110, dealer_is_partner=False) is None
+
+
+def test_no_rescue_when_no_opponent_has_passed_yet():
+    assert _opening_call(STRONG_HAND, 910, 110, opponent_passed=False) is None
+
+
+def test_no_rescue_on_a_hand_under_the_ceiling_floor():
+    assert _opening_call(JUNK_HAND, 910, 110) is None
+
+
+def test_no_rescue_once_an_opponent_has_bid():
+    # "If the opponent bids 310, pass for both teammates with the high score."
+    me, partner, opp_before, opp_after = _table(STRONG_HAND, 910, 110)
+    context = _context(
+        partner, [me.team, opp_before.team],
+        ever_bid=True, bid_history=[(opp_before, 310)],
+    )
+    assert me.choose_bid(310, 10, context) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. The retired dealer-protection rule.
+# ---------------------------------------------------------------------------
+
+def test_the_old_dealer_protection_scores_no_longer_open_on_nothing():
+    # 850/400 with a partner dealing was an unconditional OPENING_BID before
+    # #256, on any hand at all. It is inside the new trigger, so the hand floor
+    # now applies and this one does not clear it.
+    assert _opening_call(JUNK_HAND, 850, 400) is None
+
+
+def test_outside_the_trigger_the_ordinary_rules_decide():
+    # 850/500: the old rule fired here too. The opponent is not far enough
+    # back for the new trigger, so a hopeless hand simply fails the opener
+    # threshold instead of being talked into a bid.
+    assert _opening_call(JUNK_HAND, 850, 500) is None
+    assert _opening_call(STRONG_HAND, 850, 500) == OPENING_BID
+
+
+if __name__ == "__main__":
+    for fn in [
+        test_fixture_hands_sit_either_side_of_the_rescue_floor,
+        test_thresholds_are_derived_from_the_game_target,
+        test_trigger_fires_at_the_score_floor_and_not_one_point_below,
+        test_trigger_fires_under_the_opponent_cap_and_not_at_it,
+        test_passes_when_opening_however_good_the_hand,
+        test_passes_over_an_opponents_bid,
+        test_passes_over_its_own_partners_bid,
+        test_both_seats_of_the_team_pass_the_same_auction,
+        test_opens_to_save_a_dealing_partner_when_all_three_conditions_hold,
+        test_no_rescue_when_the_dealer_is_an_opponent,
+        test_no_rescue_when_no_opponent_has_passed_yet,
+        test_no_rescue_on_a_hand_under_the_ceiling_floor,
+        test_no_rescue_once_an_opponent_has_bid,
+        test_the_old_dealer_protection_scores_no_longer_open_on_nothing,
+        test_outside_the_trigger_the_ordinary_rules_decide,
+    ]:
+        fn()
+        print(f"  ok  {fn.__name__}")
+    print("all endgame bidding tests passed")

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { SkillLevel } from '../persistence/options'
-import { Card, Deck, OPENING_BID, Suit } from './card'
+import { Card, Deck, GAME_WIN_SCORE, OPENING_BID, Suit } from './card'
 import {
   ACE_VALUE,
   type AuctionContext,
@@ -11,6 +11,9 @@ import {
   computeBaseBid,
   computeCompetitiveAdjustment,
   computeMaxBid,
+  ENDGAME_OPP_SCORE_CAP,
+  ENDGAME_RESCUE_CEILING,
+  ENDGAME_SCORE_FLOOR,
   maxBid,
   MAX_BID_DEFAULT,
   NEAR_DOUBLE_PINOCHLE_VALUE,
@@ -269,32 +272,18 @@ describe('chooseBid', () => {
       expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
     })
 
-    it('always opens (dealer-protection) when partner is dealer and my score is >= 850 with opponent under 500', () => {
-      // Player 0's partner is player 2 (0<->2 seating).
-      const context = baseContext({ dealer: 2, scores: { 0: 850, 1: 400 } })
-      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBe(OPENING_BID)
-    })
-
-    it('does not open a hopeless first-bidder hand outside dealer-protection (#126)', () => {
+    it('does not open a hopeless first-bidder hand (#126)', () => {
       // The first seat to speak (passesSoFar 0) used to open at OPENING_BID
       // unconditionally, which made this the first thing that happened on every
       // deal and left OPENER_THRESHOLD unreachable. `Player.choose_bid` has no
-      // such tier: with dealer-protection not applicable, the hand decides.
-      // Pinned to a 'static' level so the assertion is about the threshold rule
-      // rather than about the evaluator (#114/#115).
-      // Dealer-protection scores, but the dealer is an opponent, so the tier
-      // does not apply and a hopeless hand stays out of the auction.
-      const context = baseContext({ dealer: 1, scores: { 0: 850, 1: 400 } })
+      // such tier: the hand decides. Pinned to a 'static' level so the
+      // assertion is about the threshold rule rather than about the evaluator
+      // (#114/#115), and to level scores so #256's endgame rule is not what is
+      // answering.
+      const context = baseContext({ dealer: 1 })
       expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
       // Same seat, a hand whose ceiling clears the threshold: it opens.
-      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, baseContext({ dealer: 1 }), 'medium')).toBe(OPENING_BID)
-    })
-
-    it('dealer-protection does not fire when my score is too low or the opponent too close', () => {
-      const scoreTooLow = baseContext({ dealer: 2, scores: { 0: 840, 1: 400 } })
-      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, scoreTooLow, 'medium')).toBeNull()
-      const oppTooClose = baseContext({ dealer: 2, scores: { 0: 850, 1: 500 } })
-      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, oppTooClose, 'medium')).toBeNull()
+      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'medium')).toBe(OPENING_BID)
     })
 
     it('passes for a weak-handed 4th bidder when partner has already had a turn', () => {
@@ -426,6 +415,163 @@ describe('chooseBid', () => {
 // disagree with the reference engine about what a hand even is - and silently
 // invalidates the distilled evaluator (#104), whose labels are computed under
 // Python's valuation.
+// Endgame protection (#256). Reported from live play at 910-110: a seat held a
+// good hand, bid 390, and needed 90 points it was already holding. The rule is
+// a hard one in front of both bid policies, so every assertion here is pinned
+// to a skill level only where the *contrast* case needs it — what the rule
+// itself does is policy-independent by construction.
+describe('endgame protection (#256)', () => {
+  // Seats 0 and 2 are partners; the auction opens left of the dealer and
+  // rotates clockwise, so with dealer 2 the order is 3, 0, 1, 2 — seat 0 is
+  // the partner-of-the-dealer seat, speaking second, after exactly one
+  // opponent (seat 3) and before both seat 1 and the dealer. That seat order
+  // is the whole reason the exception below reads one opponent and not two.
+  const OPP_BEFORE_ME: PlayerIndex = 3
+  const OTHER_OPP: PlayerIndex = 1
+
+  // Trump Run + a second Royal Marriage + the other three Aces. Base Bid 270,
+  // so its ceiling clears ENDGAME_RESCUE_CEILING, OPENER_THRESHOLD and
+  // PARTNER_RAISE_FLOOR alike at the +100 adjustment this score band carries.
+  // Nothing here should ever be mistaken for "the hand was not worth a bid".
+  const richHand = [
+    ...RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1)),
+    new Card(Suit.Hearts, 'K', 2),
+    new Card(Suit.Hearts, 'Q', 2),
+    new Card(Suit.Spades, 'A', 1),
+    new Card(Suit.Diamonds, 'A', 1),
+    new Card(Suit.Clubs, 'A', 1),
+  ]
+  // One off-trump 9: no meld, no Aces, nothing near a Run. Its ceiling is the
+  // competitive adjustment and nothing else.
+  const poorHand = [new Card(Suit.Hearts, '9', 1)]
+
+  const ceilingOf = (hand: readonly Card[], ourScore: number, theirScore: number): number => {
+    const { trump: t, total } = bestBaseBid(hand, ourScore, theirScore)
+    const cap = maxBid(hand, t)
+    return cap === null ? total : Math.min(total, cap)
+  }
+
+  const ctx = (overrides: Partial<AuctionContext> = {}): AuctionContext => ({
+    everBid: false,
+    passesSoFar: 1,
+    bidHistory: [],
+    dealer: 2,
+    scores: { 0: 910, 1: 110 },
+    passedPlayers: [OPP_BEFORE_ME],
+    ...overrides,
+  })
+
+  it('derives both thresholds from the game target rather than restating them', () => {
+    expect(ENDGAME_SCORE_FLOOR).toBe(GAME_WIN_SCORE - 250)
+    expect(ENDGAME_OPP_SCORE_CAP).toBe(GAME_WIN_SCORE - 550)
+  })
+
+  it('has fixture hands either side of the rescue ceiling', () => {
+    expect(ceilingOf(richHand, 910, 110)).toBeGreaterThan(ENDGAME_RESCUE_CEILING)
+    expect(ceilingOf(poorHand, 910, 110)).toBeLessThanOrEqual(ENDGAME_RESCUE_CEILING)
+  })
+
+  describe('the trigger', () => {
+    // Dealer 3 puts an opponent in the chair and seat 0 first to speak, so the
+    // exception cannot apply and the only thing separating these calls is the
+    // trigger. 'medium' pins the contrast case to OPENER_THRESHOLD rather than
+    // to the evaluator.
+    const opening = (ours: number, theirs: number) =>
+      chooseBid(0, richHand, OPENING_BID - 10, 10,
+        ctx({ dealer: 3, passesSoFar: 0, passedPlayers: [], scores: { 0: ours, 1: theirs } }), 'medium')
+
+    it('fires at the score floor and not one point below', () => {
+      expect(opening(ENDGAME_SCORE_FLOOR, 100)).toBeNull()
+      expect(opening(ENDGAME_SCORE_FLOOR - 1, 100)).toBe(OPENING_BID)
+    })
+
+    it('fires under the opponent cap and not at it', () => {
+      expect(opening(ENDGAME_SCORE_FLOOR, ENDGAME_OPP_SCORE_CAP - 1)).toBeNull()
+      expect(opening(ENDGAME_SCORE_FLOOR, ENDGAME_OPP_SCORE_CAP)).toBe(OPENING_BID)
+    })
+  })
+
+  describe('the default is to pass the whole auction', () => {
+    it('declines to open however good the hand', () => {
+      const context = ctx({ dealer: 3, passesSoFar: 0, passedPlayers: [] })
+      expect(chooseBid(0, richHand, OPENING_BID - 10, 10, context)).toBeNull()
+    })
+
+    it('declines the defensive push against an opponent sitting on the opening rung', () => {
+      // The push is what makes this assertion worth making: at OPENING_BID with
+      // a ceiling over DEFENSIVE_PUSH_FLOOR, every other path in chooseBid
+      // answers 310. The contrast call, at level scores, is that answer.
+      const bid = { player: OTHER_OPP, amount: OPENING_BID }
+      const endgame = ctx({ dealer: 3, everBid: true, passesSoFar: 0, passedPlayers: [], bidHistory: [bid] })
+      expect(chooseBid(0, richHand, OPENING_BID, 10, endgame)).toBeNull()
+      expect(chooseBid(0, richHand, OPENING_BID, 10, { ...endgame, scores: { 0: 0, 1: 0 } })).toBe(OPENING_BID + 10)
+    })
+
+    it('declines to raise over its own partner', () => {
+      // A constructed state — this seat would not have bid 300 under the rule
+      // in the first place — but it is the one remaining branch that returns a
+      // bid rather than null, so it is the one worth pinning. Without the rule
+      // a partner raise over our own bid answers PARTNER_RAISE_FLOOR.
+      const history = [{ player: 0 as PlayerIndex, amount: OPENING_BID }, { player: 2 as PlayerIndex, amount: 320 }]
+      const endgame = ctx({ dealer: 3, everBid: true, passesSoFar: 0, passedPlayers: [], bidHistory: history })
+      expect(chooseBid(0, richHand, 320, 10, endgame)).toBeNull()
+      expect(chooseBid(0, richHand, 320, 10, { ...endgame, scores: { 0: 0, 1: 0 } })).toBe(PARTNER_RAISE_FLOOR)
+    })
+
+    it('applies to both seats of the team, not only the one holding the good hand', () => {
+      const context = ctx({ dealer: 3, passesSoFar: 0, passedPlayers: [] })
+      expect(chooseBid(0, richHand, OPENING_BID - 10, 10, context)).toBeNull()
+      expect(chooseBid(2, richHand, OPENING_BID - 10, 10, context)).toBeNull()
+    })
+  })
+
+  describe('the one exception: saving a partner who is dealing', () => {
+    it('opens at OPENING_BID when all three conditions hold', () => {
+      expect(chooseBid(0, richHand, OPENING_BID - 10, 10, ctx())).toBe(OPENING_BID)
+    })
+
+    it('is off when the dealer is an opponent', () => {
+      expect(chooseBid(0, richHand, OPENING_BID - 10, 10, ctx({ dealer: 3 }))).toBeNull()
+    })
+
+    it('is off when the opponent ahead of us has not passed', () => {
+      expect(chooseBid(0, richHand, OPENING_BID - 10, 10, ctx({ passesSoFar: 0, passedPlayers: [] }))).toBeNull()
+      // The *other* opponent passing is not the same fact and does not count:
+      // seat 1 speaks after this seat, so it cannot have passed yet anyway.
+      expect(chooseBid(0, richHand, OPENING_BID - 10, 10, ctx({ passedPlayers: [OTHER_OPP] }))).toBeNull()
+    })
+
+    it('is off on a hand under the rescue ceiling', () => {
+      expect(chooseBid(0, poorHand, OPENING_BID - 10, 10, ctx())).toBeNull()
+    })
+
+    it('is off once an opponent has bid', () => {
+      // "If the opponent bids 310, pass for both teammates with the high score."
+      const context = ctx({
+        everBid: true,
+        passesSoFar: 0,
+        passedPlayers: [],
+        bidHistory: [{ player: OPP_BEFORE_ME, amount: OPENING_BID + 10 }],
+      })
+      expect(chooseBid(0, richHand, OPENING_BID + 10, 10, context)).toBeNull()
+    })
+  })
+
+  it('retires the old dealer-protection rule rather than keeping both', () => {
+    // 850/400 with a partner dealing was an unconditional OPENING_BID before
+    // #256, on any hand at all — the missing hand check that is half of #255.
+    // Those scores are inside the new trigger, so the rescue's own floor now
+    // applies and this hand does not clear it.
+    const context = ctx({ scores: { 0: 850, 1: 400 } })
+    expect(chooseBid(0, poorHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
+    // And outside the trigger the ordinary rules decide, where the old tier
+    // would have opened on this hand too.
+    const outside = ctx({ scores: { 0: 850, 1: 500 } })
+    expect(chooseBid(0, poorHand, OPENING_BID - 10, 10, outside, 'medium')).toBeNull()
+    expect(chooseBid(0, richHand, OPENING_BID - 10, 10, outside, 'medium')).toBe(OPENING_BID)
+  })
+})
+
 describe('parity with the Python reference engine (#118)', () => {
   it('matches pinochle_engine.py Base Bid constants exactly', () => {
     expect(NEAR_RUN_VALUE).toBe(120)

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -23,7 +23,7 @@
 // >300-meld-uncap rule (maxBid / cappedBid). bestBaseBid searches all 4
 // trump candidates and applies the cap to find the winning trump + ceiling.
 // Decision: chooseBid/chooseTrump wrap that valuation with the stateful
-// auction rules (dealer protection, 3rd-bidder-opens-cheap, when to raise
+// auction rules (endgame protection, 3rd-bidder-opens-cheap, when to raise
 // vs. pass) - ported from Player.choose_bid / Player.choose_trump. This
 // module only decides; it does not run an auction loop — that lives in
 // components/auctionReducer.ts (#34), under gameFlowReducer.ts (#47).
@@ -93,6 +93,35 @@ export const OPENER_THRESHOLD = 320
 // floor. It is a hand-strength threshold, not a bid level, so it did not move
 // with the opener.
 export const DEFENSIVE_PUSH_FLOOR = 200
+
+// -- Endgame protection (#256). The one bidding rule that is about the *game*
+// rather than about the hand: a team this close to 1000 banks its meld and
+// lets the contract go, because the contract is worth little to it - the
+// defending team scores its own meld either way (`pinochle_rules.md`, Contract
+// Check) - while being set costs the whole bid and hands back a game that was
+// one hand from over. Paul reported it from live play at 910-110, where a seat
+// bid 390 on a good hand and needed 90 points it already held.
+//
+// Both thresholds are derived from `GAME_WIN_SCORE` so they follow the target
+// if it ever moves; #243 records why moving it is expensive. 750 is "within
+// 250 of going out", which one ordinary meld plus a share of the tricks
+// reaches. 450 is "more than 550 away", more than the opponents can plausibly
+// take off a single hand, so there is a next hand to fight it out in.
+export const ENDGAME_SCORE_FLOOR = GAME_WIN_SCORE - 250
+export const ENDGAME_OPP_SCORE_CAP = GAME_WIN_SCORE - 550
+/**
+ * The one hand check in the rule, and the only thing that puts a bid back on
+ * the table while the trigger holds.
+ *
+ * This is the Max Bid **ceiling** — Base Bid plus the competitive adjustment,
+ * capped — and not the Base Bid. In the score band this rule fires in,
+ * `computeCompetitiveAdjustment` returns +100, so the effective bar is a Base
+ * Bid a little over 100 and few hands fail it. That is a deliberate choice
+ * rather than an oversight: Paul was shown the comparison and picked the
+ * ceiling. If the rescue turns out to fire on hands that cannot carry
+ * `OPENING_BID`, this number is what to revisit, not the choice of measure.
+ */
+export const ENDGAME_RESCUE_CEILING = 200
 
 /**
  * The bid a seat must commit to once its partner has passed (#93/#95).
@@ -491,7 +520,7 @@ export interface AuctionContext {
  * Meld-only bid valuation for skill 1 (easy). Mirrors EasyPlayer's
  * approach from Python: uses actual `scoreMelds` (not speculative Base
  * Bid), adds a flat trick-point constant plus uniform noise, then applies
- * the minimal positional filter. No dealer-protection, no partner-bid-count
+ * the minimal positional filter. No endgame protection, no partner-bid-count
  * tracking, no score-differential awareness — pure "meld value + guess".
  */
 function meldOnlyBid(
@@ -519,15 +548,16 @@ function meldOnlyBid(
  *   Defaults to 'hard' (base_bid, the current Proficient behavior).
  *
  * Decision tiers:
+ *   - Endgame protection (#256), ahead of everything else and of both bid
+ *     policies: my team is within 250 of going out and the opponents are
+ *     more than 550 away, so pass the whole auction and bank the meld. The
+ *     one exception opens at OPENING_BID to save a partner who is dealing.
  *   - No one has bid yet this auction:
- *     1. Dealer-protection: my partner is dealer and my score makes them
- *        a target for a "pass out and stick them with FORCED_BID" play -
- *        always open regardless of hand.
- *     2. 3rd bidder (2 passes already, no one's bid) - always open to
+ *     1. 3rd bidder (2 passes already, no one's bid) - always open to
  *        deny the last player a cheap contract, unless my score is high
  *        enough (>800) that I'd rather play it safe and only open if the
  *        hand is worth the contract.
- *     3. Otherwise, open only if the hand is worth the contract.
+ *     2. Otherwise, open only if the hand is worth the contract.
  *   - My team currently holds the bid:
  *     - Partner has already bid twice this auction - back off, they're
  *       carrying it.
@@ -566,8 +596,43 @@ export function chooseBid(
   const ceiling = cap === null ? baseBid : Math.min(baseBid, cap)
 
   const partner = partnerOf(player)
+  const partnerIsDealer = partner === context.dealer
   const partnerPassed = context.passedPlayers.includes(partner)
   const partnerHasBid = context.bidHistory.some((b) => b.player === partner)
+
+  // Endgame protection (#256) sits in front of every other bidding rule and in
+  // front of both bid policies: when the trigger holds, `shouldBid` is never
+  // consulted, because what the cards are worth has stopped being the
+  // question. The default is to pass the *entire* auction — not merely decline
+  // to open — on any hand, opening or over an opponent or over a partner, and
+  // both seats on the team do it. If the dealer is an opponent the auction
+  // passes out and they are stuck at `FORCED_BID`, which is the outcome this
+  // rule is happy to buy.
+  //
+  // The single exception is a partner who is dealing, because then passing out
+  // sticks *us* with a contract nobody chose. Reading only the one opponent is
+  // a seat-order fact and not a simplification: the auction opens left of the
+  // dealer and rotates clockwise (`initAuctionState`), so a partner-of-the-
+  // dealer seat is `dealer + 2` and speaks second — after exactly one opponent
+  // and before both the other opponent and the dealer. There is no later turn
+  // at which this seat knows more, because to still be in the auction it would
+  // have had to bid.
+  //
+  // This replaces the old dealer-protection tier outright — `partnerIsDealer
+  // && myScore >= 850 && oppScore < 500`, open on anything — which it
+  // supersedes on thresholds, adds the hand floor whose absence was half of
+  // #255, and asks whether the opponent ahead of us actually passed rather
+  // than assuming it.
+  if (myScore >= ENDGAME_SCORE_FLOOR && oppScore < ENDGAME_OPP_SCORE_CAP) {
+    const opponentHasBid = context.bidHistory.some((b) => teamOf(b.player) !== myTeam)
+    const seatBeforeMe = ((player + 3) % 4) as PlayerIndex
+    const rescueDealingPartner =
+      partnerIsDealer &&
+      !opponentHasBid &&
+      context.passedPlayers.includes(seatBeforeMe) &&
+      ceiling > ENDGAME_RESCUE_CEILING
+    return rescueDealingPartner ? OPENING_BID : null
+  }
 
   // When partner has already passed they cannot come back in (#93), so a bid
   // here is one this hand must carry alone — which means committing to
@@ -647,18 +712,6 @@ export function chooseBid(
   }
 
   if (!context.everBid) {
-    // Dealer-protection, restored from `Player.choose_bid` by the #126 audit.
-    // This tier was dropped in aeb97b3 — the same hand-port slip that took
-    // NEAR_RUN_VALUE/NEAR_DOUBLE_PINOCHLE_VALUE to 60/60 (#118) — and replaced
-    // with "the first two seats always open at 300 regardless of hand". Since
-    // the auction starts with nobody having passed, that rule fired on the very
-    // first seat of every deal, so the opener threshold below was effectively
-    // unreachable and no opening decision was ever a hand judgement.
-    const partnerIsDealer = partner === context.dealer
-    if (partnerIsDealer && myScore >= 850 && oppScore < 500) {
-      return OPENING_BID
-    }
-
     // One comparison, whether or not the partner has passed (#180). This read
     // `partnerPassed ? ceiling > OPENER_THRESHOLD : ceiling >= OPENER_THRESHOLD`
     // — the second place "a lone bidder must *clear* the threshold" was written


### PR DESCRIPTION
Closes #256

Implements the endgame bidding rule Paul specified on 2026-08-30, in both
engines and in the same commit.

## The rule

**Trigger**, for the team it applies to: `myScore >= GAME_WIN_SCORE - 250`
(750) **and** `oppScore < GAME_WIN_SCORE - 550` (450). Written as offsets from
`GAME_WIN_SCORE` so they follow the target rather than restating it (#243).

**Default: pass the entire auction.** Not merely decline to open — the seat
does not bid at all: not opening, not over an opponent, not over a partner,
regardless of hand. Both seats on the team do it. If the dealer is an opponent
the auction passes out and they take it at `FORCED_BID`, which is the outcome
the rule is buying.

**One exception — saving a partner who is dealing.** Opens at `OPENING_BID`
(300 since #257) when all of: partner is the dealer, the opponent who spoke
immediately before this seat has passed, and the hand's Max Bid ceiling is over
200. If any opponent has bid the exception is off and the seat passes like the
other.

It sits in front of the evaluator: when the trigger holds, `shouldBid` is never
consulted.

## Seat order — the claim held up

Verified against the code rather than assumed, in both engines:

- Python `Round._bidding_loop` starts at `_left_of_dealer()` (`dealer + 1`) and
  advances `idx = (idx + 1) % 4`.
- TS `initAuctionState` sets `turn: (dealer + 1) % 4` and `auctionReducer`
  advances `(player + 1) % 4`.

So the order is `dealer+1`, `dealer+2`, `dealer+3`, `dealer`, and a
partner-of-the-dealer seat (`dealer + 2`) speaks **second** — after exactly one
opponent, before both the other opponent and the dealer. There is no later turn
at which that seat knows more, because to still be in the auction it would have
had to bid. The exception is written against exactly the information available
there.

Python's `context` carries the auction record but no seat indices (as
`GeneralStrategy._auction_evidence` already notes), so "the opponent who spoke
immediately before me has passed" is read there as "an opponent has passed and
none has bid" — at this seat, and only at this seat, those are the same
statement. TS has the index and reads `(player + 3) % 4` literally.

## The ceiling-vs-Base-Bid observation, recorded

"Max Bid ceiling over 200" is implemented as specified: the ceiling **after**
the competitive adjustment, not the Base Bid. Restating the consequence Paul
was shown and decided on anyway, since it now lives in the code and should not
later read as an oversight: in this score band `computeCompetitiveAdjustment` /
`compute_competitive_adjustment` returns +100 (`my_score >= 700 and opp_score
<= 500`), so a ceiling over 200 means a **Base Bid over roughly 100** — a low
bar that few hands fail. The comment beside both constants says so, and says
that if the rescue turns out to fire on hands that cannot carry 300, the number
to revisit is the 200 rather than the choice of measure.

## Replaces, not adds

The old dealer-protection tier is deleted from both engines:

```
partnerIsDealer && myScore >= 850 && oppScore < 500  ->  OPENING_BID
```

Superseded on thresholds (850/500 → 750/450), on the hand floor it did not
have, and on the opponent-has-passed condition it assumed. Its total absence of
a hand check was half of #255, so this settles that half.

## Where it lives

- `pinochle_engine.py` — `ENDGAME_SCORE_FLOOR` / `ENDGAME_OPP_SCORE_CAP` /
  `ENDGAME_RESCUE_CEILING`, plus `endgame_protection_applies` and
  `endgame_protection_bid`. Applied in `Player.choose_bid` **and** in
  `GeneralStrategy._rollout_ev_bid`: that path only consults the static answer
  for positional back-off, so without the second call the rule would not reach
  skill 4–5, and a rollout that finds taking the contract has the higher EV is
  answering a different question from the one the rule asks.
- `web/src/engine/bidding.ts` — the same three constants and the same rule at
  the top of `chooseBid`.
- `EasyPlayer` / skill 1 / `meldOnlyBid` are deliberately left out, the same
  way they are left out of every other score-aware rule.
- `pinochle_rules.md` — new "Endgame protection: when the AI stops bidding"
  subsection under Implementation Notes, next to "The AI is real strategy, not
  placeholders", and the `choose_bid` bullet there updated. Filed as a strategy
  rule rather than a rule of the game, which is the distinction that section
  already draws: nothing in Phase 1 forbids the bid it declines to make.

## Tests

New `test_endgame_bidding.py` (15 tests) and a new `endgame protection (#256)`
block in `web/src/engine/bidding.test.ts` (12 tests). Both cover the trigger
boundaries one point either side on both axes (749/750, 449/450), the
pass-everything default including the defensive push and the partner-raise
branch that would otherwise return a bid, both seats of the team passing the
same auction, and each of the three exception conditions failing independently
plus the opponent-has-bid case.

Three existing TS tests moved. Two were the retired rule's own tests and are
gone with it. The third, "does not open a hopeless first-bidder hand (#126)",
was written at 850/400 — inside the new trigger, so it would have gone on
passing for the wrong reason, answering from the endgame rule instead of from
`OPENER_THRESHOLD`. It is re-pinned to level scores, which is what it was
always about.

## Generated artifacts

None moved. `export_parity_scenarios.py --check` and `export_evaluator.py
--check` both pass untouched inside the Python run: the parity fixture pins
recorded auctions as inputs rather than recomputing decisions, and the
evaluator model is fitted from a stored dataset.

## Verification

- `python -m pytest -q` from the repo root: **325 passed** (baseline 310).
- `cd web && npm test -- --run --maxWorkers=2`: **42 files / 502 tests**
  (baseline 42 / 490).
- `npx tsc --noEmit -p tsconfig.app.json`: clean. `npm run lint`: only the
  three pre-existing `react-hooks/exhaustive-deps` warnings.

## Not done here

The A/B run #256 asks for. Per the issue, it needs sizing for the situation —
the trigger needs a score configuration that is rare per deal, so a general run
can show nothing while the endgame stays broken, and it wants measuring on
filtered deals (games actually reaching 750+ against sub-450) as well as on the
full set. That is a separate measurement job, not a change to this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
