### PR TITLE
refactor(bidding): delete the openingPolicy 'walk' arm, measured and lost (#221)

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -329,7 +329,9 @@ one field, so a rule with no field is a rule that cannot be measured.
 
 Each policy type carries a docstring stating every arm, which arm each
 shipped row selects, and — when no shipped row selects an arm — why that
-arm still exists. `OpeningPolicy`, `FoldPolicy` and `AutoSetPolicy` all
-do this. A dial whose losing arm is retained for measurement is normal
+arm still exists. `PlayPolicy`, `FoldPolicy` and `AutoSetPolicy` all
+do this. (`OpeningPolicy` stood here until #221 retired its losing arm
+and left it a one-member type; #223 is writing down when that is the
+right move.) A dial whose losing arm is retained for measurement is normal
 here (see `ROADMAP.md` on null results being recorded and shipped
 disabled); a dial with no such note is drift.

--- a/web/README.md
+++ b/web/README.md
@@ -846,6 +846,19 @@ the contract for 250. On those deals the winner's ceiling ran median 310, p75
 
 `openingPolicy: 'walk'` is the fix, and it does not survive measurement.
 
+**The arm was deleted by #221 and this section is what is left of it.** It
+shipped wired-live and flag-off from #204, was never selected by a shipped
+`SKILL_PARAMS` row, and met all four of #215's retirement conditions — three
+seeds recorded, decisively negative, nothing selecting it, nothing baselined
+against it. Gone with it: `WALK_CONFIDENCE`, `openingLevelFor`, `shouldBid`'s
+confidence-threshold parameter, `OPENING_AB_POLICIES`, and the `opening` and
+`--policy walk` CLI commands, so the runs below are no longer reproducible from
+this tree — they are reproducible from `8048d4b..`, the commit range #204
+landed in. `OpeningPolicy` is now a one-member type. The numbers stay because
+retiring the code is not retracting the result: a reader who wonders whether
+this engine has ever tried naming a higher opening level should find the answer
+here rather than an absence.
+
 The dial is deliberately narrow. It is consulted only after `worthContract` has
 already returned true, so both arms open on an identical set of deals and pass on
 an identical set — `bidding.test.ts` asserts that directly. The only thing that
@@ -896,8 +909,10 @@ instead:
 That is the honest price of the distribution Paul asked for: symmetric, nobody
 disadvantaged, contracts going down about one extra time in every 24. Whether
 that is worse *play* or just a livelier game is a house-rules question and not a
-measurement one — which is why #204 is `ready-for-human` and why the dial ships
-wired-live and flag-off (#101) rather than being argued either way.
+measurement one — which is why #204 stayed `ready-for-human` and why the dial
+shipped wired-live and flag-off (#101) rather than being argued either way. It
+was never switched on, and #215 answered the house-rules question by retiring
+the arm rather than by leaving it disabled indefinitely.
 
 `bench/index.html` is the browser side of the latency measurement, served by
 `npm run dev` at `/bench/` (it follows `base`, which is `/`). It is never an

--- a/web/src/ab/ab.test.ts
+++ b/web/src/ab/ab.test.ts
@@ -21,7 +21,6 @@ import {
   BID_AB_POLICIES,
   DISTILLED_LEVEL,
   FOLD_AB_POLICIES,
-  OPENING_AB_POLICIES,
   PLAY_AB_POLICIES,
   SAFE_COUNTER_CONTROL,
   STATIC_LEVEL,
@@ -98,7 +97,7 @@ describe('the policy override', () => {
     // attributed to. Cheap to assert, and it is the assertion that keeps the
     // next map (#154 onward) honest as the union of policies grows.
     const safeCounter = safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)
-    const maps = [BID_AB_POLICIES, FOLD_AB_POLICIES, AUTO_SET_AB_POLICIES, PLAY_AB_POLICIES, OPENING_AB_POLICIES, safeCounter]
+    const maps = [BID_AB_POLICIES, FOLD_AB_POLICIES, AUTO_SET_AB_POLICIES, PLAY_AB_POLICIES, safeCounter]
     for (const policies of maps) {
       const [a, b] = Object.values(policies)
       const differing = (Object.keys(a) as (keyof typeof a)[]).filter((field) => a[field] !== b[field])
@@ -321,8 +320,6 @@ describe('the A/B self-test', () => {
     // the most scope to desynchronise dealer rotation or scoring between the
     // two orientations of a pair — exactly what a zero paired margin rules out.
     ['auto-set', DISTILLED_LEVEL, AUTO_SET_AB_POLICIES],
-    ['walk', DISTILLED_LEVEL, OPENING_AB_POLICIES],
-    ['fixed-open', STATIC_LEVEL, OPENING_AB_POLICIES],
     // #158's two arms, both of which now play behind auto-SET.
     ['counted', 'expert', safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)],
     ['uncounted', SAFE_COUNTER_CONTROL.expert, safeCounterAbPolicies('expert', SAFE_COUNTER_CONTROL.expert)],

--- a/web/src/ab/abRun.ts
+++ b/web/src/ab/abRun.ts
@@ -152,47 +152,6 @@ export const AUTO_SET_AB_POLICIES: Record<string, SkillParams> = {
 }
 
 /**
- * Opening-level A/B (#204): identical appetites, differing only in what number
- * a seat that has already decided to open actually names.
- *
- * Both arms bid `'distilled'`, fold with the model and play the cascade — the
- * same choice `FOLD_AB_POLICIES` and `PLAY_AB_POLICIES` make, and for the same
- * reason: this describes the change as it would ship on `hard` and above.
- *
- * What makes this map worth reading carefully is that the two arms do not
- * disagree about *which* hands are worth a contract. `openingPolicy` is
- * consulted only after `worthContract` has already returned true, so both sides
- * open on exactly the same deals and pass on exactly the same deals. The only
- * difference is the price on the table, which means a negative result here has
- * one clean interpretation — naming a higher number buys contracts that get
- * set — rather than being confounded with a change in how often the AI bids
- * at all.
- *
- * Side A (`DISTILLED_LEVEL`) carries the arm under test, matching every other
- * map in this file.
- */
-export const OPENING_AB_POLICIES: Record<string, SkillParams> = {
-  [STATIC_LEVEL]: {
-    handValuation: 'base_bid',
-    bidPolicy: 'distilled',
-    foldPolicy: 'model',
-    playPolicy: 'cascade',
-    autoSetPolicy: 'forced',
-    safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
-  },
-  [DISTILLED_LEVEL]: {
-    handValuation: 'base_bid',
-    bidPolicy: 'distilled',
-    foldPolicy: 'model',
-    playPolicy: 'cascade',
-    autoSetPolicy: 'forced',
-    safeCounterPolicy: 'counted',
-    openingPolicy: 'walk',
-  },
-}
-
-/**
  * Trick-play A/B (#153): identical bidders and identical folders, differing
  * only in which rule picks a card.
  *

--- a/web/src/ab/cli.ts
+++ b/web/src/ab/cli.ts
@@ -6,7 +6,6 @@
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts ab --pairs 400
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts fold --pairs 400
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts play --pairs 400
-//   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts opening --pairs 5000
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts autoset --pairs 5000
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts safe --pairs 400 --level expert
 //   node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts capacity --high expert --low easy
@@ -40,7 +39,6 @@ import {
   BID_AB_POLICIES,
   DISTILLED_LEVEL,
   FOLD_AB_POLICIES,
-  OPENING_AB_POLICIES,
   PLAY_AB_POLICIES,
   SAFE_COUNTER_CONTROL,
   STATIC_LEVEL,
@@ -62,8 +60,6 @@ const SELFTEST_ARMS: Record<string, { level: SkillLevel; policies: Record<string
   simple: { level: STATIC_LEVEL, policies: PLAY_AB_POLICIES },
   cascade: { level: DISTILLED_LEVEL, policies: PLAY_AB_POLICIES },
   'auto-set': { level: DISTILLED_LEVEL, policies: AUTO_SET_AB_POLICIES },
-  walk: { level: DISTILLED_LEVEL, policies: OPENING_AB_POLICIES },
-  'fixed-open': { level: STATIC_LEVEL, policies: OPENING_AB_POLICIES },
   // #158's two arms. `counted` doubles up the expert capacity against itself;
   // `uncounted` doubles up the baseline, which is the control that says the
   // safe-counter change is the only thing separating the two sides of a `safe`
@@ -109,20 +105,6 @@ if (command === 'fold') {
     labelA: 'auto-set',
     labelB: 'play-it-out',
     policies: AUTO_SET_AB_POLICIES,
-  })
-  console.log(summarise(report, analyse(report, seed)))
-} else if (command === 'opening') {
-  // #204's measurement: identical distilled bidders opening on identical hands,
-  // one naming `OPENING_BID` and one naming the highest rung its own policy
-  // still says the hand is worth.
-  const pairs = flag('pairs', 400)
-  const seed = flag('seed', 1)
-  const report = runAb({
-    nPairs: pairs,
-    seed,
-    labelA: 'walk',
-    labelB: 'fixed-open',
-    policies: OPENING_AB_POLICIES,
   })
   console.log(summarise(report, analyse(report, seed)))
 } else if (command === 'play') {

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -25,7 +25,6 @@ import {
 } from './bidding'
 import { ROYAL_MARRIAGE_VALUE, scoreMelds } from './melds'
 import { partnerOf } from './round'
-import { SKILL_PARAMS } from './skills'
 import type { PlayerIndex } from './trick'
 
 const trump = Suit.Spades
@@ -1052,111 +1051,6 @@ describe('raising over a bid our own team already holds (#206)', () => {
         passedPlayers: [],
       }
       expect(chooseBid(2, weakHand, oppBid, 10, context, 'hard')).toBe(oppBid + 10)
-    }
-  })
-})
-
-// -- openingPolicy: 'walk' (#204) -------------------------------------------
-//
-// No shipped `SKILL_PARAMS` row selects `'walk'`, so these install it the way
-// `abRun.ts` does. The measurement said `'fixed'` wins on score margin and the
-// dial ships off; these exist so the arm stays correct and re-measurable rather
-// than rotting into something the harness can no longer trust.
-describe("openingPolicy: 'walk'", () => {
-  // Base Bid 250 (Run 150 + two Royal Marriages 80 + Ace 20) -> ceiling 380 at
-  // the 0/0 adjustment, so it clears OPENER_THRESHOLD and has room above the
-  // opening rung for the walk to actually climb into.
-  const strongHand = [
-    ...RUN_RANKS.map((r) => new Card(Suit.Hearts, r, 1)),
-    new Card(Suit.Hearts, 'K', 2),
-    new Card(Suit.Hearts, 'Q', 2),
-  ]
-
-  // Dealer 1, so dealer-protection (which keys off the partner being dealer)
-  // does not fire and the opening branch is a hand judgement.
-  const context: AuctionContext = {
-    everBid: false,
-    passesSoFar: 0,
-    bidHistory: [],
-    dealer: 1,
-    scores: { 0: 0, 1: 0 },
-    passedPlayers: [],
-  }
-
-  const withWalk = (level: SkillLevel, run: () => void) => {
-    const saved = SKILL_PARAMS[level]
-    SKILL_PARAMS[level] = { ...saved, openingPolicy: 'walk' }
-    try {
-      run()
-    } finally {
-      SKILL_PARAMS[level] = saved
-    }
-  }
-
-  it('opens above OPENING_BID on a hand worth more than the opening rung', () => {
-    // The defect #204 names: `'fixed'` prices this hand at whatever rung the
-    // auction happens to start on, however much it is holding.
-    expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
-    withWalk('hard', () => {
-      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'hard')).toBeGreaterThan(OPENING_BID)
-    })
-  })
-
-  it('never opens a hand that would have passed — it changes price, not appetite', () => {
-    // `openingLevelFor` runs only once `opens` is already true, so both arms
-    // open on an identical set of deals. That is what lets #204's A/B attribute
-    // its result to the level named and not to a change in how often the AI
-    // bids at all.
-    const realRandom = Math.random
-    Math.random = seededRandom(20260820)
-    try {
-      for (let i = 0; i < 100; i++) {
-        const deck = new Deck()
-        deck.shuffle()
-        const hands = deck.deal()
-        for (const level of ['medium', 'hard'] as SkillLevel[]) {
-          for (const seat of SEATS) {
-            const fixed = chooseBid(seat, hands[seat], OPENING_BID - 10, 10, context, level)
-            withWalk(level, () => {
-              const walked = chooseBid(seat, hands[seat], OPENING_BID - 10, 10, context, level)
-              expect(walked === null).toBe(fixed === null)
-            })
-          }
-        }
-      }
-    } finally {
-      Math.random = realRandom
-    }
-  })
-
-  it('stays on the multiple-of-ten grid and never exceeds the hand ceiling (#177)', () => {
-    const realRandom = Math.random
-    Math.random = seededRandom(4242)
-    try {
-      withWalk('hard', () => {
-        for (let i = 0; i < 200; i++) {
-          const deck = new Deck()
-          deck.shuffle()
-          const hands = deck.deal()
-          const opened = chooseBid(0, hands[0], OPENING_BID - 10, 10, context, 'hard')
-          if (opened === null) continue
-          expect(opened % 10).toBe(0)
-          expect(opened).toBeGreaterThanOrEqual(OPENING_BID)
-          // The walk is ceiling-bounded; the opening *floor* is not — a
-          // distilled seat may take OPENING_BID on a hand whose speculative
-          // ceiling is under it, and always could. What must never happen is
-          // the walk carrying a seat above what its cards are worth.
-          expect(opened).toBeLessThanOrEqual(Math.max(OPENING_BID, bestBaseBid(hands[0], 0, 0).total))
-        }
-      })
-    } finally {
-      Math.random = realRandom
-    }
-  })
-
-  it('leaves every shipped level on the fixed opening rung', () => {
-    for (const level of SKILL_LEVELS) {
-      expect(SKILL_PARAMS[level].openingPolicy).toBe('fixed')
     }
   })
 })

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -205,42 +205,6 @@ export const THIRD_BIDDER_FLOOR = 200
  */
 export const PARTNER_PASSED_FLOOR = 320
 /**
- * How sure the evaluator has to be before an `openingPolicy: 'walk'` seat steps
- * its opening up another rung (#204).
- *
- * `modelDecision` uses the model's own `threshold` (0.5), which means a greedy
- * walk stops at the *highest* rung the model still tolerates — and that rung is
- * by construction the marginal one, where the model is barely past a coin flip.
- * Walking to it therefore lands the seat on the worst contract it is willing to
- * hold, systematically, on every deal it opens.
- *
- * That is the mechanism behind #204's headline result, and raising this number
- * buys it back, monotonically and at a fixed exchange rate. Measured on `hard`,
- * 3000 paired deals, seed 1, against the `'fixed'` arm:
- *
- * | confidence | avg bid | set % | margin/deal |
- * |---|---|---|---|
- * | 0.50 | 322 | 30.5% | -53 (-61 to -46) |
- * | 0.60 | 320 | 29.8% | -48 (-59 to -38) |
- * | 0.70 | 317 | 29.4% | -43 (-53 to -33) |
- * | 0.80 | 314 | 28.2% | -26 (-35 to -17) |
- * | 0.90 | 309 | 27.0% | -7 (-14 to +0) |
- *
- * There is no free rung on that curve: roughly three points of score margin per
- * point of bid lift, all the way down to the one setting whose CI touches zero,
- * which lifts the average bid by 8 and does not reach the distribution the
- * change was asked for. That is the finding, not a tuning failure — the model
- * was fitted to measured rollouts, and it is right that the cheap contract is a
- * good price.
- *
- * Left at the model's own threshold because that is the arm the three-seed
- * headline measurement ran, so the committed constant and the recorded number
- * describe the same thing. Anyone enabling `'walk'` should move this first and
- * re-measure, not inherit the greedy walk by default.
- */
-export const WALK_CONFIDENCE = 0.5
-
-/**
  * The bid a seat must commit to when it raises **over its own partner** (#206).
  *
  * Read `PARTNER_PASSED_FLOOR` above first; this is the same kind of number and
@@ -718,53 +682,6 @@ export function chooseBid(
         })
       : staticVerdict
 
-  // What number to put on the table once `opens` is true (#204). Under
-  // `'fixed'` — every shipped row today — that is the floor and nothing else,
-  // which is the behaviour this dial was split off to make measurable rather
-  // than to change. Under `'walk'` the seat steps up while its own policy still
-  // says the hand is worth the next rung, so the level it names reflects the
-  // hand it is holding instead of the rung the auction happens to start on.
-  //
-  // Bounded above by `ceiling`, so the walk cannot talk a seat past what its
-  // cards are worth, and it steps by `minIncrement` so it cannot leave the
-  // multiple-of-ten grid (#177). The static verdict keeps the cushion
-  // `OPENER_THRESHOLD` already implies over `OPENING_BID` — **20 points** at
-  // today's 320/300 pair — so a static seat asked about level L wants a
-  // ceiling of L + 20, which at the opening rung is exactly `OPENER_THRESHOLD`
-  // and stays self-consistent as the level climbs. Without that the
-  // level-independent static verdict would walk every opener to its ceiling.
-  //
-  // The cushion is derived rather than written down precisely because it is
-  // not a fixed quantity: it was 20 before #200, 70 while the opener sat at
-  // 250, and is 20 again since #257 put the opener back to 300. A narrower
-  // cushion is a more permissive walk — a static seat now accepts a level only
-  // 20 under its ceiling — so `'walk'` climbs further per hand than it did
-  // last week. That arm measured negative and is queued for deletion (#221);
-  // nothing shipped selects it, so this is a note, not a regression.
-  const openingLevelFor = (floor: number): number => {
-    if (SKILL_PARAMS[skill].openingPolicy !== 'walk') return floor
-    const cushion = OPENER_THRESHOLD - OPENING_BID
-    const accepts = (level: number): boolean =>
-      distilled
-        ? shouldBid(
-            {
-              hand,
-              bid: level,
-              ourScore: myScore,
-              theirScore: oppScore,
-              partnerHasBid,
-              partnerHasPassed: partnerPassed,
-            },
-            WALK_CONFIDENCE,
-          )
-        : ceiling >= level + cushion
-    let level = floor
-    while (level + minIncrement <= ceiling && accepts(level + minIncrement)) {
-      level += minIncrement
-    }
-    return level
-  }
-
   if (!context.everBid) {
     // One comparison, whether or not the partner has passed (#180). This read
     // `partnerPassed ? ceiling > OPENER_THRESHOLD : ceiling >= OPENER_THRESHOLD`
@@ -773,16 +690,25 @@ export function chooseBid(
     // retired the two branches say the same thing, so they are one. The level
     // being committed to still differs: a partner-passed seat opens at the
     // floor rather than at OPENING_BID.
+    //
+    // The level named here is the floor and nothing else, on purpose and not
+    // for want of asking. #204 split "should I open" from "at what level" and
+    // built `openingPolicy: 'walk'` to answer the second by stepping up while
+    // the seat's own policy still liked the next rung; over 5000 pairs on each
+    // of three seeds it lost 52-56 points per deal, and requiring more
+    // confidence per rung only bought the loss back by declining to walk. The
+    // arm was deleted by #221; the numbers stay in `web/README.md` under "What
+    // the opener puts on the table". Re-opening the question means re-running
+    // the measurement, not restoring the loop.
     const floorLevel = partnerPassed ? minBidAfterPartnerPass : OPENING_BID
     const opens = worthContract(floorLevel, ceiling >= OPENER_THRESHOLD)
-    const openingLevel = opens ? openingLevelFor(floorLevel) : floorLevel
 
     // 3rd bidder opens cheap — with a hand floor under it (#255).
     if (context.passesSoFar === 2) {
       if (myScore > 800) {
-        return opens ? openingLevel : null
+        return opens ? floorLevel : null
       }
-      if (opens) return openingLevel
+      if (opens) return floorLevel
       // The positional arm: the seat's own policy has said the hand is not
       // worth a contract, and this used to put `OPENING_BID` on the table
       // anyway to deny the last player a cheap one. It still does — but only
@@ -824,7 +750,7 @@ export function chooseBid(
 
     // Normal opener threshold (4th bidder / dealer — partner has already
     // had their turn, so no pass-out protection needed).
-    return opens ? openingLevel : null
+    return opens ? floorLevel : null
   }
 
   // Someone has already bid this auction.

--- a/web/src/engine/evaluator.ts
+++ b/web/src/engine/evaluator.ts
@@ -166,9 +166,8 @@ export function evaluateBid(situation: BidSituation): Evaluation {
 }
 
 /** True when the evaluator says taking the contract at `bid` beats defending it. */
-export function shouldBid(situation: BidSituation, threshold?: number): boolean {
-  const evaluation = evaluateBid(situation)
-  return threshold === undefined ? evaluation.decision : evaluation.probability >= threshold
+export function shouldBid(situation: BidSituation): boolean {
+  return evaluateBid(situation).decision
 }
 
 // -- The concede decision ---------------------------------------------------

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -140,33 +140,26 @@ export type SafeCounterPolicy = 'off' | 'counted'
  * What number a seat that decides to open actually puts on the table (#204).
  *
  *   `'fixed'`  open at `OPENING_BID` — 300 since #257 — whatever the hand is
- *              worth. What every level has always done.
- *   `'walk'`   open at the highest rung the seat's own bid policy still says
- *              the hand is worth, starting from `OPENING_BID` and stepping by
- *              the auction's minimum increment.
+ *              worth. What every level has always done, and now the only arm.
  *
- * The distinction exists because `chooseBid` asks two separable questions and
- * has only ever acted on the first: *should* I open, and *at what level*. The
- * opening branch answers the first with `worthContract(OPENING_BID, ...)` and
- * then hard-codes the second to `OPENING_BID`, so a seat holding a 400-ceiling
- * hand opens at the rung and, if the other three pass, buys the contract there.
- * Measured over 4000 AI-vs-AI auctions on `hard`, that is 27.4% of all deals,
- * and 44.5% of those hands were worth 320 or more. Those figures were taken
- * while `OPENING_BID` was 250 (#200) and have not been re-run since #257 put
- * it back to 300 — the shape of the finding survives the move, the exact
- * percentages are not claimed to.
+ * One member, because the other one was measured and lost. #204 split the two
+ * questions `chooseBid` conflates — *should* I open, and *at what level* — on
+ * the finding that 27.4% of all deals are an opener naming the rung on a hand
+ * worth far more, and added `'walk'` to answer the second by stepping up while
+ * the seat's own bid policy still said the next rung was worth it. Over 5000
+ * pairs on each of three seeds it lost 52, 56 and 53 points per deal, p < 1e-4
+ * throughout: it lifted the average bid 301 -> 322 and dropped its made rate
+ * 73.2% -> 69.2%, buying the distribution with sets. #221 deleted the arm under
+ * #215's retirement rule — three seeds, decisively negative, no shipped row
+ * selecting it, nothing baselined against it — and `web/README.md`'s "What the
+ * opener puts on the table" keeps the numbers, so the null result outlives the
+ * code.
  *
- * `'walk'` does not make a seat open on hands it would have passed: the loop
- * only runs once `opens` is already true, and it is bounded above by the
- * hand's own capped ceiling. It changes the *price*, not the *appetite*.
- *
- * This is a `SkillParams` field rather than a constant for the reason
- * `FoldPolicy` and `PlayPolicy` are: `abRun.ts` can only sit two rules at one
- * table by running two levels that differ in exactly one field, so a rule with
- * no field is a rule that cannot be measured. No shipped row selects `'walk'`
- * until #204's A/B says it should.
+ * The field is left in place rather than removed with the arm. Removing it
+ * touches every row of `SKILL_PARAMS` and of the `*_AB_POLICIES` maps, which is
+ * #222's diff, not this one.
  */
-export type OpeningPolicy = 'fixed' | 'walk'
+export type OpeningPolicy = 'fixed'
 
 export interface SkillParams {
   readonly handValuation: HandValuation


### PR DESCRIPTION
Closes #221

`openingPolicy: 'walk'` shipped disabled from #204 and is deleted here under the
retirement rule adopted in #215's decision comment. This is that rule's first
application.

## Both claims verified before deleting, not taken from the issue

**Nothing selects it.** All five `SKILL_PARAMS` rows in `web/src/engine/skills.ts`
read `openingPolicy: 'fixed'`. The only thing in the tree that set `'walk'` was
`OPENING_AB_POLICIES` in `web/src/ab/abRun.ts`, which never reaches the bundle.
No UI path can set the field: `OptionsPanel.tsx` exposes skill levels, not policy
fields, and `openingPolicy` appears nowhere outside `skills.ts`, `bidding.ts`,
`ab/` and their tests.

**It measured negative.** `web/README.md`, "What the opener puts on the table
(`openingPolicy`, #204)": 5000 pairs at each of three seeds, **-52 / -56 / -53**
score margin per deal against `'fixed'`, p < 1e-4 on every seed, CIs excluding
zero on all three. Direction confirmed - `walk` is the losing arm. The mechanism
is in the summary rows: average bid 301 -> 322, made rate 73.2% -> 69.2%,
auto-SET hands 7.1% -> 9.9%.

## What went, and why each thing was part of the arm

| removed | why |
|---|---|
| `'walk'` member of `OpeningPolicy` (`skills.ts`) | the arm |
| `WALK_CONFIDENCE` (`bidding.ts`) | its only reader was the walk loop |
| `openingLevelFor` (`bidding.ts`) | collapses to the identity without the walk branch, so the three call sites use `floorLevel` directly |
| the `OPENER_THRESHOLD - OPENING_BID` cushion | existed only to keep the static arm's walk self-consistent; this is the comment #257 stopped to correct from 70 to 20 |
| `shouldBid`'s `threshold` parameter (`evaluator.ts`) | added by #204 in the same commit, for no other caller; back to its pre-#204 shape |
| `OPENING_AB_POLICIES` (`ab/abRun.ts`) | see below |
| `cli.ts opening`, `--policy walk`, `--policy fixed-open` | the map's only consumers |

`OPENING_AB_POLICIES` going is what distinguishes this arm from the ones that
stay. `foldPolicy: 'never'`, `autoSetPolicy: 'off'` and `playPolicy: 'simple'`
are all retained because their A/B maps keep a live rule measurable - epic #152's
children are judged against `'simple'` specifically, so deleting it would end
that comparison. Nothing is baselined against `walk`.

## Tests deleted, not weakened

Four, all in `bidding.test.ts`'s `describe("openingPolicy: 'walk'")`:

- *opens above OPENING_BID on a hand worth more than the opening rung* - asserts the
  arm's headline behaviour. No arm.
- *never opens a hand that would have passed* - asserts appetite is unchanged
  between the two arms. One arm.
- *stays on the multiple-of-ten grid and never exceeds the hand ceiling (#177)* -
  bounds on the walk loop. No loop.
- *leaves every shipped level on the fixed opening rung* - the only one that could
  be argued for keeping, and it is subsumed rather than dropped: a one-member
  `OpeningPolicy` makes it a compile-time fact at every row, checked by `tsc` on
  all of `SKILL_PARAMS` and `*_AB_POLICIES`, instead of a runtime assertion over
  five levels.

Plus the two `walk` / `fixed-open` self-test rows in `ab.test.ts` and the map's
entry in the "varies exactly one field per policy map" list, both of which
reference the deleted map.

## The measurement is kept, deliberately

`web/README.md`'s #204 section is untouched apart from being made honest about
its own present tense. It now says the arm was deleted, by which issue, what went
with it, that `OpeningPolicy` is a one-member type, and that the runs are still
reproducible from the commit range #204 landed in even though they are no longer
reproducible from this tree. Retiring the code is not retracting the result: a
reader who wonders whether this engine has ever tried naming a higher opening
level has to find the answer, not an absence.

`bidding.ts` carries the short version at the line that names the level, so the
question cannot be re-opened from the code alone without meeting the number that
closed it.

## Scope

The `openingPolicy` field stays on `SkillParams` as a one-member type with no
branch behind it, which is what #221's "done when" asks for. Removing the field
means editing every row of `SKILL_PARAMS` and of the `*_AB_POLICIES` maps - that
is #222's diff, landing concurrently, and this branch touches **no** `SKILL_PARAMS`
row so the two should merge cleanly. The docstring records why the field outlives
its second arm.

No Python change. `pinochle_engine.py` has never had an opening-level policy;
#204 was TypeScript-only and this is its exact inverse, so #213 is satisfied by
there being nothing on the other side.

One line in `CODING_STANDARDS.md` moved rather than being left false: it cited
`OpeningPolicy` as an exemplar of "docstring says why an unselected arm exists",
which it can no longer be. `PlayPolicy` takes its place and the sentence points
at #223. That is a correction, not the rule - #223 still writes the rule.

## Notes for #223

Three things this deletion turned up that a written rule ought to say:

1. **Retire the introducing commit, not the arm's name.** Grepping for `'walk'`
   finds the union member, the constant and the loop. It does not find
   `shouldBid`'s `threshold` parameter, which #204 added in the same commit for
   the walk loop alone and which nothing else has ever passed. `git show --stat`
   on the commit that introduced the arm is the reliable list.
2. **Say where the deleted code is still runnable.** Deleting `OPENING_AB_POLICIES`
   and `cli.ts opening` means the recorded numbers can no longer be reproduced
   from `main`. That is fine, but the README section has to name the commit range
   they *are* reproducible from, or the result becomes unfalsifiable.
3. **Name the condition that separates a retired arm from a retained one.** All
   four #215 conditions were satisfiable here only because condition 4 - nothing
   baselined against it - is the one doing the work. `playPolicy: 'simple'` fails
   exactly that condition and is otherwise identical in shape. A rule that lists
   four conditions without saying which one usually decides will read as four
   equal hurdles.

There is also a small pre-existing gap noticed in passing and not fixed here:
`cli.ts`'s `usage` string never listed `opening` among its commands, so the
command was documented only in the file header. Worth a glance when the next
command is added.

## Verification

- `npm test -- --run --maxWorkers=2`: **42 files / 503 tests passed**, on a 509
  baseline. Six deleted (four in `bidding.test.ts`, two self-test arms in
  `ab.test.ts`), none broken. File count 42 = baseline, so not a #170 short run.
- `npx tsc --noEmit -p tsconfig.app.json`: clean.
- `npx oxlint`: three `react-hooks/exhaustive-deps` warnings, all pre-existing in
  `TrickPlayFlow.tsx` / `AuctionFlow.tsx`, none in a touched file.
- Python not run: no Python file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
