### PR TITLE
fix(ai): put a measured floor under the third bidder's positional open (#255)

### DIFF
--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -1921,13 +1921,23 @@ class Player:
             )
 
         if not context["ever_bid"]:
-            # 3rd bidder (2 passes already, no one's bid) - always open
-            # to deny the last player a cheap contract, unless our score
-            # is high enough (>800) that we'd rather play it safe.
+            # 3rd bidder (2 passes already, no one's bid). This opened on *any*
+            # hand to deny the last player a cheap contract, and #255 puts the
+            # house floor on it: a bid asserts a hand worth OPENER_THRESHOLD
+            # ("assume anyone bidding has 320 or they should not bid"), so a
+            # seat under that passes and lets the auction pass out rather than
+            # buying a contract it cannot make. The >800 sub-case is gone
+            # because it applied exactly this floor and it now applies always.
+            #
+            # What that leaves is the finding rather than an oversight: with
+            # the floor on, the positional rule says precisely what the normal
+            # opener below says. The rule was only ever the gap between the
+            # two, so putting a hand check on it is the same act as retiring
+            # it. The branch is kept so the decision has somewhere to live -
+            # and so the two engines' third-bidder tiers stay in the same
+            # shape - not because it can still answer differently.
             if context["passes_so_far"] == 2:
-                if my_score > 800:
-                    return OPENING_BID if ceiling >= OPENER_THRESHOLD else None
-                return OPENING_BID
+                return OPENING_BID if ceiling >= OPENER_THRESHOLD else None
 
             # Normal opener threshold
             return OPENING_BID if ceiling >= OPENER_THRESHOLD else None

--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -254,6 +254,41 @@ ENDGAME_OPP_SCORE_CAP = GAME_WIN_SCORE - 550
 # revisit, not the choice of measure.
 ENDGAME_RESCUE_CEILING = 200
 
+# -- The hand floor under the third bidder's positional open (#255).
+#
+# The seat that speaks after two passes with nobody having bid opens to deny
+# the last player a cheap contract. That used to happen on *any* hand at all,
+# which is what #255 was filed about: Paul's house rule from live play is that
+# a bid asserts a hand - "assume anyone bidding has 320 or they should not
+# bid."
+#
+# This is 200 and NOT OPENER_THRESHOLD, and the difference was measured. A
+# paired A/B on identical deals with the seats mirrored (ab_harness.run_ab,
+# 800 pairs / 1600 games) put each candidate floor against the unfloored rule
+# it replaces:
+#
+#   320: -57 score margin per deal, 95% CI -76 to -37, exact two-sided
+#        binomial p < 1e-4, sign test 34 sweeps to 83. Replicated on a second
+#        seed at -28/deal, CI -46 to -11, p = 0.0023.
+#   200: -7/deal, 95% CI -17 to +1, NOT significant (7 sweeps to 16, p = 0.09).
+#
+# So the positional open really is worth something, and all of what it is
+# worth lives in the 200-320 band - precisely the hands the house rule would
+# forbid. Paying 57 points a deal to enforce 320 here is not a trade worth
+# making; 200 still stops the seat opening on a hand with no meld and no aces,
+# which is what was actually seen at the table.
+#
+# The two numbers express different ideas and are deliberately not linked.
+# OPENER_THRESHOLD is "worth a contract". This is "not literally worthless".
+# Setting this to OPENER_THRESHOLD, or deriving it from it, would relink two
+# values that have just been measured apart.
+#
+# Like ENDGAME_RESCUE_CEILING (which independently landed on 200 by judgement
+# rather than by measurement) this is the Max Bid *ceiling*, not the Base Bid,
+# and the comparison is `>=` - reached, not cleared - which is the form that
+# was measured.
+THIRD_BIDDER_FLOOR = 200
+
 
 def endgame_protection_applies(my_score, opp_score):
     """True when this team should be banking its meld rather than buying a
@@ -1922,22 +1957,24 @@ class Player:
 
         if not context["ever_bid"]:
             # 3rd bidder (2 passes already, no one's bid). This opened on *any*
-            # hand to deny the last player a cheap contract, and #255 puts the
-            # house floor on it: a bid asserts a hand worth OPENER_THRESHOLD
-            # ("assume anyone bidding has 320 or they should not bid"), so a
-            # seat under that passes and lets the auction pass out rather than
-            # buying a contract it cannot make. The >800 sub-case is gone
-            # because it applied exactly this floor and it now applies always.
+            # hand at all to deny the last player a cheap contract, which is
+            # the path #255 was filed about. It still opens on position rather
+            # than on hand strength - that is what the tier is for, and the A/B
+            # on THIRD_BIDDER_FLOOR says the position is genuinely worth
+            # something - but there is a floor under it now, so a seat with no
+            # meld and no aces lets the auction pass out instead.
             #
-            # What that leaves is the finding rather than an oversight: with
-            # the floor on, the positional rule says precisely what the normal
-            # opener below says. The rule was only ever the gap between the
-            # two, so putting a hand check on it is the same act as retiring
-            # it. The branch is kept so the decision has somewhere to live -
-            # and so the two engines' third-bidder tiers stay in the same
-            # shape - not because it can still answer differently.
+            # The floor is deliberately well below OPENER_THRESHOLD. Paul's
+            # house rule is 320; measured against this rule, 320 cost 57 points
+            # a deal and 200 costs nothing detectable. The constant carries the
+            # numbers.
+            #
+            # The >800 sub-case is gone: it applied OPENER_THRESHOLD, which is
+            # no longer this rule's floor, and a seat near the end of the game
+            # has #256's endgame protection in front of it doing that job with
+            # thresholds chosen for it.
             if context["passes_so_far"] == 2:
-                return OPENING_BID if ceiling >= OPENER_THRESHOLD else None
+                return OPENING_BID if ceiling >= THIRD_BIDDER_FLOOR else None
 
             # Normal opener threshold
             return OPENING_BID if ceiling >= OPENER_THRESHOLD else None

--- a/pinochle_engine.py
+++ b/pinochle_engine.py
@@ -287,6 +287,11 @@ ENDGAME_RESCUE_CEILING = 200
 # rather than by measurement) this is the Max Bid *ceiling*, not the Base Bid,
 # and the comparison is `>=` - reached, not cleared - which is the form that
 # was measured.
+#
+# Both runs predate #242, which raised every hand holding a trump Run by 40.
+# The two mechanisms are independent and the gap between the arms is far larger
+# than that shift, so the direction stands; the exact figures are of the
+# valuation as it was that day.
 THIRD_BIDDER_FLOOR = 200
 
 

--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -249,9 +249,13 @@ Proficient tier landed. What they actually do:
 - `choose_bid` — Proficient bidding on the layered Base Bid valuation
   (`best_base_bid` → `compute_competitive_adjustment` → `max_bid`'s
   cap), plus positional and score-context rules: endgame protection
-  (below), the opener threshold, a forced open as third bidder, the
-  `DEFENSIVE_PUSH_FLOOR` response to a minimum opener, and backing off
-  once a partner is carrying the auction.
+  (below), the opener threshold, the `DEFENSIVE_PUSH_FLOOR` response to
+  a minimum opener, and backing off once a partner is carrying the
+  auction. The third bidder — two passes in, nobody having bid — used to
+  be a *forced* open, on any hand at all, to deny the last seat a cheap
+  contract. It is held to the opener threshold like every other seat now
+  (#255): the house rule is that a bid asserts a hand worth 320, so a
+  seat under that lets the auction pass out instead.
 - `choose_trump` — the same per-suit Base Bid comparison, so trump
   follows real speculative hand strength rather than raw card count.
 - `choose_pass_cards` — role-aware (bidder vs. partner) and split by

--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -251,11 +251,17 @@ Proficient tier landed. What they actually do:
   cap), plus positional and score-context rules: endgame protection
   (below), the opener threshold, the `DEFENSIVE_PUSH_FLOOR` response to
   a minimum opener, and backing off once a partner is carrying the
-  auction. The third bidder — two passes in, nobody having bid — used to
-  be a *forced* open, on any hand at all, to deny the last seat a cheap
-  contract. It is held to the opener threshold like every other seat now
-  (#255): the house rule is that a bid asserts a hand worth 320, so a
-  seat under that lets the auction pass out instead.
+  auction, and a positional open by the third bidder — two passes in,
+  nobody having bid — to deny the last seat a cheap contract. That open
+  is still positional rather than a judgement that the hand is worth a
+  contract; what #255 changed is that it is no longer *forced*. It has a
+  floor under it now (`THIRD_BIDDER_FLOOR`, 200 against the Max Bid
+  ceiling), so the seat no longer opens on a hand with no meld and no
+  aces. The floor is well below the opener threshold on purpose: the
+  house rule at the table is that a bid means 320, but enforcing 320
+  here was measured at −57 points per deal against opening freely,
+  while 200 costs nothing detectable — all of what the position is
+  worth sits in that band. The constant carries both A/B runs.
 - `choose_trump` — the same per-suit Base Bid comparison, so trump
   follows real speculative hand strength rather than raw card count.
 - `choose_pass_cards` — role-aware (bidder vs. partner) and split by

--- a/test_third_bidder_floor.py
+++ b/test_third_bidder_floor.py
@@ -35,7 +35,12 @@ from pinochle_engine import (
 )
 
 
-# A trump Run plus a second Royal Marriage and an off-suit Ace: ceiling 360.
+# A trump Run plus a second Royal Marriage and an off-suit Ace: ceiling 400,
+# which is the MAX_BID_DEFAULT cap. It was 360 until #242 stopped the Run
+# absorbing the Royal Marriage inside it; every hand holding a trump Run gained
+# 40 there, which is why the fixture comments in this file are checked against
+# the engine by test_fixture_hands_sit_where_the_tests_assume rather than
+# trusted.
 STRONG_HAND = [
     Card(Suit.HEARTS, "A", 1),
     Card(Suit.HEARTS, "10", 1),
@@ -137,8 +142,12 @@ def _bid_as_opener(hand, my_score=0, opp_score=0):
 # ---------------------------------------------------------------------------
 
 def test_fixture_hands_sit_where_the_tests_assume():
+    # Derived, not asserted against literals, and checked before anything else
+    # in the file leans on them. #242 moved every hand holding a trump Run up
+    # by 40 and would have quietly taken a band fixture out of its band.
     assert _ceiling(JUNK_HAND) < THIRD_BIDDER_FLOOR
-    assert THIRD_BIDDER_FLOOR < _ceiling(MIDDLING_HAND) < OPENER_THRESHOLD
+    assert _ceiling(JUST_UNDER_HAND) < THIRD_BIDDER_FLOOR
+    assert THIRD_BIDDER_FLOOR <= _ceiling(MIDDLING_HAND) < OPENER_THRESHOLD
     assert _ceiling(STRONG_HAND) >= OPENER_THRESHOLD
 
 

--- a/test_third_bidder_floor.py
+++ b/test_third_bidder_floor.py
@@ -2,20 +2,24 @@
 Tests for issue #255 - the third-bidder positional open gets a hand floor.
 
 The rule under test: the seat that speaks after two passes with nobody having
-bid used to open at OPENING_BID on *any* hand, to deny the last player a cheap
-contract. Paul's house rule from live play is that a bid asserts a hand -
-"assume anyone bidding has 320 or they should not bid" - so the hand's Max Bid
-ceiling now has to reach OPENER_THRESHOLD before this seat opens.
+bid opens at OPENING_BID to deny the last player a cheap contract. It used to
+do that on *any* hand at all. It now needs a Max Bid ceiling that reaches
+THIRD_BIDDER_FLOOR.
+
+The floor is 200, not the house rule's 320, and that is a measured choice
+rather than a compromise - see the constant's own comment for the two A/B
+runs. These tests pin the consequences of that choice, because the number
+looks like a candidate for tidying up to OPENER_THRESHOLD and is not one.
 
 What is covered here:
 
   1. A hand under the floor passes where it used to open, and a hand over it
      still opens - the floor is a floor, not a repeal of the rule.
-  2. The floor is the ceiling against OPENER_THRESHOLD, asserted at the
-     boundary rather than against a hand that is merely far from it.
-  3. The consequence, recorded so it is not rediscovered as a bug: with the
-     floor on, this tier gives the same answer as the normal opener for every
-     hand. The positional rule was only ever the gap between the two.
+  2. The comparison is `>=` against the ceiling, checked at the tightest pair
+     of hands the Base Bid grid actually reaches either side of 200.
+  3. The rule still has content: a hand in the 200-320 band opens as third
+     bidder and passes as first bidder. That difference *is* the positional
+     rule, and it is what a 320 floor would have deleted.
 """
 
 from pinochle_engine import (
@@ -24,14 +28,14 @@ from pinochle_engine import (
     OPENING_BID,
     Player,
     Suit,
+    THIRD_BIDDER_FLOOR,
     Team,
     best_base_bid,
     max_bid,
 )
 
 
-# A trump Run plus a second Royal Marriage and an off-suit Ace: comfortably
-# over OPENER_THRESHOLD.
+# A trump Run plus a second Royal Marriage and an off-suit Ace: ceiling 360.
 STRONG_HAND = [
     Card(Suit.HEARTS, "A", 1),
     Card(Suit.HEARTS, "10", 1),
@@ -43,7 +47,8 @@ STRONG_HAND = [
     Card(Suit.SPADES, "A", 1),
 ]
 
-# No meld, no Aces, nothing near a Run - the hand the old rule opened on.
+# No meld, no Aces, nothing near a Run - ceiling 140, the hand the old rule
+# opened on and the one Paul saw at the table.
 JUNK_HAND = [
     Card(Suit.SPADES, "9", 1),
     Card(Suit.SPADES, "J", 1),
@@ -51,6 +56,24 @@ JUNK_HAND = [
     Card(Suit.DIAMONDS, "J", 2),
     Card(Suit.CLUBS, "9", 2),
     Card(Suit.HEARTS, "9", 1),
+]
+
+# A Royal Marriage and two off-suit Aces: ceiling 210. Over THIRD_BIDDER_FLOOR
+# and well under OPENER_THRESHOLD, so it is the hand the whole disagreement
+# between 200 and 320 is about.
+MIDDLING_HAND = [
+    Card(Suit.HEARTS, "K", 1),
+    Card(Suit.HEARTS, "Q", 1),
+    Card(Suit.SPADES, "A", 1),
+    Card(Suit.CLUBS, "A", 1),
+]
+
+# The same Royal Marriage with one Ace instead of two: ceiling 190, the
+# nearest hand *below* the floor that the Base Bid grid reaches.
+JUST_UNDER_HAND = [
+    Card(Suit.HEARTS, "K", 1),
+    Card(Suit.HEARTS, "Q", 1),
+    Card(Suit.SPADES, "A", 1),
 ]
 
 
@@ -61,8 +84,8 @@ def _ceiling(hand, my_score=0, opp_score=0):
 
 
 def _seat(hand, my_score=0, opp_score=0):
-    """Four seats, two teams, level scores so #256's endgame rule is not what
-    answers. Returns (me, dealer_seat)."""
+    """Four seats, two teams, level scores by default so #256's endgame rule
+    is not what answers. Returns (me, dealer_seat, the two seats that pass)."""
     me = Player("Me", None)
     partner = Player("Partner", None)
     opp_a = Player("OppA", None)
@@ -95,8 +118,7 @@ def _bid_as_third(hand, my_score=0, opp_score=0):
 
 
 def _bid_as_opener(hand, my_score=0, opp_score=0):
-    """The same seat and hand as the first to speak, for the comparison in
-    test 3."""
+    """The same seat and hand as the first to speak."""
     me, dealer, _ = _seat(hand, my_score, opp_score)
     context = {
         "ever_bid": False,
@@ -111,12 +133,13 @@ def _bid_as_opener(hand, my_score=0, opp_score=0):
 
 
 # ---------------------------------------------------------------------------
-# 0. The fixtures sit either side of the floor.
+# 0. The fixtures are where the rest of the file says they are.
 # ---------------------------------------------------------------------------
 
-def test_fixture_hands_sit_either_side_of_the_opener_threshold():
+def test_fixture_hands_sit_where_the_tests_assume():
+    assert _ceiling(JUNK_HAND) < THIRD_BIDDER_FLOOR
+    assert THIRD_BIDDER_FLOOR < _ceiling(MIDDLING_HAND) < OPENER_THRESHOLD
     assert _ceiling(STRONG_HAND) >= OPENER_THRESHOLD
-    assert _ceiling(JUNK_HAND) < OPENER_THRESHOLD
 
 
 # ---------------------------------------------------------------------------
@@ -130,40 +153,56 @@ def test_third_bidder_passes_a_hand_under_the_floor():
 
 def test_third_bidder_still_opens_positionally_over_the_floor():
     assert _bid_as_third(STRONG_HAND) == OPENING_BID
+    assert _bid_as_third(MIDDLING_HAND) == OPENING_BID
 
 
-def test_the_high_score_arm_is_the_same_rule_now():
-    # The tier used to apply the floor only when my_score > 800. It applies it
-    # always, so the two arms have stopped differing - which is why the sub-case
-    # was removed rather than left sitting there agreeing with itself.
+def test_the_high_score_arm_is_gone():
+    # The tier used to fall back to OPENER_THRESHOLD when my_score > 800. That
+    # sub-case is removed: OPENER_THRESHOLD is not this rule's floor any more,
+    # and a seat near the end of the game has #256's endgame protection in
+    # front of it doing that job with thresholds chosen for it. So a middling
+    # hand that opens at 0-0 also opens at 810, where it used to pass.
+    # (810/600 is outside the endgame trigger - the opponents are not under
+    # ENDGAME_OPP_SCORE_CAP - so this really is the third-bidder rule
+    # answering.)
+    assert _bid_as_third(MIDDLING_HAND, my_score=810, opp_score=600) == OPENING_BID
     assert _bid_as_third(JUNK_HAND, my_score=810, opp_score=600) is None
-    assert _bid_as_third(STRONG_HAND, my_score=810, opp_score=600) == OPENING_BID
 
 
 # ---------------------------------------------------------------------------
-# 2. The floor is the ceiling against OPENER_THRESHOLD, at the boundary.
+# 2. The comparison is `>=` on the ceiling, at the grid's tightest pair.
 # ---------------------------------------------------------------------------
 
 def test_the_floor_is_reached_not_cleared():
-    # A trump Run and one off-suit Ace: ceiling exactly OPENER_THRESHOLD at
-    # level scores. It opens, so the comparison is `>=` — matching the normal
-    # opener and PARTNER_PASSED_FLOOR's "reach it, do not clear it" (#180).
-    # One card less is a bare Run at 300, twenty under, and it passes.
-    run = [Card(Suit.HEARTS, r, 1) for r in ("A", "10", "K", "Q", "J")]
-    on_the_line = run + [Card(Suit.SPADES, "A", 1)]
-    assert _ceiling(on_the_line) == OPENER_THRESHOLD
-    assert _bid_as_third(on_the_line) == OPENING_BID
-    assert _ceiling(run) < OPENER_THRESHOLD
-    assert _bid_as_third(run) is None
+    # The Base Bid grid does not land on 200 exactly with any small hand - it
+    # steps 190 -> 210 through this region - so the boundary is pinned with the
+    # nearest hand either side rather than with an equality case that does not
+    # exist. Reach-it-do-not-clear-it still matters as intent: it is the form
+    # that was measured, and it matches the normal opener and #180's
+    # PARTNER_PASSED_FLOOR.
+    assert _ceiling(JUST_UNDER_HAND) < THIRD_BIDDER_FLOOR
+    assert _bid_as_third(JUST_UNDER_HAND) is None
+    assert _ceiling(MIDDLING_HAND) >= THIRD_BIDDER_FLOOR
+    assert _bid_as_third(MIDDLING_HAND) == OPENING_BID
 
 
 # ---------------------------------------------------------------------------
-# 3. The finding: floored, the tier says what the normal opener says.
+# 3. The rule still has content - which a 320 floor would have removed.
 # ---------------------------------------------------------------------------
 
-def test_the_positional_tier_now_agrees_with_the_normal_opener():
-    # Recorded rather than left implicit. If a future change wants the third
-    # bidder to behave differently from a first bidder, it has to reintroduce a
-    # difference on purpose - and this test is what will say so.
-    for hand in (STRONG_HAND, JUNK_HAND):
-        assert _bid_as_third(hand) == _bid_as_opener(hand)
+def test_the_positional_open_still_differs_from_the_normal_opener():
+    # This is the whole rule, and the reason the floor is 200. In the
+    # 200-320 band the third bidder opens and a first bidder does not: the
+    # positional argument (deny the last seat a cheap contract, and keep the
+    # auction off an opponent dealer at FORCED_BID) is doing the work.
+    #
+    # A floor at OPENER_THRESHOLD would make these two equal for every hand,
+    # which is to say it would retire the rule - and the A/B on the constant
+    # measured that at -57 points per deal.
+    assert _bid_as_third(MIDDLING_HAND) == OPENING_BID
+    assert _bid_as_opener(MIDDLING_HAND) is None
+    # Either side of the band the two agree, as they should.
+    assert _bid_as_third(JUNK_HAND) is None
+    assert _bid_as_opener(JUNK_HAND) is None
+    assert _bid_as_third(STRONG_HAND) == OPENING_BID
+    assert _bid_as_opener(STRONG_HAND) == OPENING_BID

--- a/test_third_bidder_floor.py
+++ b/test_third_bidder_floor.py
@@ -1,0 +1,169 @@
+"""
+Tests for issue #255 - the third-bidder positional open gets a hand floor.
+
+The rule under test: the seat that speaks after two passes with nobody having
+bid used to open at OPENING_BID on *any* hand, to deny the last player a cheap
+contract. Paul's house rule from live play is that a bid asserts a hand -
+"assume anyone bidding has 320 or they should not bid" - so the hand's Max Bid
+ceiling now has to reach OPENER_THRESHOLD before this seat opens.
+
+What is covered here:
+
+  1. A hand under the floor passes where it used to open, and a hand over it
+     still opens - the floor is a floor, not a repeal of the rule.
+  2. The floor is the ceiling against OPENER_THRESHOLD, asserted at the
+     boundary rather than against a hand that is merely far from it.
+  3. The consequence, recorded so it is not rediscovered as a bug: with the
+     floor on, this tier gives the same answer as the normal opener for every
+     hand. The positional rule was only ever the gap between the two.
+"""
+
+from pinochle_engine import (
+    Card,
+    OPENER_THRESHOLD,
+    OPENING_BID,
+    Player,
+    Suit,
+    Team,
+    best_base_bid,
+    max_bid,
+)
+
+
+# A trump Run plus a second Royal Marriage and an off-suit Ace: comfortably
+# over OPENER_THRESHOLD.
+STRONG_HAND = [
+    Card(Suit.HEARTS, "A", 1),
+    Card(Suit.HEARTS, "10", 1),
+    Card(Suit.HEARTS, "K", 1),
+    Card(Suit.HEARTS, "Q", 1),
+    Card(Suit.HEARTS, "J", 1),
+    Card(Suit.HEARTS, "K", 2),
+    Card(Suit.HEARTS, "Q", 2),
+    Card(Suit.SPADES, "A", 1),
+]
+
+# No meld, no Aces, nothing near a Run - the hand the old rule opened on.
+JUNK_HAND = [
+    Card(Suit.SPADES, "9", 1),
+    Card(Suit.SPADES, "J", 1),
+    Card(Suit.DIAMONDS, "9", 1),
+    Card(Suit.DIAMONDS, "J", 2),
+    Card(Suit.CLUBS, "9", 2),
+    Card(Suit.HEARTS, "9", 1),
+]
+
+
+def _ceiling(hand, my_score=0, opp_score=0):
+    trump, base, _ = best_base_bid(hand, my_score, opp_score)
+    cap = max_bid(hand, trump)
+    return base if cap is None else min(base, cap)
+
+
+def _seat(hand, my_score=0, opp_score=0):
+    """Four seats, two teams, level scores so #256's endgame rule is not what
+    answers. Returns (me, dealer_seat)."""
+    me = Player("Me", None)
+    partner = Player("Partner", None)
+    opp_a = Player("OppA", None)
+    opp_b = Player("OppB", None)
+    me.hand = list(hand)
+    us = Team("Us", [me, partner])
+    them = Team("Them", [opp_a, opp_b])
+    me.team = partner.team = us
+    opp_a.team = opp_b.team = them
+    us.score = my_score
+    them.score = opp_score
+    return me, opp_b, [partner, opp_a]
+
+
+def _bid_as_third(hand, my_score=0, opp_score=0):
+    """This seat's turn with two passes behind it and nobody having bid: the
+    partner (dealer + 1) and one opponent (dealer + 2) are out, this seat is
+    dealer + 3, and the dealer has yet to speak."""
+    me, dealer, passers = _seat(hand, my_score, opp_score)
+    context = {
+        "ever_bid": False,
+        "passes_so_far": 2,
+        "bid_history": [],
+        "pass_history": [(p, OPENING_BID) for p in passers],
+        "passed_players": list(passers),
+        "dealer": dealer,
+        "teams": [me.team, dealer.team],
+    }
+    return me.choose_bid(OPENING_BID - 10, 10, context)
+
+
+def _bid_as_opener(hand, my_score=0, opp_score=0):
+    """The same seat and hand as the first to speak, for the comparison in
+    test 3."""
+    me, dealer, _ = _seat(hand, my_score, opp_score)
+    context = {
+        "ever_bid": False,
+        "passes_so_far": 0,
+        "bid_history": [],
+        "pass_history": [],
+        "passed_players": [],
+        "dealer": dealer,
+        "teams": [me.team, dealer.team],
+    }
+    return me.choose_bid(OPENING_BID - 10, 10, context)
+
+
+# ---------------------------------------------------------------------------
+# 0. The fixtures sit either side of the floor.
+# ---------------------------------------------------------------------------
+
+def test_fixture_hands_sit_either_side_of_the_opener_threshold():
+    assert _ceiling(STRONG_HAND) >= OPENER_THRESHOLD
+    assert _ceiling(JUNK_HAND) < OPENER_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# 1. The floor, both ways round.
+# ---------------------------------------------------------------------------
+
+def test_third_bidder_passes_a_hand_under_the_floor():
+    # Before #255 this returned OPENING_BID on this hand, and on any hand.
+    assert _bid_as_third(JUNK_HAND) is None
+
+
+def test_third_bidder_still_opens_positionally_over_the_floor():
+    assert _bid_as_third(STRONG_HAND) == OPENING_BID
+
+
+def test_the_high_score_arm_is_the_same_rule_now():
+    # The tier used to apply the floor only when my_score > 800. It applies it
+    # always, so the two arms have stopped differing - which is why the sub-case
+    # was removed rather than left sitting there agreeing with itself.
+    assert _bid_as_third(JUNK_HAND, my_score=810, opp_score=600) is None
+    assert _bid_as_third(STRONG_HAND, my_score=810, opp_score=600) == OPENING_BID
+
+
+# ---------------------------------------------------------------------------
+# 2. The floor is the ceiling against OPENER_THRESHOLD, at the boundary.
+# ---------------------------------------------------------------------------
+
+def test_the_floor_is_reached_not_cleared():
+    # A trump Run and one off-suit Ace: ceiling exactly OPENER_THRESHOLD at
+    # level scores. It opens, so the comparison is `>=` — matching the normal
+    # opener and PARTNER_PASSED_FLOOR's "reach it, do not clear it" (#180).
+    # One card less is a bare Run at 300, twenty under, and it passes.
+    run = [Card(Suit.HEARTS, r, 1) for r in ("A", "10", "K", "Q", "J")]
+    on_the_line = run + [Card(Suit.SPADES, "A", 1)]
+    assert _ceiling(on_the_line) == OPENER_THRESHOLD
+    assert _bid_as_third(on_the_line) == OPENING_BID
+    assert _ceiling(run) < OPENER_THRESHOLD
+    assert _bid_as_third(run) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. The finding: floored, the tier says what the normal opener says.
+# ---------------------------------------------------------------------------
+
+def test_the_positional_tier_now_agrees_with_the_normal_opener():
+    # Recorded rather than left implicit. If a future change wants the third
+    # bidder to behave differently from a first bidder, it has to reintroduce a
+    # difference on purpose - and this test is what will say so.
+    for hand in (STRONG_HAND, JUNK_HAND):
+        assert _bid_as_third(hand) == _bid_as_opener(hand)

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -21,6 +21,7 @@ import {
   OPENER_THRESHOLD,
   PARTNER_PASSED_FLOOR,
   PARTNER_RAISE_FLOOR,
+  THIRD_BIDDER_FLOOR,
 } from './bidding'
 import { ROYAL_MARRIAGE_VALUE, scoreMelds } from './melds'
 import { partnerOf } from './round'
@@ -318,6 +319,17 @@ describe('chooseBid', () => {
     ...overrides,
   })
 
+  /** The Max Bid ceiling `chooseBid` works from, at level scores. #255's
+   *  tests assert where a fixture sits relative to a floor rather than
+   *  trusting the number in its comment: #242 moved every hand holding a
+   *  trump Run up by 40 and took one of these fixtures out of the band it was
+   *  chosen for, which is the failure mode this closes. */
+  const ceilingOf = (hand: readonly Card[]): number => {
+    const { trump: suit, total } = bestBaseBid(hand, 0, 0)
+    const cap = maxBid(hand, suit)
+    return cap === null ? total : Math.min(total, cap)
+  }
+
   describe('without a context (fallback)', () => {
     it('passes when the coin flip lands under 0.6', () => {
       vi.spyOn(Math, 'random').mockReturnValue(0.1)
@@ -395,27 +407,36 @@ describe('chooseBid', () => {
       // the arm is kept anyway — so this is a unit assertion about the rule,
       // not about a position players meet.
       const context = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
+      expect(ceilingOf(weakHand)).toBeLessThan(THIRD_BIDDER_FLOOR)
       expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBeNull()
     })
 
     it('3rd bidder still opens positionally over THIRD_BIDDER_FLOOR (#255)', () => {
       // The other half of the same rule: the floor is a floor, not a repeal.
       const context = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
+      expect(ceilingOf(strongHand)).toBeGreaterThanOrEqual(THIRD_BIDDER_FLOOR)
       expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'medium')).toBe(OPENING_BID)
     })
 
     it('the floor is 200, not OPENER_THRESHOLD, and that is what the rule is (#255)', () => {
-      // `runOnlyHand`'s ceiling is 300: over THIRD_BIDDER_FLOOR and under
-      // OPENER_THRESHOLD, so it is exactly the hand the choice of floor is
-      // about. As third bidder this seat opens on it; as first bidder, on the
-      // same hand and the same static policy, it passes. That gap *is* the
-      // positional rule, and a floor at OPENER_THRESHOLD would have closed it
-      // — measured at -57 score margin per deal, which is why the constant
-      // reads 200. See THIRD_BIDDER_FLOOR for both A/B runs.
+      // The hand has to sit strictly inside the 200-320 band for this test to
+      // be testing anything, and a fixture's value is not a stable thing to
+      // assume — #242 moved every hand holding a trump Run up by 40 and this
+      // test's original fixture out of the band with it. So the band is
+      // derived from the current valuation here rather than taken on trust,
+      // and this assertion is what will fail first if it moves again.
+      expect(ceilingOf(nearRunHand)).toBeGreaterThanOrEqual(THIRD_BIDDER_FLOOR)
+      expect(ceilingOf(nearRunHand)).toBeLessThan(OPENER_THRESHOLD)
+
+      // Inside that band the third bidder opens and a first bidder — same
+      // hand, same static policy — passes. That gap *is* the positional rule,
+      // and a floor at OPENER_THRESHOLD would have closed it: measured at -57
+      // score margin per deal, which is why the constant reads 200. See
+      // THIRD_BIDDER_FLOOR for both A/B runs.
       const third = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
       const first = baseContext({ dealer: 1, passesSoFar: 0, scores: { 0: 0, 1: 0 } })
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, third, 'medium')).toBe(OPENING_BID)
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, first, 'medium')).toBeNull()
+      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, third, 'medium')).toBe(OPENING_BID)
+      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, first, 'medium')).toBeNull()
     })
 
     it('3rd bidder falls back to the normal threshold once my score is above 800', () => {

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -384,9 +384,29 @@ describe('chooseBid', () => {
       expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBeNull()
     })
 
-    it('3rd bidder (2 passes so far) always opens cheap when my score is not above 800', () => {
+    it('3rd bidder does not open a hand that cannot reach OPENER_THRESHOLD (#255)', () => {
+      // This used to assert `toBe(OPENING_BID)` on `weakHand` — a lone off-trump
+      // 9 — because the positional rule opened on anything at all to deny the
+      // last seat a cheap contract. Paul's house rule from live play is that a
+      // bid asserts a hand: "assume anyone bidding has 320 or they should not
+      // bid", so the ceiling now has to reach OPENER_THRESHOLD.
+      //
+      // Note the context: `passesSoFar: 2` with an empty `passedPlayers`, i.e.
+      // partner still to speak. That is the arm the floor guards and it is a
+      // state no real auction reaches — `biddingSim.test.ts` pins why — so this
+      // is a unit assertion about the rule, not about a position players meet.
       const context = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
-      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBe(OPENING_BID)
+      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBeNull()
+    })
+
+    it('3rd bidder still opens positionally once the hand clears the floor (#255)', () => {
+      // The other half of the same rule: the floor is a floor, not a repeal.
+      // `strongHand`'s ceiling is 340, over OPENER_THRESHOLD, and this seat
+      // still opens to deny the last player a cheap contract. Pinned on a
+      // static level so the assertion is about the threshold rather than about
+      // the evaluator (#114/#115).
+      const context = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
+      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'medium')).toBe(OPENING_BID)
     })
 
     it('3rd bidder falls back to the normal threshold once my score is above 800', () => {

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -384,29 +384,38 @@ describe('chooseBid', () => {
       expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBeNull()
     })
 
-    it('3rd bidder does not open a hand that cannot reach OPENER_THRESHOLD (#255)', () => {
+    it('3rd bidder does not open a hand under THIRD_BIDDER_FLOOR (#255)', () => {
       // This used to assert `toBe(OPENING_BID)` on `weakHand` — a lone off-trump
-      // 9 — because the positional rule opened on anything at all to deny the
-      // last seat a cheap contract. Paul's house rule from live play is that a
-      // bid asserts a hand: "assume anyone bidding has 320 or they should not
-      // bid", so the ceiling now has to reach OPENER_THRESHOLD.
+      // 9, ceiling 130 — because the positional rule opened on anything at all
+      // to deny the last seat a cheap contract. There is a floor under it now.
       //
       // Note the context: `passesSoFar: 2` with an empty `passedPlayers`, i.e.
       // partner still to speak. That is the arm the floor guards and it is a
-      // state no real auction reaches — `biddingSim.test.ts` pins why — so this
-      // is a unit assertion about the rule, not about a position players meet.
+      // state no real auction reaches — `biddingSim.test.ts` pins why, and why
+      // the arm is kept anyway — so this is a unit assertion about the rule,
+      // not about a position players meet.
       const context = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
       expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context)).toBeNull()
     })
 
-    it('3rd bidder still opens positionally once the hand clears the floor (#255)', () => {
+    it('3rd bidder still opens positionally over THIRD_BIDDER_FLOOR (#255)', () => {
       // The other half of the same rule: the floor is a floor, not a repeal.
-      // `strongHand`'s ceiling is 340, over OPENER_THRESHOLD, and this seat
-      // still opens to deny the last player a cheap contract. Pinned on a
-      // static level so the assertion is about the threshold rather than about
-      // the evaluator (#114/#115).
       const context = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
       expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'medium')).toBe(OPENING_BID)
+    })
+
+    it('the floor is 200, not OPENER_THRESHOLD, and that is what the rule is (#255)', () => {
+      // `runOnlyHand`'s ceiling is 300: over THIRD_BIDDER_FLOOR and under
+      // OPENER_THRESHOLD, so it is exactly the hand the choice of floor is
+      // about. As third bidder this seat opens on it; as first bidder, on the
+      // same hand and the same static policy, it passes. That gap *is* the
+      // positional rule, and a floor at OPENER_THRESHOLD would have closed it
+      // — measured at -57 score margin per deal, which is why the constant
+      // reads 200. See THIRD_BIDDER_FLOOR for both A/B runs.
+      const third = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
+      const first = baseContext({ dealer: 1, passesSoFar: 0, scores: { 0: 0, 1: 0 } })
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, third, 'medium')).toBe(OPENING_BID)
+      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, first, 'medium')).toBeNull()
     })
 
     it('3rd bidder falls back to the normal threshold once my score is above 800', () => {

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -160,6 +160,11 @@ export const ENDGAME_RESCUE_CEILING = 200
  * judgement rather than by measurement) this is the Max Bid **ceiling**, not
  * the Base Bid, and the comparison is `>=` — reached, not cleared — which is
  * the form that was measured.
+ *
+ * Both runs predate #242, which raised every hand holding a trump Run by 40.
+ * The two mechanisms are independent and the gap between the arms is far
+ * larger than that shift, so the direction stands; the exact figures are of
+ * the valuation as it was that day.
  */
 export const THIRD_BIDDER_FLOOR = 200
 

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -561,10 +561,10 @@ function meldOnlyBid(
  *     more than 550 away, so pass the whole auction and bank the meld. The
  *     one exception opens at OPENING_BID to save a partner who is dealing.
  *   - No one has bid yet this auction:
- *     1. 3rd bidder (2 passes already, no one's bid) - always open to
- *        deny the last player a cheap contract, unless my score is high
- *        enough (>800) that I'd rather play it safe and only open if the
- *        hand is worth the contract.
+ *     1. 3rd bidder (2 passes already, no one's bid) - open to deny the
+ *        last player a cheap contract, but only on a hand that reaches
+ *        OPENER_THRESHOLD (#255). This used to open on anything at all
+ *        below a score of 800.
  *     2. Otherwise, open only if the hand is worth the contract.
  *   - My team currently holds the bid:
  *     - Partner has already bid twice this auction - back off, they're
@@ -731,15 +731,38 @@ export function chooseBid(
     const opens = worthContract(floorLevel, ceiling >= OPENER_THRESHOLD)
     const openingLevel = opens ? openingLevelFor(floorLevel) : floorLevel
 
-    // 3rd bidder opens cheap.
+    // 3rd bidder opens cheap — with the house floor on it (#255).
     if (context.passesSoFar === 2) {
       if (myScore > 800) {
         return opens ? openingLevel : null
       }
-      // Positional, not a hand judgement: with partner still to speak this
-      // seat opens on anything to deny the last player a cheap contract, so
-      // neither policy is consulted.
-      return partnerPassed ? (opens ? openingLevel : null) : opens ? openingLevel : OPENING_BID
+      if (opens) return openingLevel
+      // The positional arm: the seat's own policy has said the hand is not
+      // worth a contract, and this used to put `OPENING_BID` on the table
+      // anyway to deny the last player a cheap one. Paul's house rule from
+      // live play is that a bid asserts a hand — "assume anyone bidding has
+      // 320 or they should not bid" — so the ceiling has to reach
+      // `OPENER_THRESHOLD` before position alone can talk this seat in.
+      //
+      // Two things a reader should know before treating that as the fix #255
+      // was after, because they are what the measurement found:
+      //
+      // The `!partnerPassed` half of this arm cannot be reached. `passesSoFar`
+      // counts every pass of the auction and never resets, so `!everBid &&
+      // passesSoFar === 2` means exactly two seats have spoken and both
+      // passed. `auctionReducer` opens left of the dealer and advances one
+      // seat at a time, so those two are `dealer + 1` and `dealer + 2`, this
+      // seat is `dealer + 3`, and its partner is `dealer + 1` — already
+      // passed, every time. Confirmed over 1162 arrivals at this tier in
+      // headless games across `medium`/`hard`/`expert`: `partnerPassed` was
+      // true on all 1162. So this floor guards a state the auction cannot
+      // produce, and it changes no decision either engine makes.
+      //
+      // The live instance of #255's third path is Python's, where
+      // `Player.choose_bid` has this tier with no hand check on either arm and
+      // no partner condition, and it fires. That one moves in this commit too.
+      if (partnerPassed) return null
+      return ceiling >= OPENER_THRESHOLD ? OPENING_BID : null
     }
 
     // Normal opener threshold (4th bidder / dealer — partner has already

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -124,6 +124,46 @@ export const ENDGAME_OPP_SCORE_CAP = GAME_WIN_SCORE - 550
 export const ENDGAME_RESCUE_CEILING = 200
 
 /**
+ * The hand floor under the third bidder's positional open (#255).
+ *
+ * The seat that speaks after two passes with nobody having bid opens to deny
+ * the last player a cheap contract. That used to happen on *any* hand at all,
+ * which is what #255 was filed about: Paul's house rule from live play is that
+ * a bid asserts a hand — "assume anyone bidding has 320 or they should not
+ * bid."
+ *
+ * **This is 200 and not `OPENER_THRESHOLD`, and the difference was measured.**
+ * A paired A/B on identical deals with the seats mirrored (`ab_harness.py`,
+ * 800 pairs / 1600 games, run on the Python engine because that is the one
+ * where this path fires — see `chooseBid`) put the floor at 320 and at 200
+ * against the unfloored rule it replaces:
+ *
+ *   320: **−57 score margin per deal**, 95% CI −76 to −37, exact two-sided
+ *        binomial p < 1e-4, sign test 34 sweeps to 83. Replicated on a second
+ *        seed at −28/deal, CI −46 to −11, p = 0.0023.
+ *   200: −7/deal, 95% CI −17 to +1, **not significant** (7 sweeps to 16,
+ *        p = 0.09).
+ *
+ * So the positional open really is worth something, and all of what it is
+ * worth lives in the 200–320 band — precisely the hands the house rule would
+ * forbid. Paying 57 points a deal to enforce 320 here is not a trade worth
+ * making; 200 still stops the seat opening on a hand with no meld and no aces,
+ * which is what was actually seen at the table.
+ *
+ * The two numbers express different ideas and are deliberately not linked.
+ * `OPENER_THRESHOLD` is "worth a contract". This is "not literally worthless".
+ * Setting this to `OPENER_THRESHOLD` — or deriving it from it — would relink
+ * two values that have just been measured apart, and the measurement above is
+ * what the next person tempted to tidy it up should read first.
+ *
+ * Like `ENDGAME_RESCUE_CEILING` (which independently landed on 200 by
+ * judgement rather than by measurement) this is the Max Bid **ceiling**, not
+ * the Base Bid, and the comparison is `>=` — reached, not cleared — which is
+ * the form that was measured.
+ */
+export const THIRD_BIDDER_FLOOR = 200
+
+/**
  * The bid a seat must commit to once its partner has passed (#93/#95).
  *
  * Not a ceiling like the two above — it is an actual bid, placed on the table,
@@ -563,8 +603,9 @@ function meldOnlyBid(
  *   - No one has bid yet this auction:
  *     1. 3rd bidder (2 passes already, no one's bid) - open to deny the
  *        last player a cheap contract, but only on a hand that reaches
- *        OPENER_THRESHOLD (#255). This used to open on anything at all
- *        below a score of 800.
+ *        THIRD_BIDDER_FLOOR (#255). This used to open on anything at all
+ *        below a score of 800. The floor is 200, not OPENER_THRESHOLD, and
+ *        the constant carries the A/B that says why.
  *     2. Otherwise, open only if the hand is worth the contract.
  *   - My team currently holds the bid:
  *     - Partner has already bid twice this auction - back off, they're
@@ -731,7 +772,7 @@ export function chooseBid(
     const opens = worthContract(floorLevel, ceiling >= OPENER_THRESHOLD)
     const openingLevel = opens ? openingLevelFor(floorLevel) : floorLevel
 
-    // 3rd bidder opens cheap — with the house floor on it (#255).
+    // 3rd bidder opens cheap — with a hand floor under it (#255).
     if (context.passesSoFar === 2) {
       if (myScore > 800) {
         return opens ? openingLevel : null
@@ -739,13 +780,16 @@ export function chooseBid(
       if (opens) return openingLevel
       // The positional arm: the seat's own policy has said the hand is not
       // worth a contract, and this used to put `OPENING_BID` on the table
-      // anyway to deny the last player a cheap one. Paul's house rule from
-      // live play is that a bid asserts a hand — "assume anyone bidding has
-      // 320 or they should not bid" — so the ceiling has to reach
-      // `OPENER_THRESHOLD` before position alone can talk this seat in.
+      // anyway to deny the last player a cheap one. It still does — but only
+      // on a hand that reaches `THIRD_BIDDER_FLOOR`, not on a lone 9.
       //
-      // Two things a reader should know before treating that as the fix #255
-      // was after, because they are what the measurement found:
+      // The floor is 200 rather than the house rule's 320 because the two were
+      // measured against each other and 320 cost 57 points a deal; the reason
+      // lives on `THIRD_BIDDER_FLOOR` and should be read before it is tidied
+      // up to `OPENER_THRESHOLD`.
+      //
+      // Two things a reader should know before treating this as the whole of
+      // #255's third path, because they are what the measurement found:
       //
       // The `!partnerPassed` half of this arm cannot be reached. `passesSoFar`
       // counts every pass of the auction and never resets, so `!everBid &&
@@ -756,13 +800,21 @@ export function chooseBid(
       // passed, every time. Confirmed over 1162 arrivals at this tier in
       // headless games across `medium`/`hard`/`expert`: `partnerPassed` was
       // true on all 1162. So this floor guards a state the auction cannot
-      // produce, and it changes no decision either engine makes.
+      // produce, and it changes no decision this engine makes today.
+      //
+      // It is kept rather than deleted as dead code, deliberately. The
+      // seat-order argument above is a fact about `auctionReducer`'s rotation,
+      // not about `chooseBid`, and if that rotation ever changes — a seat
+      // allowed back into the auction, a different opening seat — deleting
+      // this arm would silently reinstate opening-on-anything. The floored
+      // branch is the cheap net; `biddingSim.test.ts`'s seat-order test is
+      // what keeps the two in step.
       //
       // The live instance of #255's third path is Python's, where
       // `Player.choose_bid` has this tier with no hand check on either arm and
       // no partner condition, and it fires. That one moves in this commit too.
       if (partnerPassed) return null
-      return ceiling >= OPENER_THRESHOLD ? OPENING_BID : null
+      return ceiling >= THIRD_BIDDER_FLOOR ? OPENING_BID : null
     }
 
     // Normal opener threshold (4th bidder / dealer — partner has already

--- a/web/src/engine/biddingSim.test.ts
+++ b/web/src/engine/biddingSim.test.ts
@@ -68,4 +68,51 @@ describe('AI-vs-AI auction simulation', () => {
     }
     expect(offGrid.slice(0, 10)).toEqual([])
   })
+
+  it('a 3rd bidder always has a partner who has already passed (#255)', () => {
+    // `chooseBid`'s third-bidder tier carries a positional arm for "partner
+    // still to speak", and #255 put a hand floor on it. This records why that
+    // floor guards nothing a player ever meets, so the next reader does not
+    // take the arm for live behaviour.
+    //
+    // `passes` counts every pass of the auction and never resets, so
+    // `!everBid && passes === 2` means exactly two seats have spoken and both
+    // passed. The auction opens left of the dealer and advances one seat at a
+    // time, so those two are dealer+1 and dealer+2, the seat on turn is
+    // dealer+3, and its partner is dealer+1 — already out. Asserted over real
+    // auctions rather than by arithmetic, because the claim is about what
+    // `auctionReducer`'s rotation produces.
+    let seen = 0
+    const partnerStillToSpeak: PlayerIndex[] = []
+    for (let i = 0; i < 400; i++) {
+      const deck = new Deck()
+      deck.shuffle()
+      let state: AuctionState = initAuctionState(deck.deal(), (i % 4) as PlayerIndex, SEAT_NAMES, SCORES)
+      let guard = 0
+      while (state.phase === 'bidding' && guard++ < 60) {
+        const turn = state.bidding.turn
+        const passedPlayers = passedPlayersOf(state.bidding.active)
+        if (!state.bidding.everBid && state.bidding.passes === 2) {
+          seen++
+          const partner = ((turn + 2) % 4) as PlayerIndex
+          if (!passedPlayers.includes(partner)) partnerStillToSpeak.push(turn)
+        }
+        const context: AuctionContext = {
+          everBid: state.bidding.everBid,
+          passesSoFar: state.bidding.passes,
+          bidHistory: state.bidding.bidHistory,
+          dealer: state.dealer,
+          scores: state.scoresByTeam,
+          passedPlayers,
+        }
+        const decision = chooseBid(turn, state.hands[turn], state.bidding.currentBid, 10, context, 'hard')
+        state =
+          decision === null
+            ? auctionReducer(state, { type: 'PASS_BID', player: turn })
+            : auctionReducer(state, { type: 'BID', player: turn, amount: decision })
+      }
+    }
+    expect(seen).toBeGreaterThan(0)
+    expect(partnerStillToSpeak).toEqual([])
+  })
 })

--- a/web/src/engine/biddingSim.test.ts
+++ b/web/src/engine/biddingSim.test.ts
@@ -70,10 +70,17 @@ describe('AI-vs-AI auction simulation', () => {
   })
 
   it('a 3rd bidder always has a partner who has already passed (#255)', () => {
+    // This is an invariant another rule leans on, not a curiosity.
+    //
     // `chooseBid`'s third-bidder tier carries a positional arm for "partner
-    // still to speak", and #255 put a hand floor on it. This records why that
-    // floor guards nothing a player ever meets, so the next reader does not
-    // take the arm for live behaviour.
+    // still to speak". #255 put a hand floor on it and the arm was kept rather
+    // than deleted as dead code, on the grounds that if the rotation ever
+    // changes — a seat allowed back into the auction, a different opening seat
+    // — a deleted arm would silently reinstate opening-on-anything while a
+    // floored one would not. That trade is only sound while the arm really is
+    // unreachable *today*, which is what this test asserts. If it ever goes
+    // red, the branch in `chooseBid` has become live behaviour and its floor
+    // (`THIRD_BIDDER_FLOOR`) has never been measured in that position.
     //
     // `passes` counts every pass of the auction and never resets, so
     // `!everBid && passes === 2` means exactly two seats have spoken and both


### PR DESCRIPTION
Closes #255.

The third-bidder positional open — two passes in, nobody has bid, open at
`OPENING_BID` to deny the last seat a cheap contract — used to happen on **any
hand at all**. It now needs a Max Bid ceiling of `THIRD_BIDDER_FLOOR`.

**The floor is 200, not the house rule's 320, and that is the measurement's
verdict rather than a compromise.** Paul's rule from live play is *"assume
anyone bidding has 320 or they should not bid"*, and it was implemented at 320
first. Against this particular rule 320 costs 57 points a deal. 200 costs
nothing detectable, and still stops the seat opening on the hand Paul actually
saw: no meld, no aces.

Out of scope and untouched, per the decision comment on #255: `shouldBid`,
`evaluatorModel.ts` and the `bidPolicy: 'distilled'` route (path 1 keeps its
own judgement; binding it would partially revert #115), and the
partner-over-partner raise (already gated above 320 at `PARTNER_RAISE_FLOOR`,
#206). Path 2 confirmed gone: #256 deleted the dealer-protection tier and
nothing here re-adds a floor to it. #256's endgame rule still returns ahead of
this branch and is not touched.

## The measurement

Paired, identical deals, seats mirrored. Self-tests first, per `cli.ts` and
`ab_harness.py`.

Each candidate floor was run against the unfloored rule it replaces —
`ab_harness.run_ab`, 800 pairs / 1600 games, a `Player` subclass restoring the
old tier as the only difference, on the Python engine because that is the one
where this path fires (see fire rate below):

| floor | margin/deal | 95% CI | sign test | verdict |
|---|---|---|---|---|
| **320** (`OPENER_THRESHOLD`) | **−57** | −76 to −37 | 34 sweeps to 83, p < 1e-4 | significant loss |
| 320, seed 2 | −28 | −46 to −11 | 31 to 61, p = 0.0023 | replicates |
| **200** (`THIRD_BIDDER_FLOOR`) | **−7** | −17 to +1 | 7 to 16, p = 0.09 | not significant |

So the positional open really is worth something, and all of what it is worth
lives in the 200–320 band — precisely the hands the house rule would forbid.
The mechanism is legible in the round stats rather than mysterious: at 320 the
floored side takes 268 *fewer* contracts and makes a *smaller* share of the
ones it does take (66.4% vs 70.3%). What it declines is not a bad contract, it
is a cheap one — its partner has passed but still holds meld, the 3-card pass
is still to come, and the alternative is the auction passing out onto the
dealer, who is an opponent, at `FORCED_BID`.

Controls: Python self-test clean (100 pairs, every deal split, margin +0), and
an uninstrumented arm reproduces the 320 run to the digit, so it is the rule
being measured and not the harness.

Caveat, recorded rather than chased: both runs predate #242, which raised
every hand holding a trump Run by 40. The two mechanisms are independent and
the gap between the arms is far larger than that shift, so the direction stands
and the harness was not re-run; the figures are of the valuation as it was that
day.

At 320 the tier collapsed into the normal opener for every hand — flooring the
rule at 320 and retiring it are the same act. At 200 it keeps its content, and
both engines now have a test pinning the gap: in the 200–320 band the third
bidder opens where a first bidder on the same hand and the same policy passes.

TypeScript side: `selftest` clean on both bidding arms (100 pairs each, every
deal split, +0). Full-set `ab --pairs 1000` (distilled vs static) is 107/99,
p = 0.6259, +18/deal, CI −3 to +39 — **identical to the same run on the
stashed baseline**, because of the fire rate below. That is a null *by
construction*, not a null to be read as a pass.

## Fire rate — the two engines part company here

This is the substantive finding and it survives the change of floor unaltered.

**TypeScript: the path fires 0% of the time.** `chooseBid`'s positional arm is
guarded by `partnerPassed`, and at this seat the partner has *always* passed.
`passesSoFar` counts every pass of the auction and never resets, so `!everBid
&& passesSoFar === 2` means exactly two seats have spoken and both passed;
`auctionReducer` opens left of the dealer and advances one seat at a time, so
those two are dealer+1 and dealer+2, this seat is dealer+3, and its partner is
dealer+1 — already out. Measured: 1162 arrivals at the tier across
`medium`/`hard`/`expert`, `partnerPassed` true on all 1162. A dump of all
16,141 bid decisions in 600 headless games is byte-identical before and after.

**Python: the path fires, a lot.** `Player.choose_bid` has the same tier with
no hand check on *either* arm and no partner condition. Over 800 paired deals
the tier was reached 1743 times and a 320 floor changed the answer on **1142 of
them, 65.5% of arrivals**. That is the live instance of #255's path 3 and it is
what the table above measures.

The TypeScript branch is **kept rather than deleted as dead code** — the
coordinator's call. The unreachability is a fact about `auctionReducer`'s
rotation, not about `chooseBid`, so deleting the arm would let a future
rotation change silently reinstate opening-on-anything, where keeping it
floored would merely re-expose a floored branch. `biddingSim.test.ts` is what
makes that safe, and its comment now says it is pinning an invariant another
rule depends on: if it goes red, the branch has become live behaviour under a
floor never measured in that position.

## What is in the diff

- `web/src/engine/bidding.ts` — new exported `THIRD_BIDDER_FLOOR = 200`
  carrying both A/B runs in its docstring, and the floor applied on the
  positional arm. Confined to the constants block and the `chooseBid` opening
  branch so it merges cleanly with #242's valuation work.
- `pinochle_engine.py` — the same constant with the same reasoning, and the
  tier reduced to one floored return. The `>800` sub-case is gone: it applied
  `OPENER_THRESHOLD`, which is no longer this rule's floor, and a seat that
  close to going out has #256's endgame protection in front of it. The rollout
  path (`_rollout_ev_bid`) is untouched — it never consults the static answer
  when opening and already declines below `FORCED_BID`.
- `pinochle_rules.md` — said "a forced open as third bidder". The forcing is
  what changed; the open is still positional, so the wording now says that and
  records why the floor is not 320.
- Tests: the floor, the still-firing positional open, and the third-bidder vs
  first-bidder gap in `bidding.test.ts` and in a new
  `test_third_bidder_floor.py` (including the `>=` boundary at the tightest
  pair the Base Bid grid reaches either side of 200), plus the seat-order pin
  in `biddingSim.test.ts`. Every one of these asserts where its fixture sits
  relative to the floor *before* asserting behaviour, derived from the current
  valuation rather than from the number in a comment — #242 moved a fixture
  out of its band mid-branch and that is the failure mode this closes.

Both engines move together (#213). No generated artifact moved.

## Verification

Rebased onto current `main` (after #242 / PR #267).

- `cd web && npm test -- --run --maxWorkers=2` — **42 files / 509 tests**, on
  the post-#242 baseline of 506.
- `python -m pytest -q` — **336 passed**, on the post-#242 baseline of 330.
- `npx tsc --noEmit -p tsconfig.app.json` clean; `oxlint src/engine` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
