### PR TITLE
fix(bidding): hold the multiple-of-10 bid grid at both Python human seats (#297)

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -92,8 +92,8 @@ behavior the fallback preserves.
 
 ## Tests
 
-`pytest` is the suite. Twenty-five `test_*.py` modules sit at the repo
-root, 409 tests, all passing, run with `python -m pytest -q` at about
+`pytest` is the suite. Twenty-six `test_*.py` modules sit at the repo
+root, 418 tests, all passing, run with `python -m pytest -q` at about
 2m40s, most of it the dataset and model-fitting modules and the rollout
 fingerprint's 40-second re-label. There is no `pytest.ini`,
 `conftest.py`, or `pyproject.toml`: collection is stock discovery from

--- a/human_play.py
+++ b/human_play.py
@@ -43,6 +43,14 @@ class NeedsHumanInput(Exception):
         super().__init__(f"Needs human input: {kind}")
 
 
+def off_grid_bid_message(bid):
+    """The single wording both human seats use to turn away a bid off the
+    multiple-of-10 grid (issue #297). Shared rather than copied because both
+    seats reject on the same rule and read from the same constant; each caller
+    supplies its own indent."""
+    return f"{bid} is off the {MIN_BID_INCREMENT}-point bid grid - try again."
+
+
 def card_str(card):
     return f"{card.rank}{card.suit.value}"
 
@@ -80,10 +88,26 @@ class HumanPlayer(Player):
         self.played_cards = []
 
     def choose_bid(self, current_bid, min_increment, context=None):
+        rejected = None
         if self.pending_answer != _NO_ANSWER:
             ans = self.pending_answer
             self.pending_answer = _NO_ANSWER
-            return ans
+            if ans is None or ans % MIN_BID_INCREMENT == 0:
+                return ans
+            # Off the multiple-of-10 grid that pinochle_rules.md states without
+            # qualification (issue #297). Both bidding loops would take it -
+            # they only compare a bid against the minimum - and every raise
+            # after it is +MIN_BID_INCREMENT from whatever was accepted, so a
+            # single 305 puts the rest of the ladder on 315, 325, 335. The
+            # answer is dropped and this decision point re-raised, which is the
+            # ordinary resume path rather than a special case: no auction state
+            # moved before the check, so the next call prompts from the
+            # identical position. The check lives on the human seat and not in
+            # either loop deliberately - the AI raises by MIN_BID_INCREMENT
+            # from a grid-aligned opener and is already correct, so it should
+            # not be exposed to a new rejection - and putting it on the player
+            # means it holds for `Round` and `InteractiveRound` alike.
+            rejected = ans
         prompt = {
             "hand": hand_str(self.hand),
             "hand_grouped": hand_grouped(self.hand),
@@ -104,6 +128,8 @@ class HumanPlayer(Player):
                     f"{p.name}{' (you)' if p is self else ''}: {last_action.get(p.name, '(no action yet)')}"
                     for p in clockwise
                 ]
+        if rejected is not None:
+            prompt["error"] = off_grid_bid_message(rejected)
         raise NeedsHumanInput("bid", prompt)
 
     def choose_trump(self):

--- a/play_local.py
+++ b/play_local.py
@@ -12,8 +12,10 @@ import sys
 import os
 
 sys.path.insert(0, os.path.dirname(__file__))
-from human_play import HumanPlayer, InteractiveRound, NeedsHumanInput, hand_grouped
-from pinochle_engine import Player, Team, GAME_LOSE_SCORE, determine_winner
+from human_play import (
+    HumanPlayer, InteractiveRound, NeedsHumanInput, hand_grouped, off_grid_bid_message,
+)
+from pinochle_engine import Player, Team, GAME_LOSE_SCORE, MIN_BID_INCREMENT, determine_winner
 from pinochle_rollout import MAX_TRICK_POINTS
 
 SUIT_NAME = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"}
@@ -37,14 +39,28 @@ def prompt_and_get_answer(kind, data):
         print("Your hand:")
         print_grouped(data["hand_grouped"])
         print(f"Current bid: {data['current_bid']}   Min legal bid: {data['min_legal_bid']}")
+        if data.get("error"):
+            # Set when the seat itself turned an answer away (issue #297).
+            # This driver catches an off-grid bid below, so it should never be
+            # the one to print this - but the prompt data carries the reason
+            # and dropping it would leave a re-prompt looking like a redraw.
+            print(f"  {data['error']}")
         while True:
             raw = input("Enter a bid amount, or 'pass': ").strip().lower()
             if raw in ("pass", "p", ""):
                 return None
             try:
-                return int(raw)
+                amount = int(raw)
             except ValueError:
                 print("  Not a number - try again.")
+                continue
+            # Every bid sits on the multiple-of-10 grid (issue #297), read off
+            # MIN_BID_INCREMENT rather than a literal so the prompt follows the
+            # rung size if it ever moves.
+            if amount % MIN_BID_INCREMENT != 0:
+                print(f"  {off_grid_bid_message(amount)}")
+                continue
+            return amount
 
     if kind == "trump":
         print("Your hand:")

--- a/test_bid_grid.py
+++ b/test_bid_grid.py
@@ -1,0 +1,249 @@
+"""
+Tests for issue #297 - the multiple-of-10 bid grid, at the two Python human
+seats. Plain assert-based, pytest-discoverable.
+
+The rule under test is one line of `pinochle_rules.md`: "every bid falls on the
+multiple-of-10 grid that raise implies - 300, 310, 320, never 305". The browser
+gated its Bid button on it from the start; neither Python human seat checked
+anything but the minimum, so a human on either CLI could bid 305 and be taken
+at it.
+
+This is input validation on the human seat and not a rules-engine fix, which is
+what shapes the tests. There is no AI path here to check - the AI raises by
+MIN_BID_INCREMENT from a grid-aligned opener and cannot leave the grid - and
+nothing asserts anything about `_bidding_loop`'s acceptance test, which is
+deliberately unchanged.
+
+What is covered here:
+
+  1. `HumanPlayer.choose_bid` - the seat both `Round` and `InteractiveRound`
+     call. An off-grid answer is dropped and the same decision point re-raised
+     carrying a reason; the on-grid bid one rung away is returned.
+  2. `play_local.prompt_and_get_answer` - the terminal driver's own input
+     loop, re-prompting in the register the rest of that function already uses.
+  3. The rejection survives a resume. `InteractiveRound` is where an off-grid
+     bid would have done its damage, and the fix works by raising out of a
+     half-finished auction, so a full round is driven through the rejection to
+     show the auction picks up unmoved rather than losing or double-counting
+     the seat's turn.
+
+Every threshold is read from MIN_BID_INCREMENT rather than written as 10, for
+the same reason the code is: if the rung size moves, these tests should move
+with it instead of failing.
+"""
+
+import builtins
+import contextlib
+import io
+import random
+
+import human_play
+from human_play import HumanPlayer, InteractiveRound, NeedsHumanInput, _NO_ANSWER
+from pinochle_engine import MIN_BID_INCREMENT, OPENING_BID, Player, Team
+
+
+# The bid the whole issue is named for, and the legal bid one point-grid rung
+# away from it. 305 is over OPENING_BID, so "rejected" here can only mean the
+# grid check - a seat that turned it away for being too low would look the same
+# from outside.
+OFF_GRID_BID = OPENING_BID + MIN_BID_INCREMENT // 2
+ON_GRID_BID = OPENING_BID + MIN_BID_INCREMENT
+
+
+def _seated_human():
+    """A HumanPlayer wired up enough to be asked for a bid: `choose_bid` reads
+    team scores and the seating order out of its context."""
+    human = HumanPlayer("You")
+    others = [Player(n, None) for n in ("E", "S", "W")]
+    team_a = Team("Your Team", [human, others[1]])
+    team_b = Team("Opponents", [others[0], others[2]])
+    human.team = others[1].team = team_a
+    others[0].team = others[2].team = team_b
+    players = [human, others[0], others[1], others[2]]
+    context = {
+        "ever_bid": False,
+        "passes_so_far": 0,
+        "bid_history": [],
+        "dealer": players[3],
+        "teams": [team_a, team_b],
+        "players": players,
+    }
+    return human, context
+
+
+# ---------------------------------------------------------------------------
+# 1. The seat itself: human_play.HumanPlayer.choose_bid
+# ---------------------------------------------------------------------------
+
+def test_off_grid_answer_is_turned_away_with_a_reason():
+    human, context = _seated_human()
+    human.pending_answer = OFF_GRID_BID
+
+    try:
+        human.choose_bid(OPENING_BID - MIN_BID_INCREMENT, MIN_BID_INCREMENT, context)
+        assert False, f"{OFF_GRID_BID} was accepted as a bid"
+    except NeedsHumanInput as e:
+        assert e.kind == "bid"
+        assert str(OFF_GRID_BID) in e.prompt_data["error"]
+        assert str(MIN_BID_INCREMENT) in e.prompt_data["error"]
+
+    # The rejected answer is consumed, not left sitting in the seat. Were it
+    # kept, the driver's next resume would re-submit the same 305 and the
+    # prompt would repeat forever with the human answering it each time.
+    assert human.pending_answer == _NO_ANSWER
+
+
+def test_on_grid_bid_at_the_same_rung_is_accepted():
+    human, context = _seated_human()
+    human.pending_answer = ON_GRID_BID
+    assert human.choose_bid(OPENING_BID - MIN_BID_INCREMENT, MIN_BID_INCREMENT, context) == ON_GRID_BID
+
+
+def test_passing_still_passes():
+    """None is a pass, not a number, and must not be measured against the grid
+    - `None % 10` is a TypeError and would crash the seat on the commonest
+    answer in any auction."""
+    human, context = _seated_human()
+    human.pending_answer = None
+    assert human.choose_bid(OPENING_BID - MIN_BID_INCREMENT, MIN_BID_INCREMENT, context) is None
+
+
+def test_an_ordinary_prompt_carries_no_error():
+    """The reason is attached only when there is one. A driver that prints
+    `error` unconditionally would otherwise accuse the human of an off-grid bid
+    on their first turn."""
+    human, context = _seated_human()
+    try:
+        human.choose_bid(OPENING_BID - MIN_BID_INCREMENT, MIN_BID_INCREMENT, context)
+        assert False, "seat returned a bid without being given one"
+    except NeedsHumanInput as e:
+        assert "error" not in e.prompt_data
+
+
+# ---------------------------------------------------------------------------
+# 2. The terminal driver: play_local.prompt_and_get_answer
+# ---------------------------------------------------------------------------
+
+BID_PROMPT_DATA = {
+    "scores": {"Your Team": 0, "Opponents": 0},
+    "players_clockwise": [],
+    "hand_grouped": {},
+    "current_bid": OPENING_BID - MIN_BID_INCREMENT,
+    "min_legal_bid": OPENING_BID,
+}
+
+
+def _answer_bid_prompt(typed):
+    """Run play_local's bid prompt against a scripted keyboard, returning what
+    it hands back to the auction and everything it printed on the way."""
+    import play_local
+
+    replies = iter(typed)
+    real_input = builtins.input
+    builtins.input = lambda *_args: next(replies)
+    out = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out):
+            answer = play_local.prompt_and_get_answer("bid", dict(BID_PROMPT_DATA))
+    finally:
+        builtins.input = real_input
+    return answer, out.getvalue()
+
+
+def test_driver_re_prompts_after_an_off_grid_bid():
+    answer, printed = _answer_bid_prompt([str(OFF_GRID_BID), str(ON_GRID_BID)])
+    assert answer == ON_GRID_BID
+    assert human_play.off_grid_bid_message(OFF_GRID_BID) in printed
+    # In the register the rest of this function uses - a two-space indent and
+    # the same "try again" the "Not a number" branch ends on.
+    assert f"  {OFF_GRID_BID} is off" in printed
+
+
+def test_driver_takes_the_on_grid_bid_without_comment():
+    answer, printed = _answer_bid_prompt([str(ON_GRID_BID)])
+    assert answer == ON_GRID_BID
+    assert "off the" not in printed
+
+
+def test_driver_still_parses_and_still_passes():
+    """The grid check is added to the existing loop rather than replacing it,
+    so the two answers that loop already handled must still behave."""
+    answer, printed = _answer_bid_prompt(["three hundred", str(ON_GRID_BID)])
+    assert answer == ON_GRID_BID
+    assert "Not a number - try again." in printed
+
+    assert _answer_bid_prompt(["pass"])[0] is None
+
+
+def test_both_seats_reject_in_the_same_words():
+    """One wording, from `off_grid_bid_message`. Two copies of a sentence this
+    small would drift, and a human moving between the two CLIs should not have
+    to learn the rejection twice."""
+    _, printed = _answer_bid_prompt([str(OFF_GRID_BID), str(ON_GRID_BID)])
+    human, context = _seated_human()
+    human.pending_answer = OFF_GRID_BID
+    try:
+        human.choose_bid(OPENING_BID - MIN_BID_INCREMENT, MIN_BID_INCREMENT, context)
+        assert False, "seat accepted an off-grid bid"
+    except NeedsHumanInput as e:
+        assert e.prompt_data["error"].strip() in printed
+
+
+# ---------------------------------------------------------------------------
+# 3. The rejection inside a live auction, across the resume boundary
+# ---------------------------------------------------------------------------
+
+def test_rejected_bid_leaves_the_auction_where_it_was():
+    """`InteractiveRound` resumes by re-entering `run()` and replaying from
+    instance state, so a rejection is only safe if nothing moved before it. The
+    seat is left of the dealer, so the human opens: it answers off-grid once,
+    on-grid once, then passes whatever else it is asked."""
+    # Seated by hand rather than through `_seated_human`, which builds a
+    # context dict for a bare `choose_bid` call and not a table to deal to.
+    human = HumanPlayer("You")
+    e, s, w = Player("E", None), Player("S", None), Player("W", None)
+    team_a, team_b = Team("Your Team", [human, s]), Team("Opponents", [e, w])
+    human.team = s.team = team_a
+    e.team = w.team = team_b
+    players = [human, e, s, w]
+    round_ = InteractiveRound(players, [team_a, team_b], dealer_index=3,
+                              deal_rng=random.Random(297))
+
+    answers = [OFF_GRID_BID, ON_GRID_BID]
+    prompts = []
+    for _ in range(60):
+        try:
+            round_.run()
+            break
+        except NeedsHumanInput as exc:
+            prompts.append(exc)
+            if exc.kind == "bid":
+                human.pending_answer = answers.pop(0) if answers else None
+            elif exc.kind == "trump":
+                human.pending_answer = "S"
+            elif exc.kind == "pass":
+                human.pending_answer = exc.prompt_data["hand"].split()[:exc.prompt_data["count"]]
+            elif exc.kind == "card":
+                human.pending_answer = exc.prompt_data["legal_moves"][0]
+            elif exc.kind == "misdeal":
+                human.pending_answer = False
+            else:
+                assert False, f"unexpected prompt kind {exc.kind}"
+    else:
+        assert False, "round never finished"
+
+    bid_prompts = [p for p in prompts if p.kind == "bid"]
+    # Exactly one re-prompt, carrying the reason: the rejection cost the seat
+    # its answer and not its turn.
+    assert len(bid_prompts) >= 2
+    assert "error" not in bid_prompts[0].prompt_data
+    assert bid_prompts[1].prompt_data["error"] == human_play.off_grid_bid_message(OFF_GRID_BID)
+    # Both prompts describe the same position - the auction did not advance
+    # past the seat and come back round to it.
+    assert bid_prompts[0].prompt_data["min_legal_bid"] == bid_prompts[1].prompt_data["min_legal_bid"]
+    assert bid_prompts[0].prompt_data["hand"] == bid_prompts[1].prompt_data["hand"]
+
+    # And nothing off-grid reached the auction, from any seat.
+    assert (human, ON_GRID_BID) in round_._bid_history
+    for _player, amount in round_._bid_history:
+        assert amount % MIN_BID_INCREMENT == 0


### PR DESCRIPTION
Closes #297

`pinochle_rules.md` asserts the multiple-of-10 bid grid without qualification.
The browser held it; neither Python human seat did, so a human on either CLI
could bid 305 - and because every raise after it is `+MIN_BID_INCREMENT` from
whatever was accepted, one off-grid bid put the rest of the auction on 315,
325, 335.

## What changed

- **`human_play.py`** — `HumanPlayer.choose_bid` drops an off-grid answer and
  re-raises the same `NeedsHumanInput`, carrying the reason as a new `error`
  key in the bid prompt data. A pass (`None`) skips the check; `None % 10`
  would be a `TypeError` on the commonest answer in an auction.
- **`play_local.py`** — the `input()` loop rejects and re-prompts before it
  ever answers, and prints the seat's `error` key if a driver upstream ever
  hands it one.
- **`off_grid_bid_message`** — one wording for both seats, reading
  `MIN_BID_INCREMENT` rather than a literal 10.
- **`test_bid_grid.py`** — nine tests: the seat, the driver, and a full
  `InteractiveRound` driven through the rejection and out the far side.
- **`CODING_STANDARDS.md`** — the suite line moves to twenty-six modules and
  418 tests, as #225 did when it added a module.

## The one design call worth a look

The check is on `HumanPlayer.choose_bid`, not in either `_bidding_loop`. In the
loop it would sit in front of every AI bid — validation the AI does not need,
since it raises by `MIN_BID_INCREMENT` from a grid-aligned opener — and it
would need writing twice, because `InteractiveRound` is a hand-maintained
mirror of `Round` and `_bidding_loop` is one of the phases it overrides. On the
player there is one copy and it holds for both loops, including the plain
`Round` games in `test_general_strategy.py` that seat a `HumanPlayer` subclass.
No AI path and no engine bid handling changed.

**Did the mirror need updating?** No. Neither `_bidding_loop` was touched, and
putting the check on the player is what keeps it that way.

## Verification

- `python -m pytest -q` from the repo root: **418 passed**, up from 409 by the
  nine added here.
- `cd web && npm test -- --run --maxWorkers=2`: **43 files / 544 tests**,
  unmoved. No TypeScript changed — it already enforced this.
- Both checks were watched failing: with the seat's grid test forced true and
  the driver's forced false, four of the nine go red, including the auction
  test reporting one bid prompt where there should be two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
