### PR TITLE
fix(ab): stop the latency instrument reporting an unmeasured arm as free (#293)

### DIFF
--- a/web/src/ab/latency.test.ts
+++ b/web/src/ab/latency.test.ts
@@ -301,19 +301,41 @@ describe('the benchmark report', () => {
     expect(report.disagreementRate).toBe(report.disagreements / report.decisions)
   })
 
-  it('reports zero samples rather than a rate of NaN when nothing was measured', () => {
-    // The degenerate case an instrument must not paper over. `samples: 0` is
-    // the honest signal, and the guarded divisor keeps the rate a number.
-    // Note what it does *not* do: every microsecond field reads 0, and
-    // `formatLatency` prints no sample count, so a rendered empty report is
-    // indistinguishable from a measured one that cost nothing (#293).
+  it('reports NaN rather than a measured zero when nothing was measured', () => {
+    // The degenerate case an instrument must not paper over (#293). Zero is a
+    // reading this module can legitimately produce — a clock clamped coarser
+    // than the decision returns 0.00us — so an unmeasured arm reporting 0 is
+    // not vague, it is wrong in the direction that flatters the model. NaN is
+    // the value no caller can compare against a budget and pass.
     const report = runLatencyBenchmark(0, 2, true)
+    expect(report.amortised.length + report.singleShot.length).toBe(4)
     for (const summary of [...report.amortised, ...report.singleShot]) {
       expect(summary.samples).toBe(0)
+      for (const field of [summary.mean, summary.p50, summary.p95, summary.p99, summary.max]) {
+        expect(Number.isNaN(field)).toBe(true)
+      }
+      // The comparison an affordability claim would be made with: 0 passes it
+      // on no data, NaN cannot.
+      expect(summary.p95 < 1000).toBe(false)
     }
     expect(report.decisions).toBe(0)
+    // The rate stays a number, and unlike the microsecond fields it is printed
+    // beside the 0/0 it came from, so the output discloses its own emptiness.
     expect(report.disagreementRate).toBe(0)
     expect(Number.isNaN(report.disagreementRate)).toBe(false)
+  })
+
+  it('keeps every field a number as soon as there is one position to measure', () => {
+    // The other side of the guard: the empty branch must not leak into a run
+    // that measured something, however little.
+    numberPositionsOnFirstSight()
+    const report = runLatencyBenchmark(1, 2, true)
+    for (const summary of [...report.amortised, ...report.singleShot]) {
+      expect(summary.samples).toBe(1)
+      for (const field of [summary.mean, summary.p50, summary.p95, summary.p99, summary.max]) {
+        expect(field).toBe(1000)
+      }
+    }
   })
 })
 
@@ -364,15 +386,48 @@ describe('the rendered report', () => {
     expect(text).not.toContain('Single-shot')
   })
 
-  it('renders a report with no samples without throwing', () => {
-    const empty = summary('static', 0, 0)
+  it('says an empty arm measured nothing instead of printing a row of zeros', () => {
+    // #293: the row a reader scans is the whole output for most of this
+    // module's users, and `mean 0.00us   p50 0.00us   ...` is what a decision
+    // costing nothing looks like. An arm that never ran must not be able to
+    // wear that. It renders without throwing, because `benchPage.ts` takes its
+    // position count from a text input and can ask for none.
     const text = formatLatency({
-      amortised: [{ ...empty, samples: 0 }],
+      amortised: [{ label: 'static', samples: 0, mean: NaN, p50: NaN, p95: NaN, p99: NaN, max: NaN }],
       singleShot: [],
       disagreementRate: 0,
       disagreements: 0,
       decisions: 0,
     })
     expect(text).toContain('over 0 real auction positions')
+    const line = text.split('\n').find((l) => l.trimStart().startsWith('static')) as string
+    expect(line).toBe('    static     no positions measured')
+    expect(text).not.toContain('NaN')
+  })
+
+  it('still prints a measured zero as a figure, so the two cannot be confused', () => {
+    // The reading the empty row is not allowed to imitate. A coarse clock can
+    // genuinely report 0.00us per decision, and that is a measurement: it keeps
+    // its numeric row, and the two renderings share no line.
+    const measuredZero = formatLatency({
+      amortised: [{ label: 'static', samples: 200, mean: 0, p50: 0, p95: 0, p99: 0, max: 0 }],
+      singleShot: [],
+      disagreementRate: 0,
+      disagreements: 0,
+      decisions: 200,
+    })
+    expect(measuredZero).toContain('static     mean    0.00us')
+    expect(measuredZero).not.toContain('no positions measured')
+  })
+
+  it('leaves a measured row byte-for-byte as it was', () => {
+    // The empty case is worth nothing if it costs the populated rows their
+    // legibility, so the format is pinned exactly rather than by substring.
+    const line = formatLatency(report)
+      .split('\n')
+      .find((l) => l.trimStart().startsWith('static')) as string
+    expect(line).toBe(
+      '    static     mean   41.50us   p50   41.50us   p95   62.25us   p99   62.25us   max    62.25us',
+    )
   })
 })

--- a/web/src/ab/latency.ts
+++ b/web/src/ab/latency.ts
@@ -53,8 +53,10 @@ export function collectSituations(count: number, level: SkillLevel, seed = 7): B
 
 export interface LatencySummary {
   readonly label: string
+  /** Positions measured. Zero means nothing was measured, and every field
+   *  below is then `NaN` rather than a number — see `summarise`. */
   readonly samples: number
-  /** Microseconds per decision. */
+  /** Microseconds per decision. `NaN` when `samples` is 0. */
   readonly mean: number
   readonly p50: number
   readonly p95: number
@@ -62,11 +64,30 @@ export interface LatencySummary {
   readonly max: number
 }
 
+/**
+ * Statistics over one arm's per-decision costs.
+ *
+ * An empty sample reports `NaN`, not 0 (#293). Zero is a legitimate reading
+ * here — a clock clamped coarser than the decision genuinely returns 0.00us —
+ * so an unmeasured arm reporting 0 is not merely uninformative, it is
+ * indistinguishable from a real measurement of a free decision. `NaN` is the
+ * value that cannot be mistaken for one, and it fails every comparison a caller
+ * might use to claim the model is affordable. That is the same service
+ * `stats.ts` does by returning 1.0 from `binomialTwoSidedP` on zero trials: the
+ * number handed back must not support a claim the data cannot.
+ *
+ * It returns rather than throws because an empty sample is reachable —
+ * `benchPage.ts` takes its position count from a text input — and an instrument
+ * asked to measure nothing has an honest answer available.
+ */
 function summarise(label: string, micros: number[]): LatencySummary {
+  if (micros.length === 0) {
+    return { label, samples: 0, mean: NaN, p50: NaN, p95: NaN, p99: NaN, max: NaN }
+  }
   return {
     label,
     samples: micros.length,
-    mean: micros.reduce((s, v) => s + v, 0) / Math.max(1, micros.length),
+    mean: micros.reduce((s, v) => s + v, 0) / micros.length,
     p50: percentile(micros, 0.5),
     p95: percentile(micros, 0.95),
     p99: percentile(micros, 0.99),
@@ -196,11 +217,18 @@ export function runLatencyBenchmark(situationCount = 3000, repeats = 40, include
   }
 }
 
+/** An arm with nothing in it says so in words rather than printing a row of
+ *  figures. The measured row is left exactly as it was: `samples` is either 0
+ *  or the position count already in the header, so printing it on every row
+ *  would add a column repeating the header for the sake of a case this line
+ *  covers outright. */
 export function formatLatency(report: LatencyReport): string {
   const row = (s: LatencySummary) =>
-    `    ${s.label.padEnd(11)}mean ${s.mean.toFixed(2).padStart(7)}us   ` +
-    `p50 ${s.p50.toFixed(2).padStart(7)}us   p95 ${s.p95.toFixed(2).padStart(7)}us   ` +
-    `p99 ${s.p99.toFixed(2).padStart(7)}us   max ${s.max.toFixed(2).padStart(8)}us`
+    s.samples === 0
+      ? `    ${s.label.padEnd(11)}no positions measured`
+      : `    ${s.label.padEnd(11)}mean ${s.mean.toFixed(2).padStart(7)}us   ` +
+        `p50 ${s.p50.toFixed(2).padStart(7)}us   p95 ${s.p95.toFixed(2).padStart(7)}us   ` +
+        `p99 ${s.p99.toFixed(2).padStart(7)}us   max ${s.max.toFixed(2).padStart(8)}us`
   const lines = [
     `Per-decision latency over ${report.decisions} real auction positions`,
     '',


### PR DESCRIPTION
Closes #293

`summarise` in `web/src/ab/latency.ts` reported `mean 0, p50 0, p95 0, p99 0,
max 0` for a sample it never took, and `formatLatency` printed no sample count,
so a rendered arm that measured nothing was byte-for-byte an arm that measured a
free decision. Found while writing #235's tests and reported there rather than
folded into a test PR.

## The shape, and why

**`summarise` returns `NaN` for every microsecond field when `samples` is 0;
`formatLatency` prints `no positions measured` for that row instead of a row of
figures.**

The argument for `NaN` over 0 is not "0 is uninformative". It is that **0 is a
reading this module can legitimately produce** — `latency.ts`'s own header
explains that Chrome clamps `performance.now()` to 100 µs, so a single-shot
sample there really does read `0.00us` for a decision that took microseconds. An
empty arm reporting 0 is therefore not vague, it is wrong in the one direction
that flatters the model, in a shape a reader already knows how to interpret.
`NaN` cannot be mistaken for a measurement and fails every comparison an
affordability claim would be made with (`p95 < budget` is `false` on no data,
not `true`) — the same service `stats.ts` does by returning 1.0 from
`binomialTwoSidedP` on zero trials.

The rendered row says it in words rather than printing `mean     NaNus` four
times across, because this output exists to be scanned. It is a whole-row
substitution, so **not one character of the populated format changed** — a new
test pins that line exactly rather than by substring, since a fix for a
degenerate case that costs the normal case its legibility has traded down.

Considered and not done:

- **Print `n=` on every row** (the issue's first option) — adds a column that
  repeats the header. An arm's `samples` is either 0 or the position count
  already in `over N real auction positions`, because each arm takes exactly one
  sample per position.
- **`LatencySummary | null` or a discriminated union** — moves the check to
  every reader for a case with two of them, and discards the `label`, the one
  field an empty arm still has something to say with.
- **Throwing** — `benchPage.ts` takes its position count from a text input, so
  `runLatencyBenchmark(0)` is reachable by a human typing in a browser, and an
  instrument asked to measure nothing has an honest answer available.

`disagreementRate` deliberately keeps its guarded divisor and stays 0 on zero
decisions: unlike the microsecond fields it is printed beside the `0/0` it came
from, so that line already discloses its own emptiness.

Nothing crosses the `web/src/ab/` boundary — no new import, no new export, both
files already measurement-only (#236 is untouched).

## Before / after

`node node_modules/jiti/lib/jiti-cli.mjs src/ab/cli.ts latency --positions 0 --repeats 4`

Before:

```
Per-decision latency over 0 real auction positions

  Amortised (each position timed over repeats — comparable across runtimes):
    static     mean    0.00us   p50    0.00us   p95    0.00us   p99    0.00us   max     0.00us
    distilled  mean    0.00us   p50    0.00us   p95    0.00us   p99    0.00us   max     0.00us
```

After:

```
Per-decision latency over 0 real auction positions

  Amortised (each position timed over repeats — comparable across runtimes):
    static     no positions measured
    distilled  no positions measured
```

A populated report is unchanged:

```
    static     mean   24.98us   p50   24.02us   p95   28.64us   p99   38.13us   max    38.13us
    distilled  mean   43.30us   p50   52.96us   p95   59.75us   p99   64.09us   max    64.09us
```

## Tests

#235's `reports zero samples rather than a rate of NaN when nothing was
measured` now asserts the honest behaviour and its comment naming the gap is
gone. Three tests added:

- the empty summary is `NaN` in every field, including the `p95 < budget`
  comparison a caller would make;
- one measured position keeps every field a number, so the guard cannot leak
  into a real run;
- a *measured* zero (200 samples, all zero) still renders as figures — the
  reading the empty row is no longer allowed to imitate.

**Both new guards were watched failing** against the unfixed module:
`expected false to be true` on the NaN assertion, and
`expected '    static     mean     NaNus   p50  …' to be '    static     no positions measured'`
once only `summarise` was fixed.

## Verification

- `npm test -- --run --maxWorkers=2`: **43 files / 547 tests passed**, up from
  43 / 544.
- `npx tsc --noEmit -p tsconfig.app.json`: clean.
- `npm run lint`: only the pre-existing `TrickPlayFlow.tsx` exhaustive-deps
  warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
