### PR TITLE
docs(engine): re-cite the case for keeping playPolicy 'simple' (#296)

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -394,14 +394,22 @@ alone.
 **Check condition 4 against the tracker as it is today, not against the
 docstring's own claim.** The three sites that justify `'simple'` —
 `PlayPolicy` in `skills.ts`, `PLAY_AB_POLICIES` in `abRun.ts`, and the
-lead gate in `tracker.ts` — all name epic #152 in the present tense, and
-#152 closed on 2026-08-02 with every child closed. An arm's
-justification is a claim about open work, so it can go stale on its own
-in a way the rest of this file's docstring rules cannot. A stale
-citation is not a satisfied condition 4; it is the cue to go and find
-out what the live claim is. For `'simple'` that is #270's
-re-measurement scope, which names `playPolicy` — whether that is enough
-is a call for the issue, not for this file.
+lead gate in `tracker.ts` — all named epic #152 in the present tense
+until #296 refreshed them, and #152 had closed on 2026-08-02 with every
+child closed. Nobody edited those comments into being wrong: the work
+they pointed at finished, and they went on saying the same thing. An
+arm's justification is a claim about open work, so it can go stale on
+its own in a way the rest of this file's docstring rules cannot. A
+stale citation is not a satisfied condition 4; it is the cue to go and
+find out what the live claim is.
+
+For `'simple'` that live claim is #270's re-measurement, whose scope
+names `playPolicy` and which has not run — which is why the arm is
+still here. Read that as the example and not the exception: the new
+citation is mortal in exactly the way the old one was, so when #270
+reports, condition 4 is *open again* rather than answered, and whoever
+next reaches for this section should expect the same walk to the
+tracker rather than trusting the sentence they find in `skills.ts`.
 
 ### Retire the introducing commit, not the arm's name
 

--- a/web/src/ab/ab.test.ts
+++ b/web/src/ab/ab.test.ts
@@ -145,8 +145,9 @@ describe('the policy override', () => {
   })
 
   it('puts the two card-play rules at one table (#153)', () => {
-    // What epic #152 is blocked on. Both arms already ship — `simple` is what
-    // `easy` plays — so this map enables nothing; it only makes the comparison
+    // What epic #152 was blocked on. Both arms already shipped when this was
+    // written — `simple` was what `easy` played — so the map enabled nothing
+    // then and enables nothing now; it only makes the comparison
     // reachable, which is a thing `SKILL_PARAMS` alone cannot do because
     // `chooseFollowCard` reads the level it is handed.
     const before = { ...SKILL_PARAMS }
@@ -178,9 +179,10 @@ describe('the policy override', () => {
     // The other half of #156. `'simple'` is unreferenced by `SKILL_PARAMS` and
     // both `tracker.ts` branches are unreachable in a real game, which reads
     // exactly like dead code — but deleting it would leave `PlayPolicy` a
-    // one-member union and strip epic #152 of the baseline every one of its
-    // children is measured against. `PLAY_AB_POLICIES` is what keeps it alive,
-    // and this asserts that it does.
+    // one-member union and strip the trick-play dial of its baseline while
+    // #270's re-measurement still names `playPolicy` (#296).
+    // `PLAY_AB_POLICIES` is what keeps it alive, and this asserts that it
+    // does.
     expect(PLAY_AB_POLICIES[STATIC_LEVEL].playPolicy).toBe('simple')
     expect(Object.values(SKILL_PARAMS).map((p) => p.playPolicy)).not.toContain('simple')
   })

--- a/web/src/ab/abRun.ts
+++ b/web/src/ab/abRun.ts
@@ -148,19 +148,23 @@ export const AUTO_SET_AB_POLICIES: Record<string, SkillParams> = {
  * Trick-play A/B (#153): identical bidders and identical folders, differing
  * only in which rule picks a card.
  *
- * This is the dial epic #152 is blocked on. Card play is the one phase of this
- * AI that has never been measured — #105, #115, #123 and #126 are all bidding
- * or folding — so every heuristic in `tracker.ts` is there on reasoning alone,
- * and #154-#159 each propose replacing one of them. None of that can be judged
- * without a way to sit two card-play rules at one table.
+ * This is the dial epic #152 was blocked on. Card play was the one phase of
+ * this AI never measured — #105, #115, #123 and #126 are all bidding or
+ * folding — so every heuristic in `tracker.ts` was there on reasoning alone,
+ * and #154-#159 each proposed replacing one of them. None of that could be
+ * judged without a way to sit two card-play rules at one table. All of those
+ * children landed and the epic closed on 2026-08-02; the map outlived it.
  *
  * When this map was written both arms shipped: `'simple'` was what `easy`
  * played and `'cascade'` what every other level played. #156 acted on the
  * number — every level now plays `'cascade'` — so outside `tracker.test.ts`
  * this map is the **only** thing that selects `'simple'`, and deleting it
- * would take the arm with it: a one-member `PlayPolicy` union and no baseline
- * for the rest of epic #152 to be measured against. Load-bearing, not
- * leftover; `PlayPolicy` in `skills.ts` says the same from the other side.
+ * would take the arm with it: a one-member `PlayPolicy` union, and no baseline
+ * left for a re-measurement that still asks for one. That re-measurement is
+ * #270, whose scope names `playPolicy` and which has not run — it is what
+ * keeps the arm now that the epic above is closed (#296). Load-bearing, not
+ * leftover; `PlayPolicy` in `skills.ts` carries the full case, and
+ * `CODING_STANDARDS.md`'s condition 4 is the one it turns on.
  *
  * Both sides bid `'distilled'` rather than `'static'` for the same reason
  * `FOLD_AB_POLICIES` does: it describes card play as it will actually ship on

--- a/web/src/engine/skills.ts
+++ b/web/src/engine/skills.ts
@@ -113,8 +113,8 @@ export type FoldPolicy = 'never' | 'model'
  *
  * That mattered enough to be its own issue because trick play is the one phase
  * of this AI never A/B'd — #105, #115, #123 and #126 all measured bidding or
- * folding — and epic #152 is a queue of changes to it that cannot be judged
- * without a dial.
+ * folding — and epic #152 was a queue of changes to it that could not be
+ * judged without a dial.
  *
  * Splitting it off `handValuation` also unblocks the epic rather than merely
  * tidying. `meld_only` gates *bidding* valuation too (`bidding.ts`,
@@ -128,10 +128,22 @@ export type FoldPolicy = 'never' | 'model'
  * `FoldPolicy` keeps `'never'`: `abRun.ts` needs two levels differing in
  * exactly one field to measure this, and `PLAY_AB_POLICIES` is the only reason
  * the trick-play dial has a span at all. Deleting the arm would leave
- * `PlayPolicy` a one-member union and take the ruler away from epic #152 days
- * after #153 built it — every child of that epic is judged against the
- * `simple` baseline. Removing it is a decision to stop measuring card play,
- * not a cleanup.
+ * `PlayPolicy` a one-member union and take the ruler away while a measurement
+ * that asks for it is still outstanding: #270, Paul's deferred re-measurement
+ * of the shipped AI, whose scope names `playPolicy` among the arms to re-run,
+ * and which has not run.
+ *
+ * That — not the epic — is what keeps the arm now. This docstring cited
+ * epic #152 in the present tense until #296; #152 closed on 2026-08-02 with
+ * every child closed, and no comment had to be edited for the justification to
+ * stop being true. In the terms `CODING_STANDARDS.md` sets out under "Retiring
+ * a policy arm", `'simple'` clears conditions 1-3 outright — two seeds,
+ * decisively negative at -228 and -221 per deal (#156), selected by no shipped
+ * configuration — and survives on condition 4 alone. So its fate is entirely
+ * the question of what is baselined against it; the answer today is #270, and
+ * when #270 reports, the place to check that is the tracker rather than this
+ * paragraph. Removing it before then is a decision to stop measuring card
+ * play, not a cleanup.
  */
 export type PlayPolicy = 'simple' | 'cascade'
 

--- a/web/src/engine/tracker.test.ts
+++ b/web/src/engine/tracker.test.ts
@@ -13,8 +13,9 @@ import { TrumpMemory } from './trumpMemory'
  * Since #156 no `SKILL_PARAMS` row ships `'simple'` — trick play is identical
  * at all five levels — so it can no longer be reached by naming `easy`, the way
  * these tests used to reach it. It is still a live policy: `PLAY_AB_POLICIES`
- * is the baseline every child of epic #152 is measured against, and an arm the
- * suite never exercises is an arm nothing vouches for.
+ * holds it open as the baseline #270's re-measurement names (`PlayPolicy` in
+ * `skills.ts` for why), and an arm the suite never exercises is an arm nothing
+ * vouches for.
  *
  * This is `installPolicies`' mechanism (`ab/abRun.ts`) narrowed to one level,
  * rather than that import, to keep the engine's unit tests off the A/B harness
@@ -632,7 +633,8 @@ describe('chooseFollowCard', () => {
   it("'simple' plays the lowest legal card, skipping every tier above", () => {
     // Partner is winning, so `cascade` feeds them the King (the tier asserted
     // above). `simple` plays the 9 — it never asks who is winning, which is
-    // exactly the weakness epic #152 exists to fix and #153 exists to measure.
+    // exactly the weakness epic #152 existed to fix and #153 built the dial to
+    // measure.
     const trickPlays: TrickPlay[] = [{ player: 0, card: new Card(Suit.Hearts, 'Q', 1) }]
     const legalMoves = [
       new Card(Suit.Hearts, '9', 1),

--- a/web/src/engine/tracker.ts
+++ b/web/src/engine/tracker.ts
@@ -313,8 +313,9 @@ export function chooseLeadCard(
   // Simplified leading — prefer low non-trump non-count cards. No shipped
   // `SKILL_PARAMS` row selects this since #156 moved `easy` onto the cascade
   // with everyone else, so nothing reaches it in a real game; it stays as the
-  // `'simple'` arm of `PLAY_AB_POLICIES`, the baseline every remaining child of
-  // epic #152 is measured against, and is reachable only by overriding the dial.
+  // `'simple'` arm of `PLAY_AB_POLICIES` — the baseline #270's deferred
+  // re-measurement still names — and is reachable only by overriding the dial.
+  // `PlayPolicy` in `skills.ts` has the full case for keeping it.
   if (SKILL_PARAMS[skill].playPolicy === 'simple') {
     const safeLeads = hand.filter((c) => c.suit !== trump && c.rank !== 'A' && c.rank !== '10' && c.rank !== 'K')
     const pool = safeLeads.length > 0 ? safeLeads : hand


### PR DESCRIPTION
Closes #296

`playPolicy: 'simple'` is a measured-and-losing arm kept alive on purpose, and
the comments justifying it named epic #152 in the present tense. #152 closed on
2026-08-02 with every child closed, so the entire case for the arm's existence
pointed at finished work. The arm still stays — #270's re-measurement scope
names `playPolicy` and has not run — but the code now says that rather than
something that stopped being true a month ago.

Verified before rewriting: `gh issue view 152` reports `CLOSED`,
`closedAt 2026-08-02T19:14:18Z`; #153-#159 are all closed. #270 is open, and
its option 2 names `playPolicy` among the arms to re-measure.

## What each site claimed, and what it says now

**`web/src/engine/skills.ts` — the `PlayPolicy` docstring.** Claimed *"take the
ruler away from epic #152 days after #153 built it — every child of that epic is
judged against the `simple` baseline"*, plus a paragraph above in the present
tense about #152 being *"a queue of changes ... that cannot be judged without a
dial"*. This is the docstring anyone considering the deletion reads first, so it
now carries the full argument: #270 is what keeps the arm, it clears conditions
1-3 of `CODING_STANDARDS.md`'s retirement rule outright and survives on
condition 4 alone, and when #270 reports the place to check is the tracker
rather than this paragraph. The history above it moves to the past tense.

**`web/src/ab/abRun.ts` — `PLAY_AB_POLICIES`.** Claimed *"the dial epic #152 is
blocked on"* and that deleting the map leaves *"no baseline for the rest of epic
#152 to be measured against"*. The dial's own history is worth keeping — it is
why the map exists at all — so it stays, in the past tense it has earned, with a
note that all those children landed and the map outlived the epic. The live
claim is now #270, with a pointer to `skills.ts` for the full case and to
condition 4 as the one it turns on.

**`web/src/engine/tracker.ts` — the lead gate.** Claimed the branch stays as
*"the baseline every remaining child of epic #152 is measured against"*. This is
the site with no direct replacement: there are no remaining children, and #270
is one measurement rather than a queue of them. It stays a short aside — the
baseline #270's deferred re-measurement still names — and refers out to
`skills.ts` instead of restating the argument.

## Two more sites carrying the same sentence

`tracker.test.ts`'s `withSimplePlay` helper (*"`PLAY_AB_POLICIES` is the
baseline every child of epic #152 is measured against"*) and `ab.test.ts`'s
`keeps 'simple' reachable as an A/B arm` (*"strip epic #152 of the baseline
every one of its children is measured against"*) repeated the claim nearly word
for word. Fixing three and leaving two would have left the wrong version in the
files a reader hits next. Two neighbouring present-tense asides about #152 in
the same test files went to the past tense with them.

## `CODING_STANDARDS.md`

The "Retiring a policy arm" section used these exact comments as its worked
example of "check the tracker, not the docstring", and after this PR a reader
following it finds #270 rather than #152. The example is retold as something
that happened — including the part worth keeping, that nobody edited those
comments into being wrong; the work finished and they went on saying the same
thing. The rule is not weakened to match the new comments: it is pointed
forward, noting that the #270 citation is mortal in exactly the way the #152 one
was, so when #270 reports, condition 4 for this arm is open again rather than
answered.

## Not done

`web/README.md`'s #156 measurement record carries the same *"the baseline every
remaining child of #152 is judged against"* sentence. It is prose in the
measurement record rather than a code comment, and #296 scoped this to comments,
so it is left for a follow-up.

## Verification

- `npm test -- --run --maxWorkers=2` — **43 files, 544 tests**, matching the
  #170 baseline.
- `python -m pytest -q` from the repo root — **409 passed**, unmoved.
- `npx tsc --noEmit -p tsconfig.app.json` — clean.
- `npm run lint` — one pre-existing `exhaustive-deps` warning in
  `TrickPlayFlow.tsx`, untouched by this branch.

No policy behaviour changes, no arm retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
