### PR TITLE
test(trick-play): guard the resume test against a claimed play-out (#264)

### DIFF
--- a/web/src/components/TrickPlayFlow.test.tsx
+++ b/web/src/components/TrickPlayFlow.test.tsx
@@ -667,13 +667,25 @@ describe('TrickPlayFlow (component)', { timeout: COMPONENT_SUITE_TIMEOUT_MS }, (
     expect(screen.queryByRole('button', { name: 'Concede hand' })).toBeNull()
     expect(onComplete).not.toHaveBeenCalled()
 
-    driveUntil(() => onComplete.mock.calls.length > 0)
+    const actions = driveUntil(() => onComplete.mock.calls.length > 0)
+
+    // The guard that makes the title of this test true, and the one #261
+    // learned the hard way is missing without it. `trickWinners` reaching 12
+    // and the points reaching 250 are both satisfied by a claim, which
+    // *awards* the remainder rather than skipping it — so on their own they
+    // cannot tell ten resumed tricks from one resumed trick and nine claimed
+    // ones. Ten, not twelve: this mount restarts from a checkpoint taken after
+    // trick two, so the human has ten cards left to click, one per remaining
+    // trick.
+    expect(actions.filter((action) => action === 'play')).toHaveLength(10)
+    expect(actions).not.toContain('claim')
 
     // A resumed hand is one hand: the restored tricks and the played-on ones
     // add up to a whole round, with every trick point accounted for exactly
     // once. Double-counting or dropping the restored half would show here.
     expect(onComplete).toHaveBeenCalledOnce()
     const result = onComplete.mock.calls[0][0] as TrickPlayResult
+    expect(result.claim).toBeUndefined()
     expect(result.trickWinners).toHaveLength(12)
     expect(result.trickWinners.slice(0, 2)).toEqual(snapshot.trickWinners)
     expect(result.trickPointsByTeam[0] + result.trickPointsByTeam[1]).toBe(250)


### PR DESCRIPTION
Closes #264

`web/src/components/TrickPlayFlow.test.tsx`'s resume test ended on the same two
assertions #261 proved cannot distinguish a played trick from a claimed one:
`trickWinners` reaching 12 and the trick points summing to 250. A claim
*awards* the remainder rather than skipping it, so both hold either way. This
adds the guard #261 built the mechanism for, using `driveUntil`'s returned
actions.

```ts
expect(actions.filter((action) => action === 'play')).toHaveLength(10)
expect(actions).not.toContain('claim')
```

Ten, not twelve: this mount restarts from a checkpoint taken after trick two,
so ten cards are left for the human to click. `result.claim` is asserted
undefined alongside, matching the end-to-end test. Every existing assertion is
kept.

## The seed had not drifted

The issue was filed before #273 (meld scoring), #277 (bid valuation), #280
(pass priority), #283 (bid cap) and #226 (evaluator refit) landed, any of which
could move what the AI does with a pinned deal. Verified rather than assumed:
seed 217's resumed hand still plays ten tricks by hand with no claim offered at
any boundary, and the new guard passes unmodified.

## The guard was watched failing

`findClaim` was temporarily made to return a claim at the first boundary after
the resume, awarding the nine remaining tricks with the counters still out plus
the last-trick bonus — a claim that completes the round honestly rather than
truncating it. Under that break the resumed hand plays **one** trick and claims
nine, and:

- `expect(result.trickWinners).toHaveLength(12)` — still passed
- `expect(result.trickWinners.slice(0, 2)).toEqual(snapshot.trickWinners)` — still passed
- points summing to 250 — still passed
- the new play-count assertion — **failed**: `expected [ 'play' ] to have a length of 10 but got 1`

So the blindness is demonstrated in both directions on the same hand: the old
pair green, the new guard red. The `findClaim` edit was reverted with `git
checkout` and is not in this branch; the diff is one test file, additive.

## No shared helper

Grepping the file turns up two live call sites for the pattern, not three —
this test and the end-to-end one #261 already fixed. The remaining
`trickWinners` assertions are `toHaveLength(0)` on the concede and auto-SET
paths, where a claim would push the count *up* and be caught, and the claim
test asserts `[0, 0]` because a claim is what it wants. An `expectPlayedOut`
helper over two sites with different counts reads worse than the two lines it
would hide. Revisit if a third appears.

## Verification

- `npm test -- --run --maxWorkers=2` — **42 files, 523 tests, all passing**
- `npx tsc --noEmit -p tsconfig.app.json` — clean
- No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
