### PR TITLE
feat(ui): remove the difficulty setting; every seat plays the strongest AI (#222)

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -319,19 +319,30 @@ that note alive if you add another such rule.
   If you touch a file whose header describes a state of the world that
   has since changed, fix the header in the same PR.
 
-## AI behaviour goes on a dial, not behind a constant
+## AI behaviour goes on a policy field, not behind a constant
 
 New AI behaviour that could plausibly be measured becomes a field on
 `SkillParams` (`web/src/engine/skills.ts`) with a string-union type —
 not a boolean, not a bare constant. `abRun.ts` can only compare two
-rules by sitting two skill levels at one table that differ in exactly
-one field, so a rule with no field is a rule that cannot be measured.
+rules by sitting two policies at one table that differ in exactly one
+field, so a rule with no field is a rule that cannot be measured.
 
-Each policy type carries a docstring stating every arm, which arm each
-shipped row selects, and — when no shipped row selects an arm — why that
-arm still exists. `PlayPolicy`, `FoldPolicy` and `AutoSetPolicy` all
-do this. (`OpeningPolicy` stood here until #221 retired its losing arm
-and left it a one-member type; #223 is writing down when that is the
-right move.) A dial whose losing arm is retained for measurement is normal
-here (see `ROADMAP.md` on null results being recorded and shipped
-disabled); a dial with no such note is drift.
+This is a measuring instrument and not a difficulty dial, which it was
+also called until #222 removed the difficulty setting from the product.
+`SHIPPED_PARAMS` is the one configuration a player ever meets;
+`SKILL_PARAMS`' five level keys are slots `installPolicies` writes into,
+and `TRUMP_MEMORY_CAPACITY` is keyed on them. Nothing outside
+`web/src/ab/` should name a level other than `SHIPPED_SKILL`.
+
+Each policy type carries a docstring stating every arm, which arm
+`SHIPPED_PARAMS` selects, and — when the shipped configuration does not
+select an arm — why that arm still exists. `PlayPolicy`, `FoldPolicy`
+and `AutoSetPolicy` all do this, and `SHIPPED_PARAMS`' own docstring
+tabulates the answer for every field at once, so which columns are live
+is one read rather than six. A losing arm retained for measurement is
+normal here (see `ROADMAP.md` on null results being recorded and shipped
+disabled); an arm with no such note is drift. A field left with one
+member is neither — `OpeningPolicy` was that after #221 retired its
+losing arm, and #222 removed the field, because a field nothing can vary
+measures nothing. #223 is writing down when retiring an arm is the right
+move.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ measurement harness.
 
 The PWA in [`web/`](web/) is the product — a complete game against three
 AI opponents: deal, misdeal, auction, trump, 3-card pass, meld, trick
-play, round scoring, and multi-round games to ±1000, across five
-difficulty levels, with local autosave across a page reload. On a phone
+play, round scoring, and multi-round games to ±1000, with local
+autosave across a page reload. There is no difficulty setting: every
+seat plays the strongest AI the project has built (#222). On a phone
 it installs to the home screen and launches full-screen.
 
 **Deploys are manual, and merging does not ship.** GitHub is source
@@ -85,10 +86,11 @@ is where the next round of strategy work will run. See
     The distilled bid/fold model that `export_evaluator.py` generates
     from the Python rollouts, alongside `evaluatorParity.fixture.ts` /
     `evaluatorParity.test.ts`, which fail the TS suite if the two sides
-    ever compute different features. `skills.ts`'s `SKILL_PARAMS` is the
-    difficulty dial (`easy` through `expert`): `hard` and above bid with
-    the distilled evaluator, and all five levels fold with it and play
-    trick cards the same way (#156).
+    ever compute different features. `skills.ts`'s `SHIPPED_PARAMS` is
+    the one configuration every seat plays: distilled bidding, cascade
+    card play, model folding, forced auto-SET, counted safe counters,
+    and trump memory of 10 of 12. `SKILL_PARAMS` still keys five slots,
+    which is what `src/ab/` seats two differing policies on.
   - `src/components/` — the UI and the reducers behind it.
     `gameFlowReducer.ts` drives a round end to end; `auctionReducer.ts`
     and `trickPlayReducer.ts` own the auction and trick phases. The
@@ -345,18 +347,24 @@ tuning baseline for a rule the shipped game already follows. See
   UI-layer state here rather than in the engine.
 - **The shipped AI is a distilled model, not a rollout.** `evaluator.ts`
   consults `evaluatorModel.ts`'s weights instead of thresholds like
-  `OPENER_THRESHOLD`. `skills.ts`'s `SKILL_PARAMS` is the dial: `hard`
-  and above bid with the model, `easy` and `medium` keep the hand-tuned
-  constants on purpose (the model distils *skill 5*, so wiring it into
-  `easy` would delete the tier rather than calibrate it), and **all five
-  levels fold with it** — conceding and being set cost the bidding team
-  the same (`-bid`, meld forfeited either way) while a fold denies the
-  defenders their trick points, so folding well is shared competence
-  rather than part of the difficulty dial. **All five also play trick
-  cards identically** (`playPolicy: 'cascade'`, #156): a weak bid is
-  invisible to the other seats, a weak card is face up on the table and
-  reads as a broken partner rather than an easy opponent. The dial is
-  what a level is willing to *bid*.
+  `OPENER_THRESHOLD`. `skills.ts`'s `SHIPPED_PARAMS` names the one
+  configuration every seat plays, and its docstring is the single place
+  that says which policy arms are live and which exist only for `ab/`.
+- **There is no difficulty setting** (#222). There were five engine
+  levels and three panel rows, and the rows were byte-identical apart
+  from how much trump each seat could remember — a control worth about
+  four points a deal, which is to say one a player cannot feel. Epic
+  #215's answer was to stop offering it rather than to manufacture a
+  span, so the strongest configuration became the only one. Most of the
+  ladder was already gone before that: folding is shared competence
+  (conceding and being set cost the bidding team the same, `-bid` with
+  meld forfeited either way, while a fold denies the defenders their
+  trick points), and trick play has been identical everywhere since
+  #156, because a weak bid is invisible to the other seats while a weak
+  card is face up on the table and reads as a broken partner rather than
+  an easy opponent. `SkillLevel` survives as five *slots*, not tiers:
+  `src/ab/` seats two differing policies on them to measure a rule, and
+  `TRUMP_MEMORY_CAPACITY` is keyed on them.
 - **A contract the arithmetic has already killed never gets played**
   (auto-SET, #178). When the bidding team's meld plus every trick point
   in the round — `MAX_TRICK_POINTS`, derived in `round.ts`, 250 today —

--- a/pinochle_rules.md
+++ b/pinochle_rules.md
@@ -371,13 +371,15 @@ scores against the Python model so the two sides cannot drift.
 On the TS side the decision entry points are `chooseBid` /
 `chooseTrump` (`bidding.ts`), `choosePassCards` (`passing.ts`),
 `chooseLeadCard` / `chooseFollowCard` (`tracker.ts`), and `shouldBid` /
-`shouldConcede` (`evaluator.ts`). `SKILL_PARAMS` in `skills.ts` is the
-dial: `hard` and above bid with the distilled evaluator, `easy` and
-`medium` keep the hand-tuned constants, and **all five levels fold with
-the model** — a fold costs the same as being set (`-bid`, meld
+`shouldConcede` (`evaluator.ts`). `SHIPPED_PARAMS` in `skills.ts` says
+what every seat plays: the distilled evaluator for bidding, and the
+model for folding — a fold costs the same as being set (`-bid`, meld
 forfeited either way) and denies the defenders their trick points, so
-it is strictly dominant and belongs to shared competence rather than to
-the difficulty dial.
+it is strictly dominant and was never a difficulty setting. There is no
+difficulty setting at all since #222; the five `SKILL_PARAMS` keys are
+slots `web/src/ab/` measures with. Python keeps its own 1-5 skill dial
+(`GENERAL_STRATEGY_SKILL_PARAMS`), which is research apparatus and not
+a shipped control.
 
 Any strategy change is judged on a paired A/B run over identical deals
 with the seats mirrored, not on impressions: `ab_harness.py` in Python,

--- a/web/README.md
+++ b/web/README.md
@@ -31,8 +31,10 @@ npm test        # vitest
   `round.ts`, `game.ts`, `misdeal.ts`, and `names.ts`/`teamNames.ts`. Those
   tests cover the same edge cases as the Python `__main__` self-checks (Double
   Run vs. Run, Double Pinochle vs. Pinochle, etc.) plus additional coverage.
-  Alongside them: `skills.ts` (`SKILL_PARAMS`, the five-level difficulty
-  dial), the shipped AI (`evaluator.ts`), and two generated fixture pairs that
+  Alongside them: `skills.ts` (`SHIPPED_PARAMS`, the one AI configuration the
+  product plays, and the five `SKILL_PARAMS` slots `src/ab/` measures with —
+  there is no difficulty setting since #222), the shipped AI (`evaluator.ts`),
+  and two generated fixture pairs that
   check this engine against the Python reference and are never hand-edited —
   `evaluatorModel.ts` + `evaluatorParity.*` from `../export_evaluator.py`, and
   `engineParity.*` from `../export_parity_scenarios.py` (described below).
@@ -92,8 +94,8 @@ TS failure.
 
 ## Measuring the AI (`src/ab/`)
 
-`chooseBid` runs one of two policies per skill level (`SKILL_PARAMS.bidPolicy`
-in `src/engine/skills.ts`): the hand-tuned thresholds that predate epic #104, or
+`chooseBid` runs one of two policies, selected by `SKILL_PARAMS.bidPolicy`
+(`src/engine/skills.ts`): the hand-tuned thresholds that predate epic #104, or
 the evaluator distilled from the Python rollout AI. Issue #115 had to decide
 whether the second is worth switching on, which `ab_harness.py` cannot answer
 because both sides are TypeScript.

--- a/web/src/ab/ab.test.ts
+++ b/web/src/ab/ab.test.ts
@@ -13,9 +13,8 @@
 
 import { describe, expect, it } from 'vitest'
 import type { TeamId } from '../engine/round'
-import { SKILL_PARAMS } from '../engine/skills'
+import { SKILL_PARAMS, type SkillLevel } from '../engine/skills'
 import type { PlayerIndex } from '../engine/trick'
-import type { SkillLevel } from '../persistence/options'
 import {
   AUTO_SET_AB_POLICIES,
   BID_AB_POLICIES,

--- a/web/src/ab/abRun.ts
+++ b/web/src/ab/abRun.ts
@@ -48,10 +48,9 @@
 // only thing differing between them is which rule answers "is this hand worth a
 // contract here".
 
-import { SKILL_PARAMS, type SkillParams } from '../engine/skills'
+import { SKILL_PARAMS, type SkillLevel, type SkillParams } from '../engine/skills'
 import type { TeamId } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
-import type { SkillLevel } from '../persistence/options'
 import { type SideStats, makeRng, newSideStats, playHeadlessGame } from './headlessGame'
 import { binomialTwoSidedP, bootstrapMeanCi, wilsonInterval } from './stats'
 
@@ -70,7 +69,6 @@ export const BID_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -79,7 +77,6 @@ export const BID_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
   },
 }
 
@@ -100,7 +97,6 @@ export const FOLD_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -109,7 +105,6 @@ export const FOLD_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
   },
 }
 
@@ -138,7 +133,6 @@ export const AUTO_SET_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'off',
     safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -147,7 +141,6 @@ export const AUTO_SET_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
   },
 }
 
@@ -182,7 +175,6 @@ export const PLAY_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'simple',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
   },
   [DISTILLED_LEVEL]: {
     handValuation: 'base_bid',
@@ -191,7 +183,6 @@ export const PLAY_AB_POLICIES: Record<string, SkillParams> = {
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
   },
 }
 
@@ -239,7 +230,6 @@ export function safeCounterAbPolicies(
       playPolicy: 'cascade',
       autoSetPolicy: 'forced',
       safeCounterPolicy: 'counted',
-      openingPolicy: 'fixed',
     },
     [offLevel]: {
       handValuation: 'base_bid',
@@ -248,7 +238,6 @@ export function safeCounterAbPolicies(
       playPolicy: 'cascade',
       autoSetPolicy: 'forced',
       safeCounterPolicy: 'off',
-      openingPolicy: 'fixed',
     },
   }
 }
@@ -293,7 +282,6 @@ export function safeCounterCapacityPolicies(
     playPolicy: 'cascade',
     autoSetPolicy: 'forced',
     safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
   }
   return { [highLevel]: counted, [lowLevel]: counted }
 }

--- a/web/src/ab/cli.ts
+++ b/web/src/ab/cli.ts
@@ -32,8 +32,7 @@
 // the rest of the engine, and paying for that with one cast is the cheaper
 // trade than a second tsconfig project.
 
-import type { SkillParams } from '../engine/skills'
-import type { SkillLevel } from '../persistence/options'
+import type { SkillLevel, SkillParams } from '../engine/skills'
 import {
   AUTO_SET_AB_POLICIES,
   BID_AB_POLICIES,

--- a/web/src/ab/headlessGame.ts
+++ b/web/src/ab/headlessGame.ts
@@ -36,11 +36,10 @@ import { checkGameOutcome } from '../engine/game'
 import { isMisdealEligible } from '../engine/misdeal'
 import { PASS_COUNT, choosePassCards } from '../engine/passing'
 import { type Hands, isAutoSet, playTrickTakingPhase, scoreRound, teamOf, type TeamId } from '../engine/round'
-import { SKILL_PARAMS } from '../engine/skills'
+import { SKILL_PARAMS, type SkillLevel } from '../engine/skills'
 import { PlayTracker, chooseFollowCard, chooseLeadCard } from '../engine/tracker'
 import { newTrumpMemories } from '../engine/trumpMemory'
 import type { PlayerIndex } from '../engine/trick'
-import type { SkillLevel } from '../persistence/options'
 
 const SEATS: readonly PlayerIndex[] = [0, 1, 2, 3]
 const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'S0', 1: 'S1', 2: 'S2', 3: 'S3' }

--- a/web/src/ab/latency.ts
+++ b/web/src/ab/latency.ts
@@ -24,7 +24,7 @@
 import { type AuctionContext, chooseBid } from '../engine/bidding'
 import { MIN_BID_INCREMENT, type Card } from '../engine/card'
 import type { PlayerIndex } from '../engine/trick'
-import type { SkillLevel } from '../persistence/options'
+import type { SkillLevel } from '../engine/skills'
 import { type BidSituationSample, makeRng, playHeadlessGame } from './headlessGame'
 import { DISTILLED_LEVEL, STATIC_LEVEL, installPolicies } from './abRun'
 import { percentile } from './stats'

--- a/web/src/components/AuctionFlow.test.tsx
+++ b/web/src/components/AuctionFlow.test.tsx
@@ -8,7 +8,8 @@ import { AI_BID_DELAY_MS, AuctionFlow } from './AuctionFlow'
 import type { AuctionState } from './auctionReducer'
 import { auctionReducer, initAuctionState, passedPlayersOf } from './auctionReducer'
 import type { AuctionResult } from './auctionTypes'
-import { DEFAULT_OPTIONS, type GameOptions, type SkillLevel } from '../persistence/options'
+import { SKILL_LEVELS, type SkillLevel } from '../engine/skills'
+import { DEFAULT_OPTIONS } from '../persistence/options'
 
 const SEAT_NAMES: Record<PlayerIndex, string> = { 0: 'You', 1: 'West', 2: 'Partner', 3: 'East' }
 const SCORES = { 0: 0, 1: 0 }
@@ -365,21 +366,28 @@ describe('AuctionFlow (component)', { timeout: 20_000 }, () => {
   })
 
   /**
-   * The pass is three cards at every skill level, end to end (#196).
+   * The pass is three cards, end to end (#196).
    *
    * Paul's dad reported that changing the AI skill let him pass **4** cards.
    * `passing.test.ts` fixes the count in the engine; this fixes it where he
-   * actually saw it — the wiring from `GameOptions` through `AuctionFlow` into
-   * the selector's `count` prop, and the selector's own refusal of a fourth.
+   * actually saw it — the wiring from `AuctionFlow` into the selector's `count`
+   * prop, and the selector's own refusal of a fourth.
    *
    * `PassSelector.test.tsx` already proves the component honours whatever
    * `count` it is handed, and that is exactly the gap: a component that
    * faithfully enforces the wrong number passes its own suite. The number has to
    * be checked where it is chosen.
+   *
+   * This ran five times, once per skill the panel could store, because the
+   * report named that setting. #222 removed it: `GameOptions` no longer carries
+   * a level, so the five cases became five identical renders of one option
+   * blob. What the report was actually about — that nothing outside
+   * `PASS_COUNT` decides how many cards leave a hand — is pinned across every
+   * configuration the engine still has, in `passing.test.ts`.
    */
-  it.each(['easy', 'medium', 'hard', 'proficient', 'expert'] as const)(
-    'asks the human for exactly 3 cards, and refuses a 4th, at skill %s',
-    (skill) => {
+  it(
+    'asks the human for exactly 3 cards, and refuses a 4th',
+    () => {
       vi.useFakeTimers()
       const hands = buildTestHands()
 
@@ -390,7 +398,7 @@ describe('AuctionFlow (component)', { timeout: 20_000 }, () => {
           humanPlayer={0}
           dealer={3}
           scoresByTeam={SCORES}
-          options={{ ...DEFAULT_OPTIONS, opponentSkill: skill, teammateSkill: skill } as GameOptions}
+          options={DEFAULT_OPTIONS}
           onComplete={vi.fn()}
         />,
       )
@@ -428,12 +436,19 @@ describe('AuctionFlow (component)', { timeout: 20_000 }, () => {
  * leave a seat holding 11 or 13 and satisfy every test above — and "my hand has
  * the wrong number of cards" is precisely the shape of the original report.
  *
- * So this runs the real exchange over real deals at every skill and asserts the
- * two properties that make it a *pass* rather than a rewrite: every seat still
- * holds twelve, and the 48 distinct cards of the deck are all still somewhere.
+ * So this runs the real exchange over real deals across every level slot and
+ * asserts the two properties that make it a *pass* rather than a rewrite: every
+ * seat still holds twelve, and the 48 distinct cards of the deck are all still
+ * somewhere.
+ *
+ * Since #222 the five slots all hold one configuration, so the sweep varies the
+ * deal, the trump and the bidder seat rather than the policy — which is what
+ * this test was ever about, since conservation is a property of the reducer and
+ * not of how the cards were chosen. `passing.test.ts` is where both valuation
+ * paths are still covered.
  */
 describe('the pass exchange conserves the deck (#196)', () => {
-  const SKILLS: readonly SkillLevel[] = ['easy', 'medium', 'hard', 'proficient', 'expert']
+  const SKILLS: readonly SkillLevel[] = SKILL_LEVELS
   const TRUMPS = [Suit.Spades, Suit.Diamonds, Suit.Clubs, Suit.Hearts] as const
 
   it('leaves every seat on 12 cards and all 48 cards in play', () => {

--- a/web/src/components/AuctionFlow.tsx
+++ b/web/src/components/AuctionFlow.tsx
@@ -4,7 +4,6 @@ import { MIN_BID_INCREMENT, OPENING_BID } from '../engine/card'
 import { PASS_COUNT, choosePassCards } from '../engine/passing'
 import { partnerOf, teamOf, type Hands, type TeamId } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
-import type { SkillLevel } from '../persistence/options'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { auctionReducer, initAuctionState, passedPlayersOf } from './auctionReducer'
 import type { AuctionResult } from './auctionTypes'
@@ -18,10 +17,11 @@ import { TrumpSelector } from './TrumpSelector'
 
 export const AI_BID_DELAY_MS = 600
 
-/** Returns the SkillLevel to use for a given AI player, based on options. */
-function skillForPlayer(player: PlayerIndex, humanPlayer: PlayerIndex, options: GameOptions): SkillLevel {
-  return partnerOf(player) === humanPlayer ? options.teammateSkill : options.opponentSkill
-}
+// Every AI seat plays `SHIPPED_SKILL` since #222 removed the difficulty
+// setting, so nothing here names a level: `chooseBid`, `chooseTrump` and
+// `choosePassCards` all default to it. This file used to carry a
+// `skillForPlayer` that read `options.teammateSkill`/`opponentSkill`, and
+// `TrickPlayFlow` carried a byte-identical copy of it (#240).
 
 export interface AuctionFlowProps {
   initialHands: Hands
@@ -65,8 +65,7 @@ export function AuctionFlow({
         scores: state.scoresByTeam,
         passedPlayers: passedPlayersOf(state.bidding.active),
       }
-      const skill = skillForPlayer(turn, humanPlayer, options)
-      const decision = chooseBid(turn, state.hands[turn], state.bidding.currentBid, MIN_BID_INCREMENT, context, skill)
+      const decision = chooseBid(turn, state.hands[turn], state.bidding.currentBid, MIN_BID_INCREMENT, context)
       const timer = setTimeout(() => {
         if (decision === null) dispatch({ type: 'PASS_BID', player: turn })
         else dispatch({ type: 'BID', player: turn, amount: decision })
@@ -77,8 +76,7 @@ export function AuctionFlow({
     if (state.phase === 'trump') {
       if (state.bidWinner === null || state.bidWinner === humanPlayer) return
       const bidWinner = state.bidWinner
-      const skill = skillForPlayer(bidWinner, humanPlayer, options)
-      const suit = chooseTrump(state.hands[bidWinner], skill)
+      const suit = chooseTrump(state.hands[bidWinner])
       const timer = setTimeout(() => {
         dispatch({ type: 'CHOOSE_TRUMP', player: bidWinner, suit })
       }, AI_BID_DELAY_MS)
@@ -106,13 +104,11 @@ export function AuctionFlow({
 
       const timer = setTimeout(() => {
         if (bidder !== humanPlayer && !bidderReady) {
-          const skill = skillForPlayer(bidder, humanPlayer, options)
-          const cards = choosePassCards(state.hands[bidder], PASS_COUNT, state.trumpSuit!, true, skill)
+          const cards = choosePassCards(state.hands[bidder], PASS_COUNT, state.trumpSuit!, true)
           dispatch({ type: 'PASS_CARDS', from: bidder, cards })
         }
         if (partner !== humanPlayer && !partnerReady) {
-          const skill = skillForPlayer(partner, humanPlayer, options)
-          const cards = choosePassCards(state.hands[partner], PASS_COUNT, state.trumpSuit!, false, skill)
+          const cards = choosePassCards(state.hands[partner], PASS_COUNT, state.trumpSuit!, false)
           dispatch({ type: 'PASS_CARDS', from: partner, cards })
         }
       }, AI_BID_DELAY_MS)

--- a/web/src/components/OptionsPanel.test.tsx
+++ b/web/src/components/OptionsPanel.test.tsx
@@ -6,10 +6,10 @@ import { OptionsPanel } from './OptionsPanel'
 afterEach(cleanup)
 
 describe('OptionsPanel', () => {
-  it('reflects the current options in the checkboxes and selects', () => {
+  it('reflects the current options in the checkboxes', () => {
     render(
       <OptionsPanel
-        options={{ showBaseBidHint: false, opponentSkill: 'proficient', teammateSkill: 'hard', hideTrickLog: false }}
+        options={{ showBaseBidHint: false, hideTrickLog: false }}
         onChange={() => {}}
         onClose={() => {}}
       />,
@@ -17,8 +17,6 @@ describe('OptionsPanel', () => {
     expect((screen.getByLabelText('Show base-bid hint') as HTMLInputElement).checked).toBe(false)
     // The trick-log checkbox is phrased positively, so it reads the inverse of the field.
     expect((screen.getByLabelText('Show trick-play log') as HTMLInputElement).checked).toBe(true)
-    expect((screen.getByLabelText('Opponents') as HTMLSelectElement).value).toBe('proficient')
-    expect((screen.getByLabelText('Teammate') as HTMLSelectElement).value).toBe('hard')
   })
 
   // #142 removed the "Hide opponent cards" toggle — opponents' fans are now
@@ -60,10 +58,17 @@ describe('OptionsPanel', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('has skill-level controls for Opponent and Teammate (#79)', () => {
+  // #79 put per-seat difficulty selects here and #194 renamed them; #222 took
+  // the setting out of the product, so the panel must not offer it again — the
+  // same shape of guard the two removals above carry. Asserting on the word as
+  // well as the labels, since the control could come back under any name.
+  it('has no difficulty control (#222)', () => {
     render(<OptionsPanel options={DEFAULT_OPTIONS} onChange={() => {}} onClose={() => {}} />)
-    expect(screen.getByLabelText('Opponents')).toBeTruthy()
-    expect(screen.getByLabelText('Teammate')).toBeTruthy()
+    expect(screen.queryByLabelText('Opponents')).toBeNull()
+    expect(screen.queryByLabelText('Teammate')).toBeNull()
+    expect(screen.queryByText(/skill/i)).toBeNull()
+    expect(screen.queryByText(/difficulty/i)).toBeNull()
+    expect(screen.queryAllByRole('combobox')).toHaveLength(0)
   })
 
 

--- a/web/src/components/OptionsPanel.tsx
+++ b/web/src/components/OptionsPanel.tsx
@@ -1,4 +1,4 @@
-import { SELECTABLE_SKILLS, type GameOptions, type SelectableSkill } from '../persistence/options'
+import type { GameOptions } from '../persistence/options'
 
 export interface OptionsPanelProps {
   options: GameOptions
@@ -7,23 +7,19 @@ export interface OptionsPanelProps {
 }
 
 /**
- * Plain Easy/Medium/Hard (#194), replacing the five-rung Novice ... Master
- * ladder. Paul's dad tried the old settings and could not tell what they meant,
- * which is fair: "Journeyman" against "Expert" is not a difficulty, it is a
- * guild rank, and two of the five rungs are gone now anyway.
+ * Two display toggles, and no difficulty control (#222).
  *
- * The keys are engine tier names and the values are what a player reads. That
- * split is not new — this panel already showed `proficient` as "Expert" and
- * `expert` as "Master". `SELECTABLE_SKILLS` is the single source of truth for
- * which tiers are offered and in what order; see `options.ts` for why the engine
- * still defines five while only three are reachable.
+ * The panel offered Easy/Medium/Hard for opponents and teammate separately
+ * (#79, renamed by #194). Those three rows selected engine levels that were
+ * byte-identical apart from how much trump each seat could remember, which
+ * epic #215 measured at roughly four points a deal — a setting a player cannot
+ * feel is worse than no setting, because it invites them to blame it. So the
+ * control is gone rather than defaulted or hidden, and every seat plays
+ * `SHIPPED_SKILL` (`engine/skills.ts`).
+ *
+ * Nothing replaces it here. If a difficulty setting comes back it should be a
+ * span someone has measured first, not three names over one configuration.
  */
-const SKILL_LABELS: Record<SelectableSkill, string> = {
-  hard: 'Easy',
-  proficient: 'Medium',
-  expert: 'Hard',
-}
-
 export function OptionsPanel({ options, onChange, onClose }: OptionsPanelProps) {
   return (
     <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/70 p-4">
@@ -46,34 +42,6 @@ export function OptionsPanel({ options, onChange, onClose }: OptionsPanelProps) 
               onChange={(e) => onChange({ ...options, hideTrickLog: !e.target.checked })}
             />
             Show trick-play log
-          </label>
-
-          <hr className="my-1 border-neutral-200" />
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Skill Level</h3>
-
-          <label className="flex items-center justify-between gap-2">
-            <span>Opponents</span>
-            <select
-              className="rounded border border-neutral-300 px-2 py-1 text-sm"
-              value={options.opponentSkill}
-              onChange={(e) => onChange({ ...options, opponentSkill: e.target.value as SelectableSkill })}
-            >
-              {SELECTABLE_SKILLS.map((s) => (
-                <option key={s} value={s}>{SKILL_LABELS[s]}</option>
-              ))}
-            </select>
-          </label>
-          <label className="flex items-center justify-between gap-2">
-            <span>Teammate</span>
-            <select
-              className="rounded border border-neutral-300 px-2 py-1 text-sm"
-              value={options.teammateSkill}
-              onChange={(e) => onChange({ ...options, teammateSkill: e.target.value as SelectableSkill })}
-            >
-              {SELECTABLE_SKILLS.map((s) => (
-                <option key={s} value={s}>{SKILL_LABELS[s]}</option>
-              ))}
-            </select>
           </label>
         </div>
 

--- a/web/src/components/TrickPlayFlow.test.tsx
+++ b/web/src/components/TrickPlayFlow.test.tsx
@@ -15,7 +15,7 @@ import { Card, Deck, Suit } from '../engine/card'
 import type { Hands } from '../engine/round'
 import type { PlayerIndex } from '../engine/trick'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
-import { SKILL_PARAMS } from '../engine/skills'
+import { SHIPPED_SKILL, SKILL_PARAMS } from '../engine/skills'
 import { AI_PLAY_DELAY_MS, TRICK_SETTLE_MS, TrickPlayFlow } from './TrickPlayFlow'
 import { CLAIMABLE_TRUMP, claimableHands } from './claimablePosition.fixture'
 import { initTrickPlayState, type TrickPlayState } from './trickPlayReducer'
@@ -34,12 +34,13 @@ const SCORES = { 0: 0, 1: 0 }
  * Those tests are about legal-move highlighting, not folding, so they pin the
  * fold off rather than contriving meld to talk the model out of it. Save and
  * restore of a `SKILL_PARAMS` entry is the same shape `abRun.installPolicies`
- * uses, and the entry that matters is whichever one `DEFAULT_OPTIONS` puts the
- * AI seats on — **read from it, not named**. #194 changed that default from
- * `hard` to `proficient`, and while this file hardcoded `hard` the patch landed
- * on a tier nobody was playing: the fold stayed on, the bid winner conceded
- * before the first lead, and tests about which cards are clickable failed with
- * no cards on the table.
+ * uses, and the entry that matters is the one every seat plays — **read from
+ * `SHIPPED_SKILL`, not named**. This file used to hardcode `hard` while #194
+ * had moved the default to `proficient`, so the patch landed on a tier nobody
+ * was playing: the fold stayed on, the bid winner conceded before the first
+ * lead, and tests about which cards are clickable failed with no cards on the
+ * table. #222 left one configuration, which removes the way to get that wrong
+ * rather than the need to read it from the source.
  *
  * This is *not* enough on its own since #178. Auto-SET is arithmetic, not a
  * policy, so it fires whatever the dial says — and the minimum bid is 300
@@ -49,7 +50,7 @@ const SCORES = { 0: 0, 1: 0 }
  * team enough meld to clear the floor. `LIVE_MELD` is that floor with room to
  * spare; see `MAX_TRICK_POINTS` in `round.ts`.
  */
-const AI_TIER = DEFAULT_OPTIONS.opponentSkill
+const AI_TIER = SHIPPED_SKILL
 const PRISTINE_TIER = SKILL_PARAMS[AI_TIER]
 function disableAiFold() {
   SKILL_PARAMS[AI_TIER] = { ...PRISTINE_TIER, foldPolicy: 'never' }

--- a/web/src/components/TrickPlayFlow.tsx
+++ b/web/src/components/TrickPlayFlow.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type { Card, Suit } from '../engine/card'
 import { shouldConcede } from '../engine/evaluator'
-import { isAutoSet, partnerOf, teamOf, type Hands, type TeamId } from '../engine/round'
-import { SKILL_PARAMS } from '../engine/skills'
+import { isAutoSet, teamOf, type Hands, type TeamId } from '../engine/round'
+import { SHIPPED_SKILL, SKILL_PARAMS } from '../engine/skills'
 import { chooseFollowCard, chooseLeadCard, PlayTracker } from '../engine/tracker'
 import { newTrumpMemories } from '../engine/trumpMemory'
 import type { PlayerIndex } from '../engine/trick'
-import type { SkillLevel } from '../persistence/options'
 import { DEFAULT_OPTIONS, type GameOptions } from '../persistence/options'
 import { DEFAULT_TEAM_NAMES } from './scoreTypes'
 import { Table } from './Table'
@@ -78,10 +77,12 @@ export interface TrickPlayFlowProps {
 export const AI_PLAY_DELAY_MS = 700
 export const TRICK_SETTLE_MS = 1200
 
-/** Returns the SkillLevel to use for a given AI player, based on options. */
-function skillForPlayer(player: PlayerIndex, humanPlayer: PlayerIndex, options: GameOptions): SkillLevel {
-  return partnerOf(player) === humanPlayer ? options.teammateSkill : options.opponentSkill
-}
+// Every seat at the table plays `SHIPPED_SKILL` since #222 removed the
+// difficulty setting — including, for `newTrumpMemories` below, the human's,
+// whose memory nothing reads. This file and `AuctionFlow` each carried a copy
+// of a `skillForPlayer` that mapped the seat to `options.teammateSkill` or
+// `options.opponentSkill`; #240 noticed the duplication and left it for this
+// change, which resolves it by deleting both rather than extracting a third.
 
 /**
  * Drives the trick-taking phase (#35): legal-move highlighting on the
@@ -141,9 +142,7 @@ export function TrickPlayFlow({
   // makes every seat *more* cautious than it would have been — the safe
   // direction, since an under-count can only ever read as "this card can still
   // be beaten" and never the other way round.
-  const trumpMemoriesRef = useRef(
-    newTrumpMemories(hands, trumpSuit, (seat) => skillForPlayer(seat, humanPlayer, options)),
-  )
+  const trumpMemoriesRef = useRef(newTrumpMemories(hands, trumpSuit))
   const completedRef = useRef(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   // Set when the auto-SET rule (#178) fires, cleared when the player
@@ -208,9 +207,7 @@ export function TrickPlayFlow({
     }
 
     if (bidWinner === humanPlayer) return
-
-    const skill = skillForPlayer(bidWinner, humanPlayer, options)
-    if (SKILL_PARAMS[skill].foldPolicy !== 'model') return
+    if (SKILL_PARAMS[SHIPPED_SKILL].foldPolicy !== 'model') return
 
     if (
       shouldConcede({
@@ -236,7 +233,6 @@ export function TrickPlayFlow({
       const trick = buildTrick(state.trumpSuit, state.currentTrick)
       const legal = trick.legalMoves(hand)
       const isBidderFirstLead = state.trickNumber === 0 && player === state.bidWinner && state.currentTrick.length === 0
-      const skill = skillForPlayer(player, humanPlayer, options)
       const isBiddingTeam = teamOf(player) === teamOf(state.bidWinner)
       const card =
         state.currentTrick.length === 0
@@ -245,7 +241,7 @@ export function TrickPlayFlow({
               state.trumpSuit,
               trackerRef.current,
               isBidderFirstLead,
-              skill,
+              SHIPPED_SKILL,
               isBiddingTeam,
               trumpMemoriesRef.current[player],
             )
@@ -256,7 +252,7 @@ export function TrickPlayFlow({
               state.trumpSuit,
               teammatesOf(player),
               trackerRef.current,
-              skill,
+              SHIPPED_SKILL,
               trumpMemoriesRef.current[player],
             )
       notePlayed(card)

--- a/web/src/engine/bidding.test.ts
+++ b/web/src/engine/bidding.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
-import type { SkillLevel } from '../persistence/options'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { SHIPPED_SKILL, SKILL_LEVELS, SKILL_PARAMS, type SkillLevel, type SkillParams } from './skills'
 import { Card, Deck, GAME_WIN_SCORE, OPENING_BID, Suit } from './card'
 import {
   ACE_VALUE,
@@ -29,6 +29,41 @@ import type { PlayerIndex } from './trick'
 
 const trump = Suit.Spades
 const RUN_RANKS = ['A', '10', 'K', 'Q', 'J'] as const
+
+/**
+ * Two level slots carrying the arms this file needs, installed for its lifetime.
+ *
+ * Most of what is tested below is the *static* rules — `OPENER_THRESHOLD`,
+ * `PARTNER_PASSED_FLOOR`, `THIRD_BIDDER_FLOOR`, the endgame bands. They only
+ * decide an opening when the seat is on `bidPolicy: 'static'`; on the distilled
+ * one the evaluator answers first and the threshold is never asked. `'medium'`
+ * was that seat, and `'easy'` was the `handValuation: 'meld_only'` seat.
+ *
+ * #222 collapsed the dial, so both names became the shipped configuration and
+ * every one of these tests would have gone on passing while quietly asserting
+ * something else — the failure mode #261 and #263 are about. Installing the two
+ * arms explicitly says which rule each test is aimed at, and the save/restore is
+ * the same shape `abRun.installPolicies` uses.
+ *
+ * Everything not named here runs `SHIPPED_SKILL`, which is what a player meets.
+ */
+const STATIC_LEVEL: SkillLevel = 'medium'
+const MELD_ONLY_LEVEL: SkillLevel = 'easy'
+const pristine: Partial<Record<SkillLevel, SkillParams>> = {}
+beforeAll(() => {
+  pristine[STATIC_LEVEL] = SKILL_PARAMS[STATIC_LEVEL]
+  pristine[MELD_ONLY_LEVEL] = SKILL_PARAMS[MELD_ONLY_LEVEL]
+  SKILL_PARAMS[STATIC_LEVEL] = { ...SKILL_PARAMS[STATIC_LEVEL], bidPolicy: 'static' }
+  SKILL_PARAMS[MELD_ONLY_LEVEL] = {
+    ...SKILL_PARAMS[MELD_ONLY_LEVEL],
+    handValuation: 'meld_only',
+    bidPolicy: 'static',
+  }
+})
+afterAll(() => {
+  SKILL_PARAMS[STATIC_LEVEL] = pristine[STATIC_LEVEL] as SkillParams
+  SKILL_PARAMS[MELD_ONLY_LEVEL] = pristine[MELD_ONLY_LEVEL] as SkillParams
+})
 
 describe('computeBaseBid', () => {
   it('scores a full trump Run at 150, its Royal Marriage at 40, and its aces', () => {
@@ -355,11 +390,10 @@ describe('chooseBid', () => {
     it('passes when the ceiling does not clear OPENER_THRESHOLD and partner has already had a turn', () => {
       // 4th bidder (passesSoFar=3, dealer): partner (player 2) has already had
       // their turn, so the "partner hasn't bid" rule doesn't apply.
-      // Pinned to a 'static' skill level (#114): this is the OPENER_THRESHOLD
-      // rule specifically, and since #115 opened the gate only `easy` and
-      // `medium` still run it.
+      // Pinned to STATIC_LEVEL (#114): this is the OPENER_THRESHOLD rule
+      // specifically, and the distilled evaluator answers ahead of it.
       const context = baseContext({ dealer: 0, passesSoFar: 3 })
-      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
+      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, context, STATIC_LEVEL)).toBeNull()
     })
 
     it('takes this hand on a distilled level and passes it on a static one (#114/#115)', () => {
@@ -367,25 +401,25 @@ describe('chooseBid', () => {
       // rule passes. The distilled evaluator takes it — it sees 80 guaranteed
       // meld and four fifths of a run, offered the contract at the 300 minimum.
       // That divergence is the clearest single illustration of what #114
-      // changes, and #115's A/B is why `hard` now follows the evaluator rather
-      // than the threshold.
+      // changes, and #115's A/B is why every shipped seat follows the evaluator
+      // rather than the threshold.
       const context = baseContext({ dealer: 0, passesSoFar: 3 })
-      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
-      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
+      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, context, STATIC_LEVEL)).toBeNull()
+      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, context, SHIPPED_SKILL)).toBe(OPENING_BID)
     })
 
     it('does not open a hopeless first-bidder hand (#126)', () => {
       // The first seat to speak (passesSoFar 0) used to open at OPENING_BID
       // unconditionally, which made this the first thing that happened on every
       // deal and left OPENER_THRESHOLD unreachable. `Player.choose_bid` has no
-      // such tier: the hand decides. Pinned to a 'static' level so the
+      // such tier: the hand decides. Pinned to STATIC_LEVEL so the
       // assertion is about the threshold rule rather than about the evaluator
       // (#114/#115), and to level scores so #256's endgame rule is not what is
       // answering.
       const context = baseContext({ dealer: 1 })
-      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
+      expect(chooseBid(0, weakHand, OPENING_BID - 10, 10, context, STATIC_LEVEL)).toBeNull()
       // Same seat, a hand whose ceiling clears the threshold: it opens.
-      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'medium')).toBe(OPENING_BID)
+      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, STATIC_LEVEL)).toBe(OPENING_BID)
     })
 
     it('passes for a weak-handed 4th bidder when partner has already had a turn', () => {
@@ -414,7 +448,7 @@ describe('chooseBid', () => {
       // The other half of the same rule: the floor is a floor, not a repeal.
       const context = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
       expect(ceilingOf(strongHand)).toBeGreaterThanOrEqual(THIRD_BIDDER_FLOOR)
-      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, 'medium')).toBe(OPENING_BID)
+      expect(chooseBid(0, strongHand, OPENING_BID - 10, 10, context, STATIC_LEVEL)).toBe(OPENING_BID)
     })
 
     it('the floor is 200, not OPENER_THRESHOLD, and that is what the rule is (#255)', () => {
@@ -434,8 +468,8 @@ describe('chooseBid', () => {
       // THIRD_BIDDER_FLOOR for both A/B runs.
       const third = baseContext({ dealer: 1, passesSoFar: 2, scores: { 0: 0, 1: 0 } })
       const first = baseContext({ dealer: 1, passesSoFar: 0, scores: { 0: 0, 1: 0 } })
-      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, third, 'medium')).toBe(OPENING_BID)
-      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, first, 'medium')).toBeNull()
+      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, third, STATIC_LEVEL)).toBe(OPENING_BID)
+      expect(chooseBid(0, nearRunHand, OPENING_BID - 10, 10, first, STATIC_LEVEL)).toBeNull()
     })
 
     it('3rd bidder falls back to the normal threshold once my score is above 800', () => {
@@ -614,11 +648,11 @@ describe('endgame protection (#256)', () => {
   describe('the trigger', () => {
     // Dealer 3 puts an opponent in the chair and seat 0 first to speak, so the
     // exception cannot apply and the only thing separating these calls is the
-    // trigger. 'medium' pins the contrast case to OPENER_THRESHOLD rather than
+    // trigger. STATIC_LEVEL pins the contrast case to OPENER_THRESHOLD rather than
     // to the evaluator.
     const opening = (ours: number, theirs: number) =>
       chooseBid(0, richHand, OPENING_BID - 10, 10,
-        ctx({ dealer: 3, passesSoFar: 0, passedPlayers: [], scores: { 0: ours, 1: theirs } }), 'medium')
+        ctx({ dealer: 3, passesSoFar: 0, passedPlayers: [], scores: { 0: ours, 1: theirs } }), STATIC_LEVEL)
 
     it('fires at the score floor and not one point below', () => {
       expect(opening(ENDGAME_SCORE_FLOOR, 100)).toBeNull()
@@ -703,12 +737,12 @@ describe('endgame protection (#256)', () => {
     // Those scores are inside the new trigger, so the rescue's own floor now
     // applies and this hand does not clear it.
     const context = ctx({ scores: { 0: 850, 1: 400 } })
-    expect(chooseBid(0, poorHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
+    expect(chooseBid(0, poorHand, OPENING_BID - 10, 10, context, STATIC_LEVEL)).toBeNull()
     // And outside the trigger the ordinary rules decide, where the old tier
     // would have opened on this hand too.
     const outside = ctx({ scores: { 0: 850, 1: 500 } })
-    expect(chooseBid(0, poorHand, OPENING_BID - 10, 10, outside, 'medium')).toBeNull()
-    expect(chooseBid(0, richHand, OPENING_BID - 10, 10, outside, 'medium')).toBe(OPENING_BID)
+    expect(chooseBid(0, poorHand, OPENING_BID - 10, 10, outside, STATIC_LEVEL)).toBeNull()
+    expect(chooseBid(0, richHand, OPENING_BID - 10, 10, outside, STATIC_LEVEL)).toBe(OPENING_BID)
   })
 })
 
@@ -741,7 +775,6 @@ describe('parity with the Python reference engine (#118)', () => {
 // Hence a property rather than another case: sweep the decision surface and
 // assert the shape of every answer. The next off-grid constant fails here
 // instead of reaching a player, wherever in `chooseBid` someone puts it.
-const SKILL_LEVELS: readonly SkillLevel[] = ['easy', 'medium', 'hard', 'proficient', 'expert']
 const SEATS: readonly PlayerIndex[] = [0, 1, 2, 3]
 
 /** mulberry32, the generator `src/ab/headlessGame.ts` uses. Inlined rather than
@@ -914,7 +947,7 @@ describe('every bid chooseBid can return is legal (#177)', () => {
       scores: { 0: 0, 1: 0 },
       passedPlayers: [2],
     }
-    expect(chooseBid(0, ceiling320Hand, OPENING_BID - 10, 10, context, 'medium')).toBe(PARTNER_PASSED_FLOOR)
+    expect(chooseBid(0, ceiling320Hand, OPENING_BID - 10, 10, context, STATIC_LEVEL)).toBe(PARTNER_PASSED_FLOOR)
   })
 })
 
@@ -983,7 +1016,7 @@ describe('raising over a bid our own team already holds (#206)', () => {
     // Every one of these used to answer `partnerBid + 10` — 270 over a 260 —
     // while requiring a 340-worthy hand to say it.
     for (const partnerBid of [260, 270, 280, 290, 300, 310, 320, 330]) {
-      expect(chooseBid(2, strongHand, partnerBid, 10, afterPartnerRaise(partnerBid), 'hard')).toBe(
+      expect(chooseBid(2, strongHand, partnerBid, 10, afterPartnerRaise(partnerBid), SHIPPED_SKILL)).toBe(
         PARTNER_RAISE_FLOOR,
       )
     }
@@ -991,13 +1024,13 @@ describe('raising over a bid our own team already holds (#206)', () => {
 
   it('still takes the ordinary next rung once the partner is already past the floor', () => {
     // The floor is a floor, not a fixed bid: above it the normal ladder applies.
-    expect(chooseBid(2, strongHand, 350, 10, afterPartnerRaise(350), 'hard')).toBe(360)
+    expect(chooseBid(2, strongHand, 350, 10, afterPartnerRaise(350), SHIPPED_SKILL)).toBe(360)
   })
 
   it('backs off instead of being talked into a commitment it cannot make', () => {
     expect(bestBaseBid(modestHand, 0, 0).total).toBeLessThan(PARTNER_RAISE_FLOOR)
     for (const partnerBid of [260, 300, 330]) {
-      expect(chooseBid(2, modestHand, partnerBid, 10, afterPartnerRaise(partnerBid), 'hard')).toBeNull()
+      expect(chooseBid(2, modestHand, partnerBid, 10, afterPartnerRaise(partnerBid), SHIPPED_SKILL)).toBeNull()
     }
   })
 
@@ -1010,12 +1043,12 @@ describe('raising over a bid our own team already holds (#206)', () => {
         deck.shuffle()
         const hands = deck.deal()
         for (const partnerBid of [260, 275, 290, 305, 330]) {
-          // `easy` is excluded on purpose, not because it fails: `meldOnlyBid`
-          // is the deliberately-weak skill-1 path with no partner tracking of
-          // any kind (see its docstring), so it never reaches this branch and
-          // answers the plain next rung. Sweeping it here would assert that
-          // skill 1 has partner logic, which is the opposite of what it is for.
-          for (const level of SKILL_LEVELS.filter((l) => l !== 'easy')) {
+          // MELD_ONLY_LEVEL is excluded on purpose, not because it fails:
+          // `meldOnlyBid` has no partner tracking of any kind (see its
+          // docstring), so it never reaches this branch and answers the plain
+          // next rung. Sweeping it here would assert that the meld-only arm has
+          // partner logic, which is the opposite of what it is for.
+          for (const level of SKILL_LEVELS.filter((l) => l !== MELD_ONLY_LEVEL)) {
             const out = chooseBid(2, hands[2], partnerBid, 10, afterPartnerRaise(partnerBid), level)
             if (out === null) continue
             expect(out).toBeGreaterThanOrEqual(PARTNER_RAISE_FLOOR)
@@ -1050,7 +1083,7 @@ describe('raising over a bid our own team already holds (#206)', () => {
         scores: { 0: 0, 1: 0 },
         passedPlayers: [],
       }
-      expect(chooseBid(2, weakHand, oppBid, 10, context, 'hard')).toBe(oppBid + 10)
+      expect(chooseBid(2, weakHand, oppBid, 10, context, SHIPPED_SKILL)).toBe(oppBid + 10)
     }
   })
 })

--- a/web/src/engine/bidding.ts
+++ b/web/src/engine/bidding.ts
@@ -28,10 +28,15 @@
 // module only decides; it does not run an auction loop — that lives in
 // components/auctionReducer.ts (#34), under gameFlowReducer.ts (#47).
 
-import type { SkillLevel } from '../persistence/options'
 import { type Card, GAME_WIN_SCORE, handCount, OPENING_BID, type Rank, Suit, SUITS } from './card'
 import { shouldBid } from './evaluator'
-import { MELD_ONLY_BID_NOISE, MELD_ONLY_TRICK_ESTIMATE, SKILL_PARAMS } from './skills'
+import {
+  MELD_ONLY_BID_NOISE,
+  MELD_ONLY_TRICK_ESTIMATE,
+  SHIPPED_SKILL,
+  SKILL_PARAMS,
+  type SkillLevel,
+} from './skills'
 import {
   AROUND_DOUBLE_MULTIPLIER,
   AROUND_VALUES,
@@ -76,11 +81,12 @@ export const MAX_BID_DEFAULT = 400
 export const MAX_BID_MELD_THRESHOLD = 300
 
 // -- The two static bidding thresholds. Both are guesses, and both are
-// superseded by the fitted evaluator on every skill level whose `bidPolicy` is
-// `'distilled'` (see skills.ts). They are NOT dead: `'static'` is still what
-// proficient and expert run, until #115's A/B says which policy wins. Anything
-// that reads them outside `chooseBid`'s static branch is reading a rule that
-// half the dial no longer follows. ---------------------------------------
+// superseded by the fitted evaluator wherever `bidPolicy` reads `'distilled'`
+// (see skills.ts), which since #222 is every seat a player meets. They are NOT
+// dead: they still decide the raise ladder under both policies, and `'static'`
+// is the baseline `BID_AB_POLICIES` seats. But anything that reads them outside
+// `chooseBid`'s static branch is reading a rule the shipped opener does not
+// follow. -----------------------------------------------------------------
 
 // Minimum Base Bid to justify opening at all.
 export const OPENER_THRESHOLD = 320
@@ -561,7 +567,9 @@ function meldOnlyBid(
  * score-context rules. Falls back to the old coin-flip placeholder if
  * called without a context (keeps old call sites/tests working).
  *
- * @param skill Skill level from options — controls hand-valuation formula.
+ * @param skill Which `SKILL_PARAMS` slot to read `handValuation` and
+ *   `bidPolicy` from. Defaults to `SHIPPED_SKILL`, which is what every seat in
+ *   a real game plays; only `src/ab/` passes anything else.
  *   Defaults to 'hard' (base_bid, the current Proficient behavior).
  *
  * Decision tiers:
@@ -594,7 +602,7 @@ export function chooseBid(
   currentBid: number,
   minIncrement: number,
   context?: AuctionContext,
-  skill: SkillLevel = 'hard',
+  skill: SkillLevel = SHIPPED_SKILL,
 ): number | null {
   if (context === undefined) {
     return Math.random() < 0.6 ? null : currentBid + minIncrement
@@ -814,10 +822,11 @@ export function chooseBid(
  * selection reflects real speculative hand strength rather than raw card
  * count. For skill 1 (easy), picks the suit with the highest actual meld.
  *
- * @param skill Skill level — controls trump selection formula. Defaults
- *   to 'hard' (base_bid, current Proficient behavior).
+ * @param skill Which `SKILL_PARAMS` slot to read `handValuation` from —
+ *   `'meld_only'` picks the highest-melding suit instead. Defaults to
+ *   `SHIPPED_SKILL`.
  */
-export function chooseTrump(hand: readonly Card[], skill: SkillLevel = 'hard'): Suit {
+export function chooseTrump(hand: readonly Card[], skill: SkillLevel = SHIPPED_SKILL): Suit {
   if (SKILL_PARAMS[skill].handValuation === 'meld_only') {
     let best: Suit = Suit.Spades
     let bestValue = -1

--- a/web/src/engine/evaluator.test.ts
+++ b/web/src/engine/evaluator.test.ts
@@ -1,15 +1,16 @@
-// Behaviour of the distilled evaluator and of the skill dial that gates it
-// (#114). Numerical agreement with Python lives in `evaluatorParity.test.ts`;
-// this file is about the things parity cannot check — that the wiring is
-// hooked up, that the two models stay apart, and that the evaluator responds to
-// the bid level, which is the whole reason it replaces a fixed threshold.
+// Behaviour of the distilled evaluator and of the `bidPolicy` field that
+// selects it (#114). Numerical agreement with Python lives in
+// `evaluatorParity.test.ts`; this file is about the things parity cannot check
+// — that the wiring is hooked up, that the two models stay apart, and that the
+// evaluator responds to the bid level, which is the whole reason it replaces a
+// fixed threshold.
 
 import { describe, expect, it, vi } from 'vitest'
 import { type AuctionContext, chooseBid } from './bidding'
 import { Card, OPENING_BID, type Rank, Suit } from './card'
 import { evaluateBid, evaluateFold, modelLogit, shouldBid } from './evaluator'
 import { BID_MODEL, FOLD_MODEL, MODEL_PROVENANCE } from './evaluatorModel'
-import { SKILL_PARAMS } from './skills'
+import { SHIPPED_PARAMS, SHIPPED_SKILL, SKILL_LEVELS, SKILL_PARAMS, type SkillLevel, type SkillParams } from './skills'
 
 const RUN_RANKS: readonly Rank[] = ['A', '10', 'K', 'Q', 'J']
 
@@ -167,7 +168,32 @@ describe('the fold model', () => {
   })
 })
 
-describe('the skill dial selects the bid policy (#114, opened by #115)', () => {
+/**
+ * `bidPolicy` selects the bid policy (#114, opened by #115).
+ *
+ * This described a dial until #222 removed it. The two policies both still
+ * exist and `chooseBid` still branches on the field, so the behaviour these
+ * tests are about is unchanged — what changed is how the `'static'` arm is
+ * reached, since no level selects it any more. `withPolicy` installs it onto a
+ * slot for the duration, which is the same save/restore `abRun.installPolicies`
+ * uses to seat two policies at one table.
+ */
+describe('bidPolicy selects the bid policy (#114, opened by #115)', () => {
+  /** A slot to park an arm on. Any level would do — after #222 they are
+   *  interchangeable carriers — but not `SHIPPED_SKILL`, so a leaked override
+   *  could not quietly change what the rest of the suite thinks ships. */
+  const AB_SLOT: SkillLevel = 'easy'
+
+  function withPolicy<T>(patch: Partial<SkillParams>, play: (level: SkillLevel) => T): T {
+    const saved = SKILL_PARAMS[AB_SLOT]
+    SKILL_PARAMS[AB_SLOT] = { ...saved, ...patch }
+    try {
+      return play(AB_SLOT)
+    } finally {
+      SKILL_PARAMS[AB_SLOT] = saved
+    }
+  }
+
   const context: AuctionContext = {
     everBid: false,
     passesSoFar: 3,
@@ -197,31 +223,32 @@ describe('the skill dial selects the bid policy (#114, opened by #115)', () => {
     new Card(Suit.Hearts, 'Q', 2),
   ]
 
-  it('runs the evaluator on hard and above, and the thresholds below (#115)', () => {
+  it('runs the evaluator, on every seat the product deals (#115)', () => {
     // #114 pinned every level to 'static' so the model could not reach a player
     // by accident; #115 measured it and opened the gate for `hard` upward —
     // 211 deals swept to static's 50 over 1000 mirrored pairs, +227 score
-    // margin per deal with a 95% CI of +198 to +257 (see src/ab/).
+    // margin per deal with a 95% CI of +198 to +257 (see src/ab/). #222 then
+    // removed the levels below it, so what once read "which tiers are gated
+    // on" now reads "what ships", which is the same drift guard pointed at
+    // one row instead of five.
     //
-    // Still an assertion rather than a shrug, and still the place a drift shows
-    // up: `hard` is what DEFAULT_OPTIONS gives both AI seats, so a level moving
-    // in either direction here changes the default game on merge and should be
-    // a deliberate act with a measurement behind it.
-    expect(SKILL_PARAMS.easy.bidPolicy).toBe('static')
-    expect(SKILL_PARAMS.medium.bidPolicy).toBe('static')
-    for (const level of ['hard', 'proficient', 'expert'] as const) {
-      expect(SKILL_PARAMS[level].bidPolicy).toBe('distilled')
+    // Both halves matter. The first is the gate; the second is that no slot
+    // carries a stale copy of some older configuration, since `SKILL_PARAMS`
+    // is mutable and a leaked A/B override is the way that would happen.
+    expect(SHIPPED_PARAMS.bidPolicy).toBe('distilled')
+    for (const level of SKILL_LEVELS) {
+      expect(SKILL_PARAMS[level]).toEqual(SHIPPED_PARAMS)
     }
   })
 
-  it('separates the two policies on one hand the dial can be probed with', () => {
+  it('separates the two policies on one hand that can be probed with', () => {
     // Ceiling 290, under OPENER_THRESHOLD, so the static rule passes while the
-    // evaluator opens — one hand that reads the dial directly rather than
-    // asserting on SKILL_PARAMS a second time.
-    expect(chooseBid(0, belowThresholdHand, OPENING_BID - 10, 10, context, 'medium')).toBeNull()
-    for (const level of ['hard', 'proficient', 'expert'] as const) {
-      expect(chooseBid(0, belowThresholdHand, OPENING_BID - 10, 10, context, level)).toBe(OPENING_BID)
-    }
+    // evaluator opens — one hand that reads the field's effect directly rather
+    // than asserting on SKILL_PARAMS a second time.
+    withPolicy({ bidPolicy: 'static' }, (level) => {
+      expect(chooseBid(0, belowThresholdHand, OPENING_BID - 10, 10, context, level)).toBeNull()
+    })
+    expect(chooseBid(0, belowThresholdHand, OPENING_BID - 10, 10, context, SHIPPED_SKILL)).toBe(OPENING_BID)
   })
 
   it('opens this hand when the evaluator is consulted directly', () => {
@@ -240,9 +267,11 @@ describe('the skill dial selects the bid policy (#114, opened by #115)', () => {
     ).toBe(true)
   })
 
-  it('leaves easy on the meld-only path, which the evaluator never enters', () => {
-    // Skill 1 short-circuits before any Base Bid valuation happens, so its
-    // bidding is unchanged by #114 and MELD_ONLY_TRICK_ESTIMATE stays live.
+  it('keeps the meld-only path short-circuiting before the evaluator', () => {
+    // `handValuation: 'meld_only'` short-circuits before any Base Bid valuation
+    // happens, so that arm is unchanged by #114 and MELD_ONLY_TRICK_ESTIMATE
+    // stays live. `easy` selected it until #222 removed the dial; it is
+    // installed here for the same reason `'static'` is above.
     // This hand melds 190 under Hearts (Run 150 + Royal Marriage 40), so the
     // meld-only ceiling is 190 + 60 flat + noise in [-30, 30] = [220, 280].
     //
@@ -257,13 +286,15 @@ describe('the skill dial selects the bid policy (#114, opened by #115)', () => {
     // this fails on the specific number instead of going quietly random.
     const random = vi.spyOn(Math, 'random')
     try {
-      random.mockReturnValue(0) // noise -30 -> ceiling 220, 80 under the opener
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'easy')).toBeNull()
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
+      withPolicy({ handValuation: 'meld_only' }, (meldOnly) => {
+        random.mockReturnValue(0) // noise -30 -> ceiling 220, 80 under the opener
+        expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, meldOnly)).toBeNull()
+        expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, SHIPPED_SKILL)).toBe(OPENING_BID)
 
-      random.mockReturnValue(1) // noise +30 -> ceiling 280, still 20 under it
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'easy')).toBeNull()
-      expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, 'hard')).toBe(OPENING_BID)
+        random.mockReturnValue(1) // noise +30 -> ceiling 280, still 20 under it
+        expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, meldOnly)).toBeNull()
+        expect(chooseBid(0, runOnlyHand, OPENING_BID - 10, 10, context, SHIPPED_SKILL)).toBe(OPENING_BID)
+      })
     } finally {
       random.mockRestore()
     }

--- a/web/src/engine/passing.test.ts
+++ b/web/src/engine/passing.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import type { SkillLevel } from '../persistence/options'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { SKILL_LEVELS, SKILL_PARAMS, type SkillLevel, type SkillParams } from './skills'
 import { Card, Deck, Suit } from './card'
 import { PASS_COUNT, bidderPassSelection, choosePassCards, partnerPassSelection } from './passing'
 
@@ -150,7 +150,7 @@ describe('choosePassCards', () => {
 })
 
 /**
- * The 3-card pass, pinned against the skill dial (#196).
+ * The 3-card pass, pinned against every configuration the engine has (#196).
  *
  * Paul's dad reported that changing the AI skill level let him pass **4** cards
  * instead of 3. It was not reproducible — he was on a stale deployed build whose
@@ -159,19 +159,37 @@ describe('choosePassCards', () => {
  * report named a dial that nothing should connect to the pass at all.
  *
  * So this fixes the count as a property rather than trusting that no future
- * skill row grows a `passCount` field. Every combination that a real game can
- * produce — five levels x both roles x four trumps, over real dealt hands —
+ * policy row grows a `passCount` field. Every combination the engine can
+ * produce — five level slots x both roles x four trumps, over real dealt hands —
  * must return exactly three distinct cards that the hand actually held.
+ *
+ * #222 removed the setting the report named, and would have quietly gutted this
+ * sweep with it: `choosePassCards` branches on `handValuation`, and with one
+ * configuration on all five slots the loop would run the same branch five times.
+ * So `meld_only` — the arm `easy` used to select, now reachable only through an
+ * override — is installed onto one slot for the duration, using the same
+ * save/restore `abRun.installPolicies` and `tracker.test.ts` use. The sweep
+ * covers what it always covered.
  *
  * `pinochle_rules.md` is the authority: the pass is three cards, always. The
  * existing "returns exactly `count`" tests above take `count` as a parameter and
  * so cannot catch a caller passing the wrong one; these fix the number itself.
  */
 describe('the 3-card pass is invariant across skill levels (#196)', () => {
-  const SKILLS: readonly SkillLevel[] = ['easy', 'medium', 'hard', 'proficient', 'expert']
+  const SKILLS: readonly SkillLevel[] = SKILL_LEVELS
   const TRUMPS = [Suit.Spades, Suit.Diamonds, Suit.Clubs, Suit.Hearts] as const
 
-  it('is three cards, and no skill level is wired to change it', () => {
+  const MELD_ONLY_LEVEL: SkillLevel = 'easy'
+  let pristine: SkillParams
+  beforeAll(() => {
+    pristine = SKILL_PARAMS[MELD_ONLY_LEVEL]
+    SKILL_PARAMS[MELD_ONLY_LEVEL] = { ...pristine, handValuation: 'meld_only' }
+  })
+  afterAll(() => {
+    SKILL_PARAMS[MELD_ONLY_LEVEL] = pristine
+  })
+
+  it('is three cards, and no configuration is wired to change it', () => {
     expect(PASS_COUNT).toBe(3)
   })
 

--- a/web/src/engine/passing.ts
+++ b/web/src/engine/passing.ts
@@ -8,10 +8,9 @@
 // is the entry point; bidderPassSelection / partnerPassSelection hold
 // the tiered priority logic for each role.
 
-import type { SkillLevel } from '../persistence/options'
 import { type Card, type Rank, Suit, SUITS } from './card'
 import { scoreMelds } from './melds'
-import { SKILL_PARAMS } from './skills'
+import { SHIPPED_SKILL, SKILL_PARAMS, type SkillLevel } from './skills'
 
 export type PassCategory = 'DS' | 'HC'
 
@@ -280,15 +279,17 @@ function easyCardWorth(card: Card, trump: Suit): number {
  * back to random selection if trumpSuit/isBidWinner aren't supplied
  * (keeps the function usable in isolation / old call sites).
  *
- * @param skill Skill level — skill 1 (easy) uses simplified
- *   meld-only passing logic; 2-5 use the full Proficient tiers.
+ * @param skill Which `SKILL_PARAMS` slot to read `handValuation` from:
+ *   `'meld_only'` uses the simplified passing logic, `'base_bid'` the full
+ *   Proficient tiers. Defaults to `SHIPPED_SKILL`, which is `'base_bid'`; the
+ *   simplified arm is reachable only through an override (see `HandValuation`).
  */
 export function choosePassCards(
   hand: readonly Card[],
   count: number,
   trumpSuit?: Suit,
   isBidWinner?: boolean,
-  skill: SkillLevel = 'hard',
+  skill: SkillLevel = SHIPPED_SKILL,
 ): Card[] {
   if (trumpSuit === undefined || isBidWinner === undefined) {
     return sampleRandom(hand, count)

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -1,16 +1,62 @@
-import type { SkillLevel } from '../persistence/options'
+/**
+ * The five configurations the engine can be asked for, keyed 1-5 in this order
+ * — the same ladder as Python's `GENERAL_STRATEGY_SKILL_PARAMS`
+ * (`pinochle_engine.py`) and as `trumpMemory.ts`'s `TRUMP_MEMORY_CAPACITY`
+ * (`2 x level`).
+ *
+ * **These are not a difficulty setting.** #222 removed the dial: the product
+ * ships exactly one configuration, `SHIPPED_SKILL`, nothing a player can touch
+ * selects another, and `GameOptions` no longer carries a level at all. The type
+ * lived in `persistence/options.ts` while it was a stored preference; it lives
+ * here now that it is engine configuration and nothing else.
+ *
+ * What the other four keys are for is measurement, and only measurement. Two
+ * mechanisms need a level to be a thing you can name:
+ *
+ *   - `abRun.ts`'s `installPolicies` sits two rules at one table by overwriting
+ *     two entries of `SKILL_PARAMS` and seating one on each side. A comparison
+ *     needs two keys that differ in exactly one field, so a single-key map
+ *     would end paired A/B measurement outright.
+ *   - `TRUMP_MEMORY_CAPACITY` is keyed on the level itself and is deliberately
+ *     *not* a `SkillParams` field (#157), so the level a `'counted'` arm sits
+ *     on **is** the capacity under test (#158). Collapsing the keys would take
+ *     that ruler away as well as the dial.
+ *
+ * So a level name inside `src/ab/` is a slot, and a level name outside it
+ * should be `SHIPPED_SKILL`.
+ */
+export const SKILL_LEVELS = ['easy', 'medium', 'hard', 'proficient', 'expert'] as const
+export type SkillLevel = (typeof SKILL_LEVELS)[number]
 
-/** Ported from Python's GENERAL_STRATEGY_SKILL_PARAMS (pinochle_engine.py:1917).
- *  Controls which hand-valuation formula the AI uses in bidding. */
+/**
+ * Which hand-valuation formula the AI uses in bidding. Ported from Python's
+ * GENERAL_STRATEGY_SKILL_PARAMS (`pinochle_engine.py`).
+ *
+ *   `'base_bid'`   the layered valuation in `bidding.ts` — certain meld plus
+ *                  speculative meld plus a trick estimate off the hand's shape.
+ *                  What `SHIPPED_PARAMS` selects.
+ *   `'meld_only'`  `meldOnlyBid`: meld in the best suit plus a flat trick
+ *                  estimate and uniform noise, with the same shortcut applied
+ *                  to `chooseTrump` and `choosePassCards`.
+ *
+ * `'meld_only'` is unselected since #222 — it was `easy`'s valuation and there
+ * is no `easy` to select it any more. It is kept on the terms every other
+ * unselected arm in this file is kept on: `installPolicies` can still seat it,
+ * so "bid on meld alone" remains a baseline the distilled bidder can be
+ * measured against, and the arm has never been through the retirement rule.
+ */
 export type HandValuation = 'meld_only' | 'base_bid'
 
 /**
- * Which rule decides "is this hand worth a contract at this level" (#114).
+ * Which rule decides "is this hand worth a contract" (#114).
  *
  *   `'static'`    the hand-tuned constants — `OPENER_THRESHOLD`,
- *                 `DEFENSIVE_PUSH_FLOOR` — that shipped before epic #104. Still
- *                 live: `medium` runs them, and they still decide the auction's
- *                 raise ladder on every level (see `chooseBid`).
+ *                 `DEFENSIVE_PUSH_FLOOR` — that shipped before epic #104. No
+ *                 longer selected by anything the product runs (#222), but the
+ *                 constants themselves are *not* dead: they still decide the
+ *                 auction's raise ladder under both policies (see `chooseBid`),
+ *                 and this arm is the baseline #115 measured the evaluator
+ *                 against and that `BID_AB_POLICIES` still seats.
  *   `'distilled'` the evaluator fitted to 2000 measured rollout decisions
  *                 (`evaluator.ts`), which reads the bid level, the auction
  *                 state and the hand's shape rather than one number against
@@ -31,9 +77,9 @@ export type BidPolicy = 'static' | 'distilled'
  *   `'model'`  ask `shouldConcede` (`evaluator.ts`) in the same window the
  *              human's fold button gets: after meld, before the first lead.
  *
- * Unlike `bidPolicy` this is **deliberately uniform across all five levels**,
- * and the type exists to keep the alternative measurable rather than to give
- * the dial another notch. The reason is that folding is not a matter of taste:
+ * This was uniform across all five levels while the dial existed, and the type
+ * existed to keep the alternative measurable rather than to give the dial
+ * another notch. The reason is that folding is not a matter of taste:
  * conceding and being set cost the bidding team exactly the same (`-bid`, meld
  * forfeited either way), and the only thing a fold changes is that the
  * defenders are denied their trick points. So a fold can never beat making the
@@ -42,9 +88,9 @@ export type BidPolicy = 'static' | 'distilled'
  * it would read as a bug.
  *
  * `'never'` is retained because `abRun.ts` needs two levels differing in
- * exactly one field to measure this, and because the day someone wants a tier
- * that folds *badly* the honest way to build it is a third policy that folds
- * on the wrong hands - not a tier that cannot fold at all.
+ * exactly one field to measure this, and because the day someone wants an
+ * opponent that folds *badly* the honest way to build it is a third policy
+ * that folds on the wrong hands - not one that cannot fold at all.
  */
 export type FoldPolicy = 'never' | 'model'
 
@@ -123,43 +169,19 @@ export type AutoSetPolicy = 'forced' | 'off'
  *                back to the lowest counter when nothing qualifies. Side-suit
  *                safety comes from `PlayTracker` and is exact at every level;
  *                trump safety comes from #157's `TrumpMemory`, whose capacity
- *                is `2 x skill level`, so it is the one thing in trick play a
- *                weak seat is genuinely worse at.
+ *                is `2 x skill level`, so how well it is answered depends on
+ *                the level the seat sits on.
  *
- * This is the only field whose *effect* varies with the skill level rather than
- * with the row: `'counted'` is the same rule everywhere, but at `easy` it is
- * answered from 2 remembered trump and at `expert` from 10. That is deliberate
- * and it is #157's whole point — same reasoning, worse recall — so it does not
- * contradict #156's "identical rules at every level". A seat that cannot
- * remember does not play a different rule, it plays the same rule
- * conservatively, and conservative here means "assume the card can be beaten".
+ * This is the only field whose *effect* depends on the level as well as on the
+ * value: `'counted'` is the same rule everywhere, but on the `easy` slot it is
+ * answered from 2 remembered trump and on `expert` from 10. Every shipped seat
+ * is `expert` since #222, so in a real game this is 10 of 12 for all four
+ * players and the human. It still matters to `ab/`: `safeCounterAbPolicies`
+ * varies the level precisely to vary the recall behind an unchanged rule, which
+ * is the comparison #158 exists to make and the reason the level keys survive
+ * the dial's removal.
  */
 export type SafeCounterPolicy = 'off' | 'counted'
-
-/**
- * What number a seat that decides to open actually puts on the table (#204).
- *
- *   `'fixed'`  open at `OPENING_BID` — 300 since #257 — whatever the hand is
- *              worth. What every level has always done, and now the only arm.
- *
- * One member, because the other one was measured and lost. #204 split the two
- * questions `chooseBid` conflates — *should* I open, and *at what level* — on
- * the finding that 27.4% of all deals are an opener naming the rung on a hand
- * worth far more, and added `'walk'` to answer the second by stepping up while
- * the seat's own bid policy still said the next rung was worth it. Over 5000
- * pairs on each of three seeds it lost 52, 56 and 53 points per deal, p < 1e-4
- * throughout: it lifted the average bid 301 -> 322 and dropped its made rate
- * 73.2% -> 69.2%, buying the distribution with sets. #221 deleted the arm under
- * #215's retirement rule — three seeds, decisively negative, no shipped row
- * selecting it, nothing baselined against it — and `web/README.md`'s "What the
- * opener puts on the table" keeps the numbers, so the null result outlives the
- * code.
- *
- * The field is left in place rather than removed with the arm. Removing it
- * touches every row of `SKILL_PARAMS` and of the `*_AB_POLICIES` maps, which is
- * #222's diff, not this one.
- */
-export type OpeningPolicy = 'fixed'
 
 export interface SkillParams {
   readonly handValuation: HandValuation
@@ -168,169 +190,101 @@ export interface SkillParams {
   readonly playPolicy: PlayPolicy
   readonly autoSetPolicy: AutoSetPolicy
   readonly safeCounterPolicy: SafeCounterPolicy
-  readonly openingPolicy: OpeningPolicy
 }
 
 /**
- * The dial.
+ * **The one AI the product ships** (#222), and the single place to read which
+ * of this file's policy columns are live behaviour and which are A/B arms.
  *
- * #114 landed the evaluator wired but switched on for nobody. At the time a
- * push to `main` deployed straight to GitHub Pages, and `DEFAULT_OPTIONS` puts
- * both AI seats on `hard`, so enabling it there would have changed every seat
- * of the default game on merge — and #114 could describe the behaviour change
- * without judging it. #115 measured it, and the gate is now open for `hard`
- * and above. (The Pages deployment was removed on 2026-08-01; the reasoning
- * stands on its own, since merging is still what makes a change real.)
+ * | field               | shipped     | other arms, selectable only from `ab/` |
+ * | ---                 | ---         | ---                                    |
+ * | `handValuation`     | `base_bid`  | `meld_only`                            |
+ * | `bidPolicy`         | `distilled` | `static`                               |
+ * | `foldPolicy`        | `model`     | `never`                                |
+ * | `playPolicy`        | `cascade`   | `simple`                               |
+ * | `autoSetPolicy`     | `forced`    | `off`                                  |
+ * | `safeCounterPolicy` | `counted`   | `off`                                  |
  *
- * What #115 found, over 1000 paired deals played twice with the seats mirrored
- * (2000 headless games, `src/ab/`):
+ * Read as prose: distilled bidding, cascade card play, `model` folding,
+ * `forced` auto-SET, `counted` safe counters, and — since the shipped seat is
+ * `SHIPPED_SKILL` — trump memory of 10 of the 12 trump.
  *
- *   distilled swept 211 deals, static 50, 739 split. 95% CI on distilled's
- *   share of the 261 decisive deals: 75.6%–85.2%, exact two-sided binomial
- *   p < 1e-4. Score margin +227 per deal, 95% CI +198 to +257.
+ * Every one of those is the arm that measured better, and this configuration is
+ * what `hard`, `proficient` and `expert` all already were apart from recall.
+ * Epic #215 is where the dial went: three panel rows that were byte-identical
+ * except for `TRUMP_MEMORY_CAPACITY` are a control a player cannot feel, and
+ * the answer was to stop offering it rather than to manufacture a span. So the
+ * table below is one configuration written once and pointed at from every slot,
+ * not five rows that happen to agree — which is the state #215 objected to.
  *
- * The mechanism is the one #114 flagged and could not evaluate.
- * `DEFENSIVE_PUSH_FLOOR = 200` tells a seat to raise a 300 opener on almost any
- * hand — a ceiling of 200 is barely above the "no meld, no aces" floor — so the
- * static side buys a great many cheap contracts and is set on 45.4% of them.
- * The model declines most of those pushes: it takes a third fewer contracts and
- * makes 63.7% of them against static's 54.6%. Declining a contract you cannot
- * make is worth more than the contract.
+ * The right-hand column is the honest cost of the arrangement and is why it is
+ * tabulated here rather than left to six separate docstrings: each unselected
+ * arm keeps a branch of production code no player can reach. They are retained
+ * on purpose — `abRun.ts` compares two rules only by seating two levels that
+ * differ in exactly one field, so an arm deleted is a comparison that can no
+ * longer be made — and the standing rule for when one is nonetheless retired
+ * lives in `CODING_STANDARDS.md`. Each type above says why its own arm stays.
  *
- * That effect survives the harness's own control: the same policy against
- * itself splits every pair with a paired margin of exactly zero, so the
- * mirroring really is cancelling the seat advantage rather than hiding a bug.
- * It is also not a quirk of playing *against* the static rule — an all-
- * distilled table is set on 38.8% of its contracts where an all-static table is
- * set on 42.3%.
+ * The column that is *not* here is `openingPolicy`. #221 retired its `'walk'`
+ * arm under that rule and left the one-member field for this change to clear,
+ * since removing it touched every row of this table and of the `*_AB_POLICIES`
+ * maps. A field with one value is not a dial, so it is gone; the finding it
+ * carried is at `chooseBid`'s opening branch in `bidding.ts` and in
+ * `web/README.md`, which is where a retired arm's numbers are supposed to live.
  *
- * Cost, since a model that thinks visibly is a regression however well it
- * plays: +1.9 kB raw / +872 B gzipped on the shipped bundle (255.1 kB -> 253.2
- * kB with it removed), and p95 per-decision latency of 72us against static's
- * 41us in Node, 495us against 313us in Chrome at a 375x812 viewport. Even
- * multiplied by a 6x mobile-CPU emulation factor that is ~3 ms, against the
- * 600 ms `AI_BID_DELAY_MS` the auction already waits before each AI bid.
- *
- * Why the levels land where they do:
- *
- *   easy stays 'static' — its bidding never reaches the Base Bid path
- *   (`handValuation: 'meld_only'` short-circuits into `meldOnlyBid`), and the
- *   evaluator distils *skill 5*, so wiring it in would not make easy
- *   better-calibrated, it would make easy the strongest bidder and delete the
- *   tier.
- *
- *   medium stays 'static', unchanged from what it plays today. Before this
- *   change medium, hard, proficient and expert were byte-identical, so the dial
- *   had exactly two settings; leaving medium on the thresholds gives it a real
- *   third one — a bidder that opens on a rule of thumb and pushes every cheap
- *   contract is a fair description of a middling player.
- *
- *   proficient and expert take 'distilled' rather than staying on the
- *   thresholds. Epic #104's sketch was the other way round — evaluator for
- *   skills 1-3, real rollouts for 4-5 — but that mapping assumed 4-5 would
- *   *have* rollouts, and in the browser they do not and will not until the Web
- *   Worker work exists. Between the two policies that do exist here, distilled
- *   is the measurably stronger one, so leaving the top tiers on the weaker rule
- *   would rank them below `hard`. When real rollouts land they replace this on
- *   4-5; until then it is the floor, not the ceiling.
- *
- * `foldPolicy` reads `'model'` on every row on purpose (#123) and is not a
- * second dial — see `FoldPolicy` for why folding is shared competence rather
- * than a difficulty setting. The dial this table exists to express is
- * `bidPolicy`; a level's strength is meant to come from what it is willing to
- * bid, not from whether it is allowed to notice a dead contract.
- *
- * `playPolicy` (#153) reads `'cascade'` on every row, and that column is the
- * one place the table deliberately does *not* express a difficulty setting
- * (#156). Paul's reasoning, which is about what a player can see rather than
- * about strength: *"humans get really mad if you play this last part wrong,
- * but bidding they never know what you have."* A weak bid is invisible — the
- * other three seats never see the hand it was made on — while a weak card is
- * face up on the table, and it does not read as an easy opponent, it reads as
- * a partner who is broken. So trick play is shared competence, like
- * `foldPolicy`, and a level's strength comes from what it is willing to bid.
- *
- * `easy` was the one row on `'simple'`, inherited from the
- * `handValuation === 'meld_only'` card-play gate that used to live in
- * `tracker.ts`. That shortcut cost **+121 points per deal** measured against
- * the cascade on identical deals (#153, confirmed at 5000 pairs in #156) — the
- * largest effect epic #152 has found, and far too large to be a difficulty
- * notch even if it were an invisible one.
- *
- * Note what did *not* change: `easy` keeps `handValuation: 'meld_only'`, so it
- * still bids on meld alone. Easy bids like easy and plays cards like everyone
- * else, and that separation is precisely what #153 split the two fields apart
- * to allow — while one flag carried both, this change was not expressible
- * without also rewriting how easy bids.
- *
- * `'simple'` itself survives as an A/B arm and must not be deleted as dead
- * code — see `PlayPolicy` for why.
- *
- * `autoSetPolicy` (#178) reads `'forced'` on every row for a stronger reason
- * than either of those: it is not a policy at all in a real game, it is a rule
- * of arithmetic that the human bid winner gets too. See `AutoSetPolicy`.
- *
- * `safeCounterPolicy` (#158) reads `'counted'` on every row, and is the one
- * column where a uniform value still produces different play at different
- * levels — the rule is identical everywhere and only the trump recall behind it
- * scales (#157's `2 x skill level`). So it does not reopen #156: nobody plays a
- * worse rule, a weak seat just answers the same question off less information.
- * It ships enabled because it measured positive at every capacity; the rows
- * grew a line each here rather than staying on one, because five fields no
- * longer fit one readable line. See `SafeCounterPolicy` and `web/README.md`.
+ * On the numbers behind `bidPolicy`: #115 measured distilled against static
+ * over 1000 paired deals at +227 per deal (95% CI +198 to +257, p < 1e-4),
+ * with the mechanism being that the model declines the cheap contracts
+ * `DEFENSIVE_PUSH_FLOOR` tells the static rule to buy. #255 re-ran the same
+ * comparison on 2026-08-30 and got +18 per deal (CI -3 to +39) with clean
+ * self-tests on both arms. That gap is unexplained and open on #227, so treat
+ * the magnitude as provisional; the direction has never reversed, and nothing
+ * in the record argues for shipping the static rule.
  */
-export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = {
-  easy: {
-    handValuation: 'meld_only',
-    bidPolicy: 'static',
-    foldPolicy: 'model',
-    playPolicy: 'cascade',
-    autoSetPolicy: 'forced',
-    safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
-  },
-  medium: {
-    handValuation: 'base_bid',
-    bidPolicy: 'static',
-    foldPolicy: 'model',
-    playPolicy: 'cascade',
-    autoSetPolicy: 'forced',
-    safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
-  },
-  hard: {
-    handValuation: 'base_bid',
-    bidPolicy: 'distilled',
-    foldPolicy: 'model',
-    playPolicy: 'cascade',
-    autoSetPolicy: 'forced',
-    safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
-  },
-  proficient: {
-    handValuation: 'base_bid',
-    bidPolicy: 'distilled',
-    foldPolicy: 'model',
-    playPolicy: 'cascade',
-    autoSetPolicy: 'forced',
-    safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
-  },
-  expert: {
-    handValuation: 'base_bid',
-    bidPolicy: 'distilled',
-    foldPolicy: 'model',
-    playPolicy: 'cascade',
-    autoSetPolicy: 'forced',
-    safeCounterPolicy: 'counted',
-    openingPolicy: 'fixed',
-  },
+export const SHIPPED_PARAMS: SkillParams = {
+  handValuation: 'base_bid',
+  bidPolicy: 'distilled',
+  foldPolicy: 'model',
+  playPolicy: 'cascade',
+  autoSetPolicy: 'forced',
+  safeCounterPolicy: 'counted',
 }
 
-/** Flat trick-point estimate for meld-only bidding (skill 1), matching
- *  Python's `MELD_ONLY_TRICK_ESTIMATE` / `EASY_FLAT_TRICK_ESTIMATE`. Survives
- *  #114: it belongs to `meldOnlyBid`, the deliberately-weak skill-1 path the
- *  evaluator does not replace (see `SKILL_PARAMS` above). */
+/**
+ * The level every seat in a real game plays at, and the default for every
+ * engine entry point that takes one.
+ *
+ * `expert` rather than an arbitrary pick: the level decides
+ * `TRUMP_MEMORY_CAPACITY` (#157), which `SkillParams` deliberately does not
+ * carry, so this constant is the one remaining thing a level name still means
+ * outside `ab/` — 10 of 12 trump remembered, the top of the capacity ladder and
+ * the arm #158 measured best.
+ */
+export const SHIPPED_SKILL: SkillLevel = 'expert'
+
+/**
+ * What each level slot is currently configured to play.
+ *
+ * Every slot holds `SHIPPED_PARAMS`, because the product has one AI and the
+ * slots are not tiers — see `SkillLevel`. Nothing outside `src/ab/` should
+ * index this with anything but `SHIPPED_SKILL`.
+ *
+ * Mutable on purpose, and the only mutable export in `src/engine/`.
+ * `abRun.ts`'s `installPolicies` overwrites two entries for the duration of a
+ * run and restores them in a `finally`; that seam is what lets two policies
+ * live in one process, which a mirrored A/B needs because both arms sit at the
+ * same table. It survives the dial's removal deliberately (#215's explicit
+ * boundary) — collapsing this to a single frozen object would end paired A/B
+ * measurement, which is how `CLAUDE.md` says strategy changes are judged.
+ */
+export const SKILL_PARAMS: Record<SkillLevel, SkillParams> = Object.fromEntries(
+  SKILL_LEVELS.map((level) => [level, SHIPPED_PARAMS]),
+) as Record<SkillLevel, SkillParams>
+
+/** Flat trick-point estimate for meld-only bidding, matching Python's
+ *  `MELD_ONLY_TRICK_ESTIMATE` / `EASY_FLAT_TRICK_ESTIMATE`. Belongs to
+ *  `meldOnlyBid`, which since #222 is reachable only through
+ *  `installPolicies` — see `HandValuation` for why the arm stays. */
 export const MELD_ONLY_TRICK_ESTIMATE = 60
 
 /** Uniform noise range +/- for meld-only bidding ceiling. */

--- a/web/src/engine/tracker.test.ts
+++ b/web/src/engine/tracker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { SkillLevel } from '../persistence/options'
+import type { SkillLevel } from './skills'
 import { Card, Suit } from './card'
 import { SKILL_PARAMS } from './skills'
 import { Trick, type TrickPlay } from './trick'

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -16,9 +16,9 @@
 // capacity-limited to `2 x skill level` trump. `seenCount` below routes each
 // question to whichever of the two owns it — the exact tracker for side suits,
 // the seat's memory for trump — and that split is the only thing in this file
-// that behaves differently at different skill levels.
+// whose answer depends on which `SKILL_PARAMS` slot the seat is on. Every seat
+// in a real game is `SHIPPED_SKILL` (#222), so in practice that is 10 of 12.
 
-import type { SkillLevel } from '../persistence/options'
 import {
   type Card,
   handCount,
@@ -32,7 +32,7 @@ import {
   TOTAL_TRUMP_COPIES,
 } from './card'
 import { POINT_RANKS, type PlayerIndex, type TrickPlay } from './trick'
-import { SKILL_PARAMS } from './skills'
+import { SHIPPED_SKILL, SKILL_PARAMS, type SkillLevel } from './skills'
 import type { TrumpMemory } from './trumpMemory'
 
 /** Tracks cards played so far this round, across all 4 hands. */
@@ -216,10 +216,11 @@ function defenderLead(
  * Tier 3 is the leading half of #158: *"a counter that is provably boss is safe
  * to lead; one that is not, is not."* That was already true of side suits, where
  * `PlayTracker` counts exactly. What #158 adds is that when the card in question
- * is **trump**, the count comes from this seat's `TrumpMemory` instead — so an
- * `easy` seat holding the trump 10 with both Aces long gone often does not know
- * it, and drops to the junk tier rather than cashing it. That is the skill dial
- * during trick play, and it is reached here only on an all-trump hand:
+ * is **trump**, the count comes from this seat's `TrumpMemory` instead — so a
+ * seat holding the trump 10 with both Aces long gone may not know it, and drops
+ * to the junk tier rather than cashing it. How often that happens is the one
+ * thing capacity decides during trick play (10 of 12 on every shipped seat),
+ * and it is reached here only on an all-trump hand:
  * `offenseTrumpLead` and `defenderLead` both filter trump out first whenever the
  * hand has anything else.
  */
@@ -283,13 +284,13 @@ function leadSafeCascade(
  *
  * @param isBidderFirstLead - When true (bidder opening the first trick of the
  *   round), forces a trump lead if the player has any trump cards remaining.
- * @param skill - Skill level, read for `playPolicy` (#153). Since #156 every
- *   shipped row is `'cascade'` — the full Proficient cascade — so this argument
- *   no longer varies the strategy in a real game — except through
- *   `safeCounterPolicy`, which does not change the rule but does change how well
- *   this seat can answer it (#158). `'simple'` (low non-trump non-counter)
- *   survives as an A/B arm, reachable only through an override. Defaults to
- *   'hard'.
+ * @param skill - Which `SKILL_PARAMS` slot to read `playPolicy` (#153) from.
+ *   The shipped configuration is `'cascade'` — the full Proficient cascade —
+ *   and has been on every level since #156, so this argument does not vary the
+ *   strategy in a real game, except through `safeCounterPolicy`, which does not
+ *   change the rule but does change how well this seat can answer it (#158).
+ *   `'simple'` (low non-trump non-counter) survives as an A/B arm, reachable
+ *   only through an override. Defaults to `SHIPPED_SKILL`.
  * @param isBiddingTeam - Which side this seat is on. Undefined = fallback.
  * @param trumpMemory - This seat's capacity-limited view of the trump seen so
  *   far (#157), consulted only when `safeCounterPolicy` is `'counted'`. Omit it
@@ -300,7 +301,7 @@ export function chooseLeadCard(
   trump: Suit,
   tracker: PlayTracker,
   isBidderFirstLead = false,
-  skill: SkillLevel = 'hard',
+  skill: SkillLevel = SHIPPED_SKILL,
   isBiddingTeam?: boolean,
   trumpMemory?: TrumpMemory,
 ): Card {
@@ -512,12 +513,13 @@ function currentWinner(trickPlays: readonly TrickPlay[], trump: Suit): TrickPlay
  * exact tracker as load-bearing for the parity fixtures, and degrading that one
  * is its own issue with its own measurement.
  *
- * @param skill Skill level, read for `playPolicy` (#153) and
- *   `safeCounterPolicy` (#158). Since #156 every shipped row is `'cascade'`, so
- *   the tiers themselves are the same at every level; what the level changes is
- *   how much of the trump this seat can still recall when tier 2 of
- *   `chooseForcedBeat` asks. `'simple'` (play the lowest legal card) survives as
- *   an A/B arm, reachable only through an override. Defaults to 'hard'.
+ * @param skill Which `SKILL_PARAMS` slot to read `playPolicy` (#153) and
+ *   `safeCounterPolicy` (#158) from. The shipped configuration is `'cascade'`
+ *   and `'counted'`, so the tiers are the same wherever this is called from;
+ *   what the *level* changes is how much of the trump this seat can still recall
+ *   when tier 2 of `chooseForcedBeat` asks. `'simple'` (play the lowest legal
+ *   card) survives as an A/B arm, reachable only through an override. Defaults
+ *   to `SHIPPED_SKILL`.
  * @param trumpMemory This seat's capacity-limited trump view (#157). Consulted
  *   only when `safeCounterPolicy` is `'counted'`; omitted, trump questions fall
  *   back to the exact `tracker`, which is the pre-#158 reading.
@@ -529,7 +531,7 @@ export function chooseFollowCard(
   trump: Suit,
   myTeamPlayers: readonly PlayerIndex[],
   tracker?: PlayTracker,
-  skill: SkillLevel = 'hard',
+  skill: SkillLevel = SHIPPED_SKILL,
   trumpMemory?: TrumpMemory,
 ): Card {
   if (legalMoves.length === 1) return legalMoves[0]

--- a/web/src/engine/trumpMemory.test.ts
+++ b/web/src/engine/trumpMemory.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { SkillLevel } from '../persistence/options'
+import type { SkillLevel } from './skills'
 import { type CopyId, Card, RANKS, Suit, TOTAL_TRUMP_COPIES } from './card'
 import { TRUMP_MEMORY_CAPACITY, TrumpMemory, newTrumpMemories } from './trumpMemory'
 

--- a/web/src/engine/trumpMemory.ts
+++ b/web/src/engine/trumpMemory.ts
@@ -2,9 +2,14 @@
 // have been seen this round, in meld and in play.
 //
 // Trick-play *rules* are identical at every skill level (#156): every seat runs
-// the same cascade in `tracker.ts`. This module is the one thing the skill dial
-// still changes during trick play — not the decision, the information the
-// decision is made on. Same reasoning, worse recall.
+// the same cascade in `tracker.ts`. This module changes not the decision but the
+// information the decision is made on — same reasoning, worse recall.
+//
+// It was the one thing the difficulty setting still varied in trick play, and
+// #222 removed that setting: every seat in a shipped game is `SHIPPED_SKILL` and
+// remembers 10 of the 12 trump. The capacity ladder below survives as a ruler
+// rather than a dial — `safeCounterAbPolicies` varies the level to vary the
+// recall behind an unchanged rule, which is the comparison #158 exists to make.
 //
 // Why this is a sibling of `PlayTracker` rather than a subclass or a wrapper:
 // `PlayTracker` stores counts, not order, and order is exactly what a capacity
@@ -29,18 +34,22 @@
 // only from its own test, on purpose — #114 and #153's pattern of landing the
 // machinery inert so the behaviour change can be measured on its own.
 
-import type { SkillLevel } from '../persistence/options'
+import { SHIPPED_SKILL, type SkillLevel } from './skills'
 import type { Card, CopyId, Rank, Suit } from './card'
 import { extractMeldCards } from './melds'
 import type { PlayerIndex } from './trick'
 
 /**
  * How many of the 12 trump a seat can hold in mind at once: **2 x skill level**,
- * skill 1 (`easy`) through skill 5 (`expert`).
+ * slot 1 (`easy`) through slot 5 (`expert`).
  *
- * `expert` at 10 of 12 is deliberately imperfect. A tier that never forgets a
- * card is not a strong player, it is a different kind of thing to play against,
- * and the top of the dial is meant to still be beatable.
+ * Every shipped seat reads `expert`, so 10 of 12 is the number a player meets;
+ * the other four rungs are what `ab/` varies to measure recall (see
+ * `SkillLevel` in `skills.ts`).
+ *
+ * 10 of 12 is deliberately imperfect. An AI that never forgets a card is not a
+ * strong player, it is a different kind of thing to play against, and the AI
+ * this game ships is meant to still be beatable.
  *
  * The 12-copy total is `TOTAL_TRUMP_COPIES`, exported from `card.ts` and
  * derived there from the deck (#241). This module deliberately does **not**
@@ -97,7 +106,7 @@ export class TrumpMemory {
   readonly skill: SkillLevel
   readonly capacity: number
 
-  constructor(trump: Suit, skill: SkillLevel = 'hard') {
+  constructor(trump: Suit, skill: SkillLevel = SHIPPED_SKILL) {
     this.trump = trump
     this.skill = skill
     this.capacity = TRUMP_MEMORY_CAPACITY[skill]
@@ -174,11 +183,13 @@ export class TrumpMemory {
  * @param hands - Hands as of the start of trick play, i.e. after the 3-card
  *   pass and the meld reveal. Melds are derived from these.
  * @param skillOf - The level each seat plays at, which fixes its capacity.
+ *   Defaults to `SHIPPED_SKILL` for every seat, which is what a real game
+ *   wants since #222; `ab/` passes a real per-seat lookup.
  */
 export function newTrumpMemories(
   hands: readonly (readonly Card[])[],
   trump: Suit,
-  skillOf: (seat: PlayerIndex) => SkillLevel,
+  skillOf: (seat: PlayerIndex) => SkillLevel = () => SHIPPED_SKILL,
 ): Record<PlayerIndex, TrumpMemory> {
   const seats: readonly PlayerIndex[] = [0, 1, 2, 3]
   const meldBySeat = seats.map((seat) => extractMeldCards(hands[seat] ?? [], trump).meldCards)

--- a/web/src/persistence/options.test.ts
+++ b/web/src/persistence/options.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { DEFAULT_OPTIONS, SELECTABLE_SKILLS, loadOptions, saveOptions } from './options'
+import { DEFAULT_OPTIONS, loadOptions, saveOptions } from './options'
 
 afterEach(() => {
   window.localStorage.clear()
@@ -11,8 +11,8 @@ describe('options persistence', () => {
   })
 
   it('round-trips a saved options value', () => {
-    saveOptions({ showBaseBidHint: false, opponentSkill: 'hard', teammateSkill: 'expert', hideTrickLog: true })
-    expect(loadOptions()).toEqual({ showBaseBidHint: false, opponentSkill: 'hard', teammateSkill: 'expert', hideTrickLog: true })
+    saveOptions({ showBaseBidHint: false, hideTrickLog: true })
+    expect(loadOptions()).toEqual({ showBaseBidHint: false, hideTrickLog: true })
   })
 
   it('falls back to DEFAULT_OPTIONS on corrupt JSON', () => {
@@ -25,22 +25,16 @@ describe('options persistence', () => {
     const loaded = loadOptions()
     expect(loaded.hideTrickLog).toBe(false)
     expect(loaded.showBaseBidHint).toBe(true)
-    expect(loaded.opponentSkill).toBe(DEFAULT_OPTIONS.opponentSkill)
-    expect(loaded.teammateSkill).toBe(DEFAULT_OPTIONS.teammateSkill)
-
-    window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ opponentSkill: 42 }))
-    const loaded2 = loadOptions()
-    expect(loaded2.opponentSkill).toBe(DEFAULT_OPTIONS.opponentSkill)
 
     window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ showBaseBidHint: 'nope' }))
     expect(loadOptions()).toEqual(DEFAULT_OPTIONS)
   })
 
-  // #142 removed `hideOpponentCards` and #148 removed `showMeldHint`, but the
-  // storage key is deliberately NOT bumped: a new key would reset everyone's
-  // surviving preferences (the skill levels especially). Leftover keys from
-  // both removals must simply be ignored, including in the same payload — a
-  // save written before either removal carries both.
+  // #142 removed `hideOpponentCards`, #148 removed `showMeldHint`, and #222
+  // removed `opponentSkill`/`teammateSkill` with the difficulty setting. The
+  // storage key is deliberately NOT bumped for any of them: a new key would
+  // reset everyone's surviving preferences to buy nothing. Leftover keys from
+  // every removal must simply be ignored, including in the same payload.
   it('ignores leftover keys from removed options without disturbing the other saved preferences', () => {
     window.localStorage.setItem(
       'pinochle:options:v1',
@@ -53,38 +47,25 @@ describe('options persistence', () => {
       }),
     )
     const loaded = loadOptions()
-    expect(loaded).toEqual({
-      ...DEFAULT_OPTIONS,
-      opponentSkill: 'expert',
-      teammateSkill: 'proficient',
-      showBaseBidHint: false,
-    })
+    expect(loaded).toEqual({ ...DEFAULT_OPTIONS, showBaseBidHint: false })
     expect('hideOpponentCards' in loaded).toBe(false)
     expect('showMeldHint' in loaded).toBe(false)
   })
 
-  // #194 retired engine levels 1-2 from the panel. A save written before that
-  // still names one, and the player who wrote it chose "as weak as possible" —
-  // so it lands on the weakest tier still offered, not on the (stronger)
-  // default, which would be a bigger change than the setting going away.
-  it('redirects a saved skill level that is no longer selectable to the new floor', () => {
-    window.localStorage.setItem(
-      'pinochle:options:v1',
-      JSON.stringify({ opponentSkill: 'easy', teammateSkill: 'medium' }),
-    )
-    const loaded = loadOptions()
-    expect(loaded.opponentSkill).toBe('hard')
-    expect(loaded.teammateSkill).toBe('hard')
-    expect(loaded.opponentSkill).not.toBe(DEFAULT_OPTIONS.opponentSkill)
-  })
-
-  // The three offered tiers keep the identifiers Python and every measurement in
-  // skills.ts use, which is the whole reason the storage key did not need
-  // bumping: a stored 'hard' means the same AI it always did.
-  it('keeps every selectable level loadable unchanged', () => {
-    for (const skill of SELECTABLE_SKILLS) {
-      window.localStorage.setItem('pinochle:options:v1', JSON.stringify({ opponentSkill: skill }))
-      expect(loadOptions().opponentSkill).toBe(skill)
+  // The specific blob a returning player has (#222). Every level name the panel
+  // could ever have written — including `easy` and `medium`, which #194 had
+  // already retired and mapped to a floor — must load to the same options and
+  // must not leak a skill field back into the game.
+  it('loads any pre-#222 saved difficulty without carrying it forward', () => {
+    for (const skill of ['easy', 'medium', 'hard', 'proficient', 'expert']) {
+      window.localStorage.setItem(
+        'pinochle:options:v1',
+        JSON.stringify({ showBaseBidHint: true, opponentSkill: skill, teammateSkill: skill, hideTrickLog: false }),
+      )
+      const loaded = loadOptions()
+      expect(loaded).toEqual({ showBaseBidHint: true, hideTrickLog: false })
+      expect('opponentSkill' in loaded).toBe(false)
+      expect('teammateSkill' in loaded).toBe(false)
     }
   })
 })

--- a/web/src/persistence/options.ts
+++ b/web/src/persistence/options.ts
@@ -5,87 +5,19 @@
 
 const OPTIONS_KEY = 'pinochle:options:v1'
 
-/** Every AI tier the *engine* defines — `skills.ts`'s `SKILL_PARAMS`, and
- * `trumpMemory.ts`'s `TRUMP_MEMORY_CAPACITY` (`2 x level`), keyed 1-5 in that
- * order. Not the same set as what a player can choose: see `SELECTABLE_SKILLS`. */
-export type SkillLevel = 'easy' | 'medium' | 'hard' | 'proficient' | 'expert'
-
-/**
- * The three tiers the Options panel offers, and the only values `GameOptions`
- * can hold (#194).
- *
- * Paul's ask was "eliminate skill levels 1 and 2, rename 3/4/5 to Easy/Medium/
- * Hard, default to Medium". This is that ask, implemented where it can actually
- * be implemented. **The engine keeps all five levels**, because levels 1-2 are
- * not only player-facing settings:
- *
- *   - `engineParity.fixture.ts` is *generated from Python* and pins seats to
- *     `'easy'`. Deleting the value breaks the parity contract that
- *     `export_parity_scenarios.py` exists to guard — Python is authoritative for
- *     ported constants (CLAUDE.md), so the TS side cannot unilaterally drop one.
- *   - `abRun.ts`'s `SAFE_COUNTER_CONTROL` uses `'easy'` and `'medium'` as the
- *     capacity controls for #158's measurement, on the same reasoning `skills.ts`
- *     gives for keeping the `'simple'` and `'never'` policy arms: an A/B needs
- *     two levels differing in one field, so removing a level removes a ruler.
- *
- * So levels 1-2 stop being *reachable*, which is what a player experiences, and
- * stay *defined*, which is what the harness needs.
- *
- * The display names live in `OptionsPanel`, which has always relabelled these
- * (it showed `proficient` as "Expert" and `expert` as "Master"). Mapping is:
- * `hard` -> Easy, `proficient` -> Medium, `expert` -> Hard. Note that the
- * identifiers deliberately still mean what they meant to Python and to every
- * measurement in `skills.ts` — a stored `'hard'` is the same AI it always was,
- * which is why no storage-key bump is needed here.
- */
-export const SELECTABLE_SKILLS = ['hard', 'proficient', 'expert'] as const satisfies readonly SkillLevel[]
-export type SelectableSkill = (typeof SELECTABLE_SKILLS)[number]
-
-/** Where a stored level that is no longer selectable lands: the new floor. A
- *  player who had chosen 1 or 2 gets the weakest tier still on offer rather than
- *  being silently jumped to the default, which would be a bigger change than
- *  their setting going away. */
-const RETIRED_SKILLS: Readonly<Record<string, SelectableSkill>> = {
-  easy: 'hard',
-  medium: 'hard',
-}
-
 export interface GameOptions {
   /** Show BiddingControls' "Your hand suggests up to N" hint during the
    * human's bidding turn. On by default, matching current behavior. */
   readonly showBaseBidHint: boolean
-  /** AI skill level for the two opponents (#79). */
-  readonly opponentSkill: SelectableSkill
-  /** AI skill level for the human's teammate (#79). */
-  readonly teammateSkill: SelectableSkill
   /** Hide the trick-play event log (card plays, trick winners). Default on
    * (#81) so the table is less cluttered; turn off to see every play logged
    * in the right-hand panel. The bid/auction history is always shown. */
   readonly hideTrickLog: boolean
 }
 
-/** Default skill is **Medium** (#194), i.e. engine level 4. It was `'hard'`
- *  (level 3) before, so a fresh install now gets a slightly stronger table:
- *  same rules and same card play — every level has shared those since #156 —
- *  with 8 trump remembered instead of 6. */
 export const DEFAULT_OPTIONS: GameOptions = {
   showBaseBidHint: true,
-  opponentSkill: 'proficient',
-  teammateSkill: 'proficient',
   hideTrickLog: true,
-}
-
-const SELECTABLE = new Set<string>(SELECTABLE_SKILLS)
-
-/**
- * Resolves a stored skill value: a selectable level is kept as-is, a retired one
- * (1-2) maps to the new floor, and anything else — a corrupt value, a number, a
- * level name that never existed — falls back.
- */
-function parseSkill(raw: unknown, fallback: SelectableSkill): SelectableSkill {
-  if (typeof raw !== 'string') return fallback
-  if (SELECTABLE.has(raw)) return raw as SelectableSkill
-  return RETIRED_SKILLS[raw] ?? fallback
 }
 
 /** Reads saved options from localStorage, falling back to DEFAULT_OPTIONS
@@ -98,23 +30,21 @@ export function loadOptions(): GameOptions {
     const parsed: unknown = JSON.parse(raw)
     if (typeof parsed !== 'object' || parsed === null) return DEFAULT_OPTIONS
     // Destructures only the fields it knows about, so keys left behind by
-    // removed options (`hideOpponentCards`, dropped in #142; `showMeldHint`,
-    // dropped in #148) are ignored rather than migrated. That is why
-    // OPTIONS_KEY is *not* bumped when an option goes away: a new key would
-    // silently reset every player's surviving preferences — the skill levels
-    // especially.
+    // removed options are ignored rather than migrated — `hideOpponentCards`
+    // (dropped in #142), `showMeldHint` (#148), and now `opponentSkill` /
+    // `teammateSkill` (#222, the difficulty setting). That is why OPTIONS_KEY
+    // is *not* bumped when an option goes away: a new key would silently reset
+    // every player's surviving preferences, which is a real cost paid to avoid
+    // a field this function never reads.
     //
-    // #194 retired two skill levels without bumping it either, and that is safe
-    // for a stronger reason than habit: the level *identifiers* did not change
-    // meaning, only which of them the panel offers. A stored `'hard'` is the
-    // same tier it was before, so there is no version of this value that needs
-    // disambiguating — `parseSkill` only has to redirect the two that are no
-    // longer reachable.
-    const { showBaseBidHint, opponentSkill, teammateSkill, hideTrickLog } = parsed as Partial<GameOptions>
+    // So a returning player who had chosen a difficulty keeps their hint and
+    // trick-log toggles, loses the setting, and gets the one shipped AI. The
+    // dead keys stay in localStorage until the next `saveOptions` overwrites
+    // the blob; nothing reads them in the meantime, and JSON with extra keys
+    // is not a broken blob.
+    const { showBaseBidHint, hideTrickLog } = parsed as Partial<GameOptions>
     return {
       showBaseBidHint: typeof showBaseBidHint === 'boolean' ? showBaseBidHint : DEFAULT_OPTIONS.showBaseBidHint,
-      opponentSkill: parseSkill(opponentSkill, DEFAULT_OPTIONS.opponentSkill),
-      teammateSkill: parseSkill(teammateSkill, DEFAULT_OPTIONS.teammateSkill),
       hideTrickLog: typeof hideTrickLog === 'boolean' ? hideTrickLog : DEFAULT_OPTIONS.hideTrickLog,
     }
   } catch {


### PR DESCRIPTION
Closes #222

The main change of epic #215. Player-visible: the Options panel's Easy/Medium/Hard
rows are gone and every AI seat plays what was `expert` — distilled bidding, cascade
card play, `model` folding, `forced` auto-SET, `counted` safe counters, trump memory
10 of 12.

Verified on top of `26f96e0` (#221's merge), not on the branch in isolation.

## How `ab/` can still vary a policy

This is the crux, so it is the first thing here rather than the last.

`SkillParams` was two things under one name: the difficulty dial, and the ruler
`abRun.ts` measures with. Only the first is removed.

- **`SKILL_PARAMS` keeps all five level keys and stays mutable.** What collapsed is
  its *content*, not its shape: one `SHIPPED_PARAMS` object fanned across the five
  slots instead of five hand-written rows that agreed on every column. That is #222's
  "collapsed to the single shipped configuration" without taking the seam away.
- **`installPolicies` is untouched**, and so are `BID_AB_POLICIES`,
  `FOLD_AB_POLICIES`, `AUTO_SET_AB_POLICIES`, `PLAY_AB_POLICIES`,
  `safeCounterAbPolicies` and `safeCounterCapacityPolicies`. Nothing in `web/src/ab/`
  lost an arm.
- **Five keys and not two, deliberately.** `TRUMP_MEMORY_CAPACITY` is keyed on the
  level and is *not* a `SkillParams` field (#157), so the level a `'counted'` arm sits
  on **is** the capacity under test (#158). Collapse the keys and
  `capacity --high expert --low easy` has no question left to ask. A comparison also
  needs two keys differing in one field; one key is no comparison at all.
- **Every arm still runs.** Smoke-run against this tree, all varying what they claim
  to: `bid` (distilled vs static, +120/deal at 6 pairs), `play` (cascade vs simple),
  `capacity --high expert --low easy` (counted@expert vs counted@easy), plus `fold`,
  `autoset` and `safe`. `selftest` still finds exactly nothing — every deal split,
  paired margin exactly zero — which is `ab.test.ts`'s self-test property holding.

`SkillLevel` moves from `persistence/options.ts` to `engine/skills.ts`. It lived in
persistence because a stored preference carried it; there is no stored preference now,
so it is engine configuration, and its docstring says plainly that a level name inside
`ab/` is a slot and a level name outside it should be `SHIPPED_SKILL`.

## Saved games and stored options — checked, not assumed

**No in-progress game is discarded and no surviving preference is lost.**

- `gameSave.ts`'s `SAVE_VERSION` is **not** bumped and did not need to be.
  `GameFlowState` never carried a skill or an options blob — `GameShell` holds options
  in React state from `loadOptions()`, and the save is the reducer state — so there is
  no field in the save format to migrate. A player mid-hand resumes exactly where they
  were.
- `OPTIONS_KEY` is **not** bumped either, following the reasoning already written into
  `loadOptions`: it destructures only the fields it knows about, so `opponentSkill` and
  `teammateSkill` are read past rather than migrated, exactly as `hideOpponentCards`
  (#142) and `showMeldHint` (#148) already are. A returning player keeps
  `showBaseBidHint` and `hideTrickLog` and simply no longer has a difficulty. The dead
  keys sit in localStorage until the next `saveOptions` overwrites the blob; nothing
  reads them, and JSON with extra keys is not a broken blob. A version bump would have
  reset the two surviving toggles to buy nothing.
- `options.test.ts` pins it: a pre-change blob at every level name the panel could ever
  have written — including `easy` and `medium`, which #194 had already retired — loads
  to the same options, with no skill field leaking forward.

The one behaviour a resuming player sees change: trump memories are rebuilt at
`SHIPPED_SKILL`, so a hand that was being played at "Easy" resumes with 10-of-12 recall
instead of 6. That is the intended effect of the change, not a save-format problem.

## `openingPolicy` — #221's leftover, cleared here

#221 landed while this was open. It retired the `'walk'` arm and left `openingPolicy` a
one-member type *explicitly* because removing the field touches every row of
`SKILL_PARAMS` and of the `*_AB_POLICIES` maps — "which is #222's diff, not this one",
in its own words. So the field is removed here. A field nothing can vary measures
nothing, and the finding it carried is preserved where a retired arm's numbers belong:
`chooseBid`'s opening branch in `bidding.ts` and `web/README.md`'s "What the opener puts
on the table", neither of which this PR touches. #221's `'walk'` arm itself is not
resurrected or re-deleted — it was already gone before this branch rebased.

## Also in scope

- **`skillForPlayer` (#240's deferral)** resolved by deleting *both* copies — the one in
  `AuctionFlow.tsx` and the byte-identical one in `TrickPlayFlow.tsx` — rather than
  extracting a third. There is nothing left to look up.
- **Everything naming a difficulty**: the panel's "Skill Level" heading, the Opponents
  and Teammate selects and their labels, `SKILL_LABELS`, `SELECTABLE_SKILLS`,
  `SelectableSkill`, `RETIRED_SKILLS`, `parseSkill`. `OptionsPanel` is now two display
  toggles and a Done button.
- **`SHIPPED_PARAMS`' docstring answers #215's engineering note directly**: one table,
  every field against what ships and what only `ab/` can reach, so "which columns are
  live" is one read rather than six docstrings.
- **Docs**: `web/README.md`'s structure section and its one-line description of how
  `chooseBid` selects a policy; the root `README.md`'s feature summary and AI section;
  `pinochle_rules.md`'s Implementation Notes; `CODING_STANDARDS.md`'s dial section, now
  describing a measuring instrument rather than a difficulty setting. **The A/B
  measurement tables in `web/README.md` are untouched** — #269 owns those — including
  the `openingPolicy` paragraph #221 added.

## Tests changed, one line each on why

Nothing was deleted because it broke.

| test | what happened |
| --- | --- |
| `options.test.ts` "redirects a saved skill level that is no longer selectable" | **Deleted.** Asserts #194's retired-level floor, a behaviour that no longer exists. |
| `options.test.ts` "keeps every selectable level loadable unchanged" | **Deleted.** Asserts `SELECTABLE_SKILLS`, which no longer exists. |
| `options.test.ts` "loads any pre-#222 saved difficulty without carrying it forward" | **Added.** The migration this issue asks for, over all five level names. |
| `options.test.ts` "ignores leftover keys from removed options" | Extended to carry `opponentSkill`/`teammateSkill` alongside #142's and #148's dead keys. |
| `OptionsPanel.test.tsx` "has skill-level controls for Opponent and Teammate (#79)" | **Inverted** into "has no difficulty control (#222)" — same shape as the panel's existing #142/#148 guards, and it checks for no combobox and no matching text as well as no labels, since the control could return under another name. |
| `AuctionFlow.test.tsx` "asks the human for exactly 3 cards… at skill %s" | `it.each` over five stored levels → one `it`. With no stored level the five cases were five identical renders. The property #196 was really about is pinned across every configuration in `passing.test.ts`. |
| `AuctionFlow.test.tsx` "the pass exchange conserves the deck" | Sweep now sources `SKILL_LEVELS` from the engine; comment says what it varies now (deal, trump, bidder seat) and points at `passing.test.ts` for the policy coverage. |
| `passing.test.ts` "the 3-card pass is invariant across skill levels (#196)" | Would silently have become one branch run five times, since `choosePassCards` branches on `handValuation`. Now installs `'meld_only'` onto one slot for the describe's lifetime — same coverage as before, explicitly. |
| `bidding.test.ts` (13 call sites) | Same failure mode, larger: `'medium'` meant "the static rule". Four failed outright; the rest would have kept passing while asserting something else. Two slots — `STATIC_LEVEL`, `MELD_ONLY_LEVEL` — installed for the file's lifetime, so each test names the rule it is aimed at. |
| `evaluator.test.ts` "runs the evaluator on hard and above" | Described a gate across tiers. Now asserts what ships *and* that no slot carries a stale configuration — the same drift guard pointed at one row. |
| `evaluator.test.ts` static and meld-only probes | Kept; reached through an installed arm instead of a level name. |
| `TrickPlayFlow.test.tsx` `AI_TIER` | Read `DEFAULT_OPTIONS.opponentSkill`, now reads `SHIPPED_SKILL`. Still read rather than named, for the reason its docstring gives. |

## Verification

- TypeScript: **42 files / 498 tests passed**, on a 503 baseline. The five fewer are
  exactly the five accounted for above (−4 `it.each`, −2 +1 in `options.test.ts`).
- `npx tsc -b` clean; `npx tsc --noEmit -p tsconfig.app.json` clean.
- `oxlint` clean apart from the pre-existing `dealer` exhaustive-deps warning in
  `TrickPlayFlow` — verified identical on `origin/main`.
- `npm run build` clean.
- Python: **336 passed**, unchanged. Its `GENERAL_STRATEGY_SKILL_PARAMS` dial is
  research apparatus and is untouched; nothing in the Python suite depends on the TS
  side of this.
- `src/ab/cli.ts`: `selftest`, `bid`, `play`, `fold`, `autoset`, `safe` and `capacity`
  all run and vary what they claim to.

Out of scope, as briefed: the A/B measurement record in `web/README.md` (#269), any
re-measurement (#270), and the arm-retirement rule text (#223).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
