### PR TITLE
test(architecture): fail the suite when the app can reach the harness (#236)

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,4 +414,8 @@ tuning baseline for a rule the shipped game already follows. See
 - **The measurement harness doesn't ship.** `web/src/ab/` plays complete
   games through the same reducers and AI entry points the UI calls,
   minus React and the animation delays. Nothing outside the App's import
-  graph reaches the bundle.
+  graph reaches the bundle, and `src/boundaries/bundleBoundary.test.ts`
+  asserts it rather than leaving it to habit: it walks outward from
+  `index.html`'s module scripts and fails if `src/ab/` is reachable
+  (#236). The direction matters — the harness imports the engine and the
+  components constantly, and a walk from the app never follows that edge.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -314,10 +314,18 @@ static-vs-rollout switch moves together across all decision points.
 entry points the UI calls, minus React and the delays; `abRun.ts` pairs
 them the way `ab_harness.py` does; `stats.ts` is a direct port of its
 three statistics; `bench/index.html` is the browser side of the latency
-measurement. None of it reaches the bundle — though nothing
-checks that, and `installPolicies` writes into the shared `SKILL_PARAMS`
-object rather than a copy, so the failure mode is a mutable engine config
-rather than a fat bundle (#236). Run `selftest` before believing `ab`:
+measurement. None of it reaches the bundle, and
+`src/boundaries/bundleBoundary.test.ts` is what holds that: it walks the
+import graph outward from `index.html`'s module scripts and fails the
+suite the moment anything under `src/ab/` turns up in it (#236). The
+guard is worth its weight because `installPolicies` writes into the
+shared `SKILL_PARAMS` object rather than a copy — #222 kept it mutable
+on purpose, since a mirrored A/B needs both policies seated at one table
+— so the cost of an accidental import is engine configuration that is
+writable at runtime in the product, not a fat bundle. Because the walk
+only ever follows edges away from the app, the harness goes on importing
+the engine and the components freely; only the reverse edge is an error.
+Run `selftest` before believing `ab`:
 one policy against itself must find *exactly* nothing, and `ab.test.ts`
 asserts that.
 

--- a/web/README.md
+++ b/web/README.md
@@ -47,6 +47,11 @@ npm test        # vitest
   options.
 - `src/ab/` — the measurement harness (issue #115). Not shipped: nothing under
   `src/` outside the App's import graph reaches the bundle. See below.
+- `src/boundaries/` — the check on that claim (#236). `bundleBoundary.test.ts`
+  walks the import graph out from `index.html`'s module scripts and fails if
+  `src/ab/` or `src/layout/` is reachable. Imports the other way — the harness
+  reading the engine and the components — are what the walk's direction
+  deliberately leaves alone.
 
 ## Parity with the Python engine (`engineParity.*`)
 

--- a/web/src/boundaries/bundleBoundary.test.ts
+++ b/web/src/boundaries/bundleBoundary.test.ts
@@ -1,0 +1,336 @@
+/// <reference types="node" />
+
+// Measurement code must not be reachable from the shipped app (#236).
+//
+// `src/ab/` is the A/B harness, the latency instrument and the headless game
+// driver. It lives inside `src/` because it drives the real engine and must not
+// drift from it, and it stays out of the bundle because nothing the app loads
+// happens to import it. Until this file, that was the whole of the enforcement:
+// a true sentence about the current import graph, written down in `ROADMAP.md`
+// and nowhere checked.
+//
+// WHY THAT IS WORTH A TEST RATHER THAN A CONVENTION. `installPolicies` in
+// `abRun.ts` does not build a private copy of the tuning table - it writes rows
+// into the shared `SKILL_PARAMS` and hands back a restore function. #222 kept
+// `SKILL_PARAMS` mutable on purpose so the harness could do exactly that, and
+// that decision is right: a mirrored A/B needs both policies live in one
+// process, and installing them explicitly is what makes the measurement
+// independent of whichever dial happens to be shipped. The cost of keeping the
+// seam is that an accidental import is not "the harness got bundled", it is
+// "engine configuration became writable at runtime in the product". A seam
+// preserved deliberately is one to guard, not one to close.
+//
+// WHY REACHABILITY RATHER THAN A BAN ON THE IMPORT. The forbidden edge is
+// directional. `src/ab/` imports the engine and the components constantly -
+// that is the entire point of it, and a rule reading "nothing may import across
+// the `ab/` boundary" would have to be suppressed on almost every file in the
+// harness. Walking outward from `index.html`'s module scripts gets the
+// asymmetry for free: the walk only ever follows edges away from the app, so
+// `ab/ -> engine/` is never even visited, while `engine/ -> ab/` is found the
+// moment it is written. It also settles the test question without an allowlist.
+// `engine/round.test.ts` and `components/TrickPlayFlow.test.tsx` both import
+// `dealFromRng` from `../ab/headlessGame` today; neither is reachable from an
+// entry, so neither is a violation, and no carve-out has to be maintained for
+// them.
+//
+// WHAT THIS DOES NOT CATCH. It is a static walk, so: a specifier built at
+// runtime (`import('./' + name)`) is invisible to it; so is anything pulled in
+// through a Vite alias or plugin virtual module, since it resolves relative and
+// root-absolute specifiers only; and it says nothing about a *copy* of harness
+// code pasted into an engine file, which is a different failure with a
+// different remedy. It also does not check the emitted bundle - if Rollup ever
+// included a module no entry imports, this would not see it. Those gaps are
+// accepted because the mistake being guarded is the ordinary one: someone
+// imports a type or a helper from `ab/` into an engine or component file
+// because it was the nearest definition of the thing they wanted.
+
+import { describe, expect, it } from 'vitest'
+import {
+  chainTo,
+  dirOf,
+  diskReader,
+  htmlEntries,
+  moduleSpecifiers,
+  resolveSpecifier,
+  walkImports,
+  type GraphWalk,
+  type SourceReader,
+} from './importGraph'
+
+/** `web/`, the directory a root-absolute `/src/...` in `index.html` hangs off. */
+const webRoot = dirOf(import.meta.url, '../../')
+
+/**
+ * Directories, not files, so nothing here has to be maintained as `src/ab/`
+ * grows. Each is a tree with its own dev-only HTML page that `vite build` never
+ * takes as an input - `bench/index.html` for the latency instrument,
+ * `layout/index.html` for the portrait-fit probe - which is precisely the
+ * arrangement that makes them unreachable today and gives them nothing to
+ * announce if that stops being true.
+ */
+const DEV_ONLY_TREES = [
+  { prefix: 'src/ab/', what: 'the A/B harness, latency bench and headless driver' },
+  { prefix: 'src/layout/', what: 'the portrait-fit probe served at /layout/' },
+  // This directory, which reads the filesystem and imports the TypeScript
+  // compiler. It has no dev page of its own and so no arrangement protecting
+  // it, and it is the one tree where an accidental import would pull a
+  // multi-megabyte parser into a phone's download. A guard that exempts itself
+  // is a guard with a hole in it.
+  { prefix: 'src/boundaries/', what: 'this import-graph guard and its parser' },
+] as const
+
+function forbiddenTree(relPath: string): (typeof DEV_ONLY_TREES)[number] | undefined {
+  return DEV_ONLY_TREES.find((tree) => relPath.startsWith(tree.prefix))
+}
+
+function relative(path: string): string {
+  return path.startsWith(`${webRoot}/`) ? path.slice(webRoot.length + 1) : path
+}
+
+function describeChain(walk: GraphWalk, file: string): string {
+  return chainTo(walk, file).map(relative).join('\n     -> ')
+}
+
+/** The real graph, walked once and shared: parsing ~90 files is not free. */
+const appEntries = htmlEntries(`${webRoot}/index.html`, webRoot, diskReader)
+const appGraph = walkImports(appEntries, webRoot, diskReader)
+
+describe('the shipped app does not reach measurement code', () => {
+  it('nothing under a dev-only tree is reachable from index.html', () => {
+    const violations = appGraph.reachable
+      .map(relative)
+      .filter((rel) => forbiddenTree(rel) !== undefined)
+      .map((rel) => {
+        const tree = forbiddenTree(rel)!
+        const edge = appGraph.edges.find((e) => relative(e.to) === rel)
+        const kind = edge?.typeOnly ? 'type-only import' : 'import'
+        return (
+          `${rel} is ${tree.what}, and the app loads it.\n` +
+          `  Reached by ${kind} from ${edge ? relative(edge.from) : 'an entry'}:\n` +
+          `     -> ${describeChain(appGraph, `${webRoot}/${rel}`)}`
+        )
+      })
+
+    expect(violations, violations.join('\n\n')).toEqual([])
+  })
+
+  // Everything below keeps the assertion above from passing for the wrong
+  // reason. A reachability check reports success when the walk finds nothing,
+  // and a walk that resolved no entries, or died at the first import, finds
+  // nothing too.
+
+  it('walks from real entries rather than from an empty root set', () => {
+    expect(appEntries.map(relative)).toContain('src/main.tsx')
+  })
+
+  it('resolved every relative import it met', () => {
+    const misses = appGraph.unresolved.map((u) => `${relative(u.from)} -> ${u.specifier}`)
+    expect(misses, `unwalked imports:\n${misses.join('\n')}`).toEqual([])
+  })
+
+  it('reached the modules the app is known to be built out of', () => {
+    const reached = new Set(appGraph.reachable.map(relative))
+    for (const anchor of [
+      'src/App.tsx',
+      'src/components/GameFlow.tsx',
+      'src/engine/round.ts',
+      'src/engine/skills.ts',
+      'src/engine/evaluatorModel.ts',
+      'src/persistence/gameSave.ts',
+    ]) {
+      expect(reached, `${anchor} should be reachable from index.html`).toContain(anchor)
+    }
+  })
+
+  it('leaves the permitted direction alone', () => {
+    // The harness reads the engine, and must go on being able to. Asserted
+    // against the real tree, not a fixture, so a future rewrite of this guard
+    // into something symmetric fails here instead of quietly banning the seam.
+    const abRun = diskReader.read(`${webRoot}/src/ab/abRun.ts`)
+    expect(abRun).not.toBeNull()
+    const intoEngine = moduleSpecifiers(abRun!, 'abRun.ts').filter((i) =>
+      i.specifier.includes('../engine/'),
+    )
+    expect(intoEngine.length).toBeGreaterThan(0)
+  })
+
+  it('does not count test files as part of the app', () => {
+    // Both of these import `../ab/headlessGame`. Tests do not ship, and the
+    // reason they pass is structural - an entry does not import a test - rather
+    // than an exemption someone has to remember to keep in step.
+    const reached = new Set(appGraph.reachable.map(relative))
+    expect(reached).not.toContain('src/engine/round.test.ts')
+    expect(reached).not.toContain('src/components/TrickPlayFlow.test.tsx')
+  })
+})
+
+// -- The walker itself, over trees written for the purpose --------------------
+//
+// The assertion above is only ever watched passing on this repository, because
+// the property it guards is true here. These run it against graphs that break
+// it, so its failure path is exercised on every run rather than once by whoever
+// wrote it (#261).
+
+const ROOT = '/proj'
+
+function virtualReader(files: Record<string, string>): SourceReader {
+  return { read: (path) => (path in files ? files[path] : null) }
+}
+
+function walkFixture(files: Record<string, string>, entry = '/proj/src/main.tsx'): GraphWalk {
+  return walkImports([entry], ROOT, virtualReader(files))
+}
+
+function reachedRel(walk: GraphWalk): string[] {
+  return walk.reachable.map((p) => p.slice(ROOT.length + 1))
+}
+
+describe('the walk that guard rests on', () => {
+  it('reports a direct import of forbidden code', () => {
+    const walk = walkFixture({
+      '/proj/src/main.tsx': `import { helper } from './ab/abRun'\nhelper()\n`,
+      '/proj/src/ab/abRun.ts': `export const helper = () => 0\n`,
+    })
+    expect(reachedRel(walk)).toContain('src/ab/abRun.ts')
+  })
+
+  it('reports it through a chain, and names the chain', () => {
+    const walk = walkFixture({
+      '/proj/src/main.tsx': `import './App'\n`,
+      '/proj/src/App.tsx': `import './engine/round'\n`,
+      '/proj/src/engine/round.ts': `import { SkillParams } from '../ab/abRun'\nexport const p: SkillParams = 1\n`,
+      '/proj/src/ab/abRun.ts': `export type SkillParams = number\n`,
+    })
+    expect(chainTo(walk, '/proj/src/ab/abRun.ts')).toEqual([
+      '/proj/src/main.tsx',
+      '/proj/src/App.tsx',
+      '/proj/src/engine/round.ts',
+      '/proj/src/ab/abRun.ts',
+    ])
+  })
+
+  it('does not report the reverse edge, which is the one that must keep working', () => {
+    const walk = walkFixture({
+      '/proj/src/main.tsx': `import './engine/round'\n`,
+      '/proj/src/engine/round.ts': `export const play = () => 0\n`,
+      '/proj/src/ab/abRun.ts': `import { play } from '../engine/round'\nplay()\n`,
+    })
+    expect(reachedRel(walk)).toEqual(['src/engine/round.ts', 'src/main.tsx'])
+  })
+
+  it('does not report a test file that imports forbidden code', () => {
+    const walk = walkFixture({
+      '/proj/src/main.tsx': `import './engine/round'\n`,
+      '/proj/src/engine/round.ts': `export const play = () => 0\n`,
+      '/proj/src/engine/round.test.ts': `import { deal } from '../ab/headlessGame'\ndeal()\n`,
+      '/proj/src/ab/headlessGame.ts': `export const deal = () => 0\n`,
+    })
+    expect(reachedRel(walk)).not.toContain('src/ab/headlessGame.ts')
+  })
+
+  it('reports a type-only import, and labels it as one', () => {
+    // Erased at compile time, so it adds no bytes. It is still a violation:
+    // `ab/`'s API has become part of the engine's compile-time surface, the
+    // module it names is one deleted `type` keyword away from being loaded for
+    // real, and a reader who sees the import has been told the engine may
+    // depend on the harness.
+    const walk = walkFixture({
+      '/proj/src/main.tsx': `import type { SkillParams } from './ab/abRun'\nexport type P = SkillParams\n`,
+      '/proj/src/ab/abRun.ts': `export type SkillParams = number\n`,
+    })
+    expect(reachedRel(walk)).toContain('src/ab/abRun.ts')
+    expect(walk.edges[0].typeOnly).toBe(true)
+  })
+
+  it('treats a bindings-only type import as a real load', () => {
+    // `import { type A } from 'x'` keeps the statement under
+    // `verbatimModuleSyntax`, so the module is fetched at runtime with nothing
+    // taken from it. Reported as a value edge, because that is what it is.
+    const walk = walkFixture({
+      '/proj/src/main.tsx': `import { type SkillParams } from './ab/abRun'\nexport type P = SkillParams\n`,
+      '/proj/src/ab/abRun.ts': `export type SkillParams = number\n`,
+    })
+    expect(walk.edges[0].typeOnly).toBe(false)
+  })
+
+  it('follows dynamic imports and re-exports', () => {
+    const dynamic = walkFixture({
+      '/proj/src/main.tsx': `const go = async () => (await import('./ab/cli')).run()\ngo()\n`,
+      '/proj/src/ab/cli.ts': `export const run = () => 0\n`,
+    })
+    expect(reachedRel(dynamic)).toContain('src/ab/cli.ts')
+
+    const reexport = walkFixture({
+      '/proj/src/main.tsx': `export * from './engine/api'\n`,
+      '/proj/src/engine/api.ts': `export { stats } from '../ab/stats'\n`,
+      '/proj/src/ab/stats.ts': `export const stats = 1\n`,
+    })
+    expect(reachedRel(reexport)).toContain('src/ab/stats.ts')
+  })
+
+  it('ignores import paths that only appear in comments and strings', () => {
+    // Every file under `src/ab/` is heavily commented and several quote engine
+    // paths in prose. A guard with false positives gets muted, so this is the
+    // reason the parser is used instead of a regular expression.
+    const walk = walkFixture({
+      '/proj/src/main.tsx':
+        `// see import { x } from './ab/abRun' for the harness\n` +
+        `/* import './ab/cli' */\n` +
+        `const note = "import './ab/stats'"\n` +
+        `export default note\n`,
+      '/proj/src/ab/abRun.ts': `export const x = 1\n`,
+      '/proj/src/ab/cli.ts': `export const y = 1\n`,
+      '/proj/src/ab/stats.ts': `export const z = 1\n`,
+    })
+    expect(reachedRel(walk)).toEqual(['src/main.tsx'])
+  })
+
+  it('surfaces an import it could not resolve instead of walking past it', () => {
+    const walk = walkFixture({
+      '/proj/src/main.tsx': `import './does/not/exist'\n`,
+    })
+    expect(walk.unresolved).toEqual([{ from: '/proj/src/main.tsx', specifier: './does/not/exist' }])
+  })
+
+  it('records a non-source file as reached without trying to parse it', () => {
+    const walk = walkFixture({
+      '/proj/src/main.tsx': `import './ab/bench.css'\n`,
+      '/proj/src/ab/bench.css': `body { color: red }\n`,
+    })
+    expect(reachedRel(walk)).toContain('src/ab/bench.css')
+  })
+
+  it('takes every module script on the page as a root', () => {
+    const files = {
+      '/proj/index.html':
+        `<script type="module" src="/src/main.tsx"></script>\n` +
+        `<script type="module" src="/src/second.ts"></script>\n`,
+      '/proj/src/main.tsx': `export default 1\n`,
+      '/proj/src/second.ts': `import './ab/abRun'\n`,
+      '/proj/src/ab/abRun.ts': `export const x = 1\n`,
+    }
+    const reader = virtualReader(files)
+    const entries = htmlEntries('/proj/index.html', ROOT, reader)
+    expect(entries).toEqual(['/proj/src/main.tsx', '/proj/src/second.ts'])
+    expect(reachedRel(walkImports(entries, ROOT, reader))).toContain('src/ab/abRun.ts')
+  })
+
+  it('resolves the specifier shapes this codebase actually writes', () => {
+    const reader = virtualReader({
+      '/proj/src/App.tsx': '',
+      '/proj/src/engine/round.ts': '',
+      '/proj/src/engine/index.ts': '',
+      '/proj/src/index.css': '',
+    })
+    const from = '/proj/src/main.tsx'
+    expect(resolveSpecifier('./App.tsx', from, ROOT, reader)).toBe('/proj/src/App.tsx')
+    expect(resolveSpecifier('./engine/round', from, ROOT, reader)).toBe('/proj/src/engine/round.ts')
+    expect(resolveSpecifier('./engine/round.js', from, ROOT, reader)).toBe(
+      '/proj/src/engine/round.ts',
+    )
+    expect(resolveSpecifier('./engine', from, ROOT, reader)).toBe('/proj/src/engine/index.ts')
+    expect(resolveSpecifier('/src/index.css', from, ROOT, reader)).toBe('/proj/src/index.css')
+    expect(resolveSpecifier('react', from, ROOT, reader)).toBeNull()
+    expect(resolveSpecifier('node:fs', from, ROOT, reader)).toBeNull()
+  })
+})

--- a/web/src/boundaries/importGraph.ts
+++ b/web/src/boundaries/importGraph.ts
@@ -1,0 +1,267 @@
+/// <reference types="node" />
+
+// A reader-driven walk of the app's static import graph (#236).
+//
+// This module is test-only infrastructure: it reads source off disk and parses
+// it, and nothing under `src/` outside this directory imports it. That is not a
+// convention here - `bundleBoundary.test.ts` walks the graph this module builds
+// and would report this file if it ever became reachable from `index.html`.
+//
+// All filesystem access goes through `SourceReader` so the walk can be run over
+// a virtual tree in a test. A guard whose only subject is the real repository
+// can only ever be watched passing, and its failure path gets exercised once by
+// whoever wrote it and never again (#261).
+
+import { readFileSync } from 'node:fs'
+import * as posix from 'node:path/posix'
+import { fileURLToPath } from 'node:url'
+import * as ts from 'typescript'
+
+/**
+ * Paths are POSIX-normalised everywhere below, including on Windows, where the
+ * caller converts separators on the way in. Node's `fs` accepts forward slashes
+ * on Windows, so nothing has to convert back.
+ */
+export interface SourceReader {
+  /** File contents, or `null` if there is no file at that path. */
+  read(path: string): string | null
+}
+
+export interface ImportEdge {
+  readonly from: string
+  readonly specifier: string
+  readonly to: string
+  /**
+   * `import type ...` / `export type ... from ...` / `import('x').T`. Erased by
+   * the compiler, so a type-only edge puts no bytes in the bundle - see
+   * `bundleBoundary.test.ts` for why it is still reported as a violation.
+   */
+  readonly typeOnly: boolean
+}
+
+export interface GraphWalk {
+  /** Every module reachable from the entries, entries included. Sorted. */
+  readonly reachable: readonly string[]
+  readonly edges: readonly ImportEdge[]
+  /**
+   * Relative specifiers this resolver could not find a file for. Never expected
+   * to be non-empty on a tree that compiles; surfaced rather than swallowed,
+   * because an unresolved import is a branch of the graph that went unwalked,
+   * and an unwalked branch is indistinguishable from a clean one.
+   */
+  readonly unresolved: readonly { readonly from: string; readonly specifier: string }[]
+  /** How each reachable module was first reached. Entries map to `null`. */
+  readonly reachedVia: ReadonlyMap<string, string | null>
+}
+
+const PARSEABLE = /\.(c|m)?[jt]sx?$/
+const TSX = /\.[jt]sx$/
+
+/**
+ * Extension candidates in the order a bundler would try them. `.js` specifiers
+ * map to their TypeScript sources as well: this codebase writes extensionless
+ * and explicit `.tsx` specifiers today, but a `.js` specifier resolves to a
+ * `.ts` file under `moduleResolution: bundler`, and a resolver that missed that
+ * shape would walk straight past a real edge.
+ */
+function candidates(base: string): string[] {
+  const out = [base]
+  if (/\.jsx?$/.test(base)) {
+    out.push(base.replace(/\.jsx?$/, '.ts'), base.replace(/\.jsx?$/, '.tsx'))
+  }
+  out.push(`${base}.ts`, `${base}.tsx`, `${base}.js`, `${base}.jsx`)
+  out.push(`${base}/index.ts`, `${base}/index.tsx`, `${base}/index.js`)
+  return out
+}
+
+/** True for specifiers that name a file in this repository rather than a package. */
+export function isLocalSpecifier(specifier: string): boolean {
+  const clean = specifier.split('?')[0]
+  return clean.startsWith('.') || clean.startsWith('/')
+}
+
+/**
+ * Resolves a relative or root-absolute specifier to a path under `root`. Bare
+ * specifiers (`react`, `node:fs`) return `null`: they are packages, not part of
+ * this repository's own graph, and following them would walk `node_modules`.
+ */
+export function resolveSpecifier(
+  specifier: string,
+  fromFile: string,
+  root: string,
+  reader: SourceReader,
+): string | null {
+  const clean = specifier.split('?')[0]
+  // `join` rather than `resolve`: a Windows-rooted path like `C:/repo/web` is
+  // not absolute to `path/posix`, so `resolve` would silently prefix it with
+  // `process.cwd()` and every relative import in the tree would come back
+  // unresolved. `join` normalises `.` and `..` without consulting the cwd.
+  let base: string
+  if (clean.startsWith('/')) base = posix.join(root, clean)
+  else if (clean.startsWith('.')) base = posix.join(posix.dirname(fromFile), clean)
+  else return null
+
+  for (const candidate of candidates(base)) {
+    if (reader.read(candidate) !== null) return candidate
+  }
+  return null
+}
+
+interface RawImport {
+  readonly specifier: string
+  readonly typeOnly: boolean
+}
+
+/**
+ * Every module specifier in one file, via the TypeScript parser rather than a
+ * regular expression. The distinction matters for a guard: this module's own
+ * header quotes an import path inside a comment, and several files under
+ * `src/ab/` discuss `../engine/...` in prose. A textual scan reports those as
+ * edges, and a guard that cries wolf gets suppressed rather than fixed.
+ */
+export function moduleSpecifiers(source: string, fileName: string): RawImport[] {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    TSX.test(fileName) ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+  const found: RawImport[] = []
+
+  const push = (node: ts.Node | undefined, typeOnly: boolean): void => {
+    if (node && ts.isStringLiteralLike(node)) found.push({ specifier: node.text, typeOnly })
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      // `import { type A } from 'x'` is deliberately *not* type-only: under
+      // `verbatimModuleSyntax` the statement itself survives compilation, so the
+      // module is loaded at runtime even though every binding it named is gone.
+      push(node.moduleSpecifier, node.importClause?.isTypeOnly ?? false)
+    } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+      push(node.moduleSpecifier, node.isTypeOnly)
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      push(node.moduleReference.expression, false)
+    } else if (ts.isImportTypeNode(node)) {
+      if (ts.isLiteralTypeNode(node.argument)) push(node.argument.literal, true)
+    } else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      push(node.arguments[0], false)
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  ts.forEachChild(sourceFile, visit)
+  return found
+}
+
+/**
+ * Breadth-first from `entries`. Reachable files that are not parseable source
+ * (`./index.css`, an imported asset) are recorded as reached and not opened -
+ * they are real nodes of the shipped graph, so a stylesheet under a forbidden
+ * directory still counts, but there is nothing in them to follow.
+ */
+export function walkImports(
+  entries: readonly string[],
+  root: string,
+  reader: SourceReader,
+): GraphWalk {
+  const reachedVia = new Map<string, string | null>()
+  const edges: ImportEdge[] = []
+  const unresolved: { from: string; specifier: string }[] = []
+  const queue: string[] = []
+
+  for (const entry of entries) {
+    if (!reachedVia.has(entry)) {
+      reachedVia.set(entry, null)
+      queue.push(entry)
+    }
+  }
+
+  while (queue.length > 0) {
+    const file = queue.shift()!
+    if (!PARSEABLE.test(file)) continue
+    const source = reader.read(file)
+    if (source === null) continue
+
+    for (const { specifier, typeOnly } of moduleSpecifiers(source, file)) {
+      if (!isLocalSpecifier(specifier)) continue
+      const to = resolveSpecifier(specifier, file, root, reader)
+      if (to === null) {
+        unresolved.push({ from: file, specifier })
+        continue
+      }
+      edges.push({ from: file, specifier, to, typeOnly })
+      if (!reachedVia.has(to)) {
+        reachedVia.set(to, file)
+        queue.push(to)
+      }
+    }
+  }
+
+  return { reachable: [...reachedVia.keys()].sort(), edges, unresolved, reachedVia }
+}
+
+/**
+ * The chain from an entry down to `file`, as first reached. Reported instead of
+ * a bare filename so a failure names the import that has to be undone rather
+ * than the module at the bottom of it.
+ */
+export function chainTo(walk: GraphWalk, file: string): string[] {
+  const chain: string[] = []
+  let current: string | null | undefined = file
+  while (current != null && !chain.includes(current)) {
+    chain.unshift(current)
+    current = walk.reachedVia.get(current)
+  }
+  return chain
+}
+
+const MODULE_SCRIPT = /<script\b[^>]*\btype\s*=\s*["']module["'][^>]*\bsrc\s*=\s*["']([^"']+)["']/gi
+
+/**
+ * The module scripts of an HTML page, which is what Rollup takes as build input.
+ * Deriving the roots from the page rather than naming `src/main.tsx` here is the
+ * difference between a guard on the app and a guard on one path through it: a
+ * second `<script type="module">` added to `index.html` becomes a root
+ * automatically, where a hardcoded entry would leave it unwalked and the guard
+ * would go on reporting success.
+ */
+export function htmlEntries(htmlPath: string, root: string, reader: SourceReader): string[] {
+  const html = reader.read(htmlPath)
+  if (html === null) return []
+  const out: string[] = []
+  for (const match of html.matchAll(MODULE_SCRIPT)) {
+    const resolved = resolveSpecifier(match[1], htmlPath, root, reader)
+    if (resolved !== null) out.push(resolved)
+  }
+  return out
+}
+
+/** Reads real files. Callers hand it the POSIX paths used throughout this module. */
+export const diskReader: SourceReader = {
+  read(path: string): string | null {
+    try {
+      return readFileSync(path, 'utf8')
+    } catch {
+      return null
+    }
+  },
+}
+
+/**
+ * A `file:` URL as a POSIX path, with the trailing slash and any Windows
+ * separators taken off. Callers pass their own `import.meta.url`: under
+ * vite-node only an entry module is guaranteed a `file:` URL of its own, so a
+ * module-relative constant computed *here* resolves against something else
+ * entirely and throws. This keeps the module ignorant of where the repository
+ * sits, which is the right shape for it anyway.
+ */
+export function dirOf(metaUrl: string, up: string): string {
+  return fileURLToPath(new URL(up, metaUrl))
+    .replace(/\\/g, '/')
+    .replace(/\/+$/, '')
+}


### PR DESCRIPTION
Closes #236

`web/src/ab/` stayed out of the bundle because nothing the app loads happened
to import it. This makes that a checked property instead of a coincidence.

## The mechanism, and why this one

`web/src/boundaries/bundleBoundary.test.ts` walks the static import graph
outward from the module scripts in `web/index.html` — Rollup's actual build
input — and fails if anything under a dev-only tree turns up in it.
`importGraph.ts` is the walker: a reader-driven BFS with all filesystem access
behind a `SourceReader` interface, so it can be run over a virtual tree.

Three choices worth defending:

**Reachability, not a ban on the import.** The forbidden edge is directional.
`src/ab/` imports the engine and the components constantly and must go on
doing so; a symmetric rule would need suppressing on nearly every file in the
harness. Walking outward from the app never follows `ab/ → engine/`, because it
never arrives at `ab/` — and it finds `engine/ → ab/` the moment it is written.
The same asymmetry settles tests for free: `engine/round.test.ts` and
`components/TrickPlayFlow.test.tsx` both import `dealFromRng` from
`../ab/headlessGame` today, neither is reachable from an entry, and no
allowlist has to be maintained for them.

**Roots parsed off the page, not `src/main.tsx` hardcoded.** A hardcoded entry
is a guard on one path through the app; a second `<script type="module">` added
later would go unwalked while the check kept reporting success. The dev-only
pages fall out of this for the right reason — `bench/index.html` and
`layout/index.html` are not build inputs, so their scripts are not roots.

**TypeScript's parser, not a regex.** Files under `src/ab/` quote engine paths
in prose; so does the new module's own header. A guard with false positives
gets muted rather than fixed. It reports `import`, `export … from`, dynamic
`import()`, `import … = require()` and `import('x').T`, and labels each edge
type-only or not — `import type` is erased, `import { type A }` is not, since
under `verbatimModuleSyntax` the statement survives with nothing taken from it.

Not a lint rule: oxlint has no import-graph plugin and could only express "this
file may not import that path", which is the symmetric rule above. Not a bundle
grep: it needs a build, and it reports a string in a chunk rather than the
import to undo.

### What it catches

The realistic mistake the issue names — someone imports a type or a helper from
`ab/` into an engine or component file because it was the nearest definition —
directly or through any depth of chain, as a value or as a type, statically or
via `import()`.

### What it does not catch

- A specifier built at runtime (`import('./' + name)`).
- Anything arriving through a Vite alias or a plugin's virtual module; only
  relative and root-absolute specifiers are resolved.
- Harness code *copied* into an engine file rather than imported.
- Anything Rollup emits that no entry imports. The subject is the graph, not
  the artifact.

Type-only edges are failed even though they ship no bytes: once one exists,
`ab/`'s API is part of the engine's compile-time surface and is one deleted
keyword from being loaded for real.

## Demonstrated firing

Two production edits, watched, then reverted — no production file is in this
branch.

`import { makeRng } from '../ab/headlessGame'` in `engine/round.ts`:

```
AssertionError: src/ab/headlessGame.ts is the A/B harness, latency bench and
headless driver, and the app loads it.
  Reached by import from src/engine/round.ts:
     -> src/main.tsx
     -> src/App.tsx
     -> src/components/GameShell.tsx
     -> src/persistence/gameSave.ts
     -> src/engine/round.ts
     -> src/ab/headlessGame.ts
```

`import type { AbAnalysis } from '../ab/abRun'` in `components/Scoreboard.tsx`
gives the same shape, reported as `Reached by type-only import from
src/components/Scoreboard.tsx`.

That is a one-off, and the property being guarded is true here, so from now on
the real assertion can only be watched passing. Thirteen further tests run the
walk against trees written to break it — the direct edge, the transitive one
with its chain, the reverse edge that must keep working, a test file importing
the harness, both flavours of type import, dynamic imports and re-exports,
paths appearing only in comments and strings, and the specifier shapes this
codebase writes. Four more keep the real assertion from passing vacuously: that
entries were found at all, that every relative import resolved, that modules
the app is demonstrably built from were reached, and that `abRun.ts` still
imports the engine — so a later rewrite into something symmetric fails here
rather than quietly banning the seam.

`src/boundaries/` lists itself as forbidden. It reads the filesystem and
imports the TypeScript compiler, and it has no dev-only page arranging its
exclusion.

## `installPolicies`

Untouched, deliberately. #222 kept `SKILL_PARAMS` mutable so a mirrored A/B can
seat two policies at one table, and that is what makes the measurement
independent of whichever dial is shipped. It is the reason the guard is worth
having — an accidental import would make engine configuration writable at
runtime inside the product — not something to remove.

## Docs

`ROADMAP.md`'s "None of it reaches the bundle — though nothing checks that",
plus the matching sentences in `README.md` and `web/README.md`, now cite the
guard and state the direction it leaves alone.

## Verification

- `npm test` (bare gate run): 44 files / 566 tests, up from 43 / 548. Also
  green under `-- --run --maxWorkers=2`.
- `npm run build` succeeds. Built before and after the change: identical
  content hashes and identical md5 for both `index-*.js` and `index-*.css`,
  because nothing added here is reachable — which is the claim under test.
- `npx tsc --noEmit -p tsconfig.app.json` clean; `npm run lint` unchanged (the
  one pre-existing `TrickPlayFlow.tsx` warning).
- `python -m pytest -q`: 418 passed, unmoved.

`CODING_STANDARDS.md`'s test count is deliberately not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
